### PR TITLE
Improve error location (RFC, do not merge)

### DIFF
--- a/src/core/index.mli
+++ b/src/core/index.mli
@@ -12,7 +12,7 @@ type error =
   | UnboundIdSub
   | PatVarNotUnique
   | IllFormedCompTyp
-  | MispacedOperator of Id.name
+  | MisplacedOperator of Id.name
   | ParseError
   | NoRHS
 

--- a/src/core/index.mli
+++ b/src/core/index.mli
@@ -13,6 +13,7 @@ type error =
   | PatVarNotUnique
   | IllFormedCompTyp
   | MisplacedOperator of Id.name
+  | MissingArguments  of Id.name * int * int
   | ParseError
   | NoRHS
 


### PR DESCRIPTION
This is an attempt to improve the handling of locations in the `reconstruction` part of 'shunting yard'. Instead of discarding the locations of operators (heads of spines are considered prefix operators as far as I can tell), they are passed through.

I was confronted with an unlocated error message when I extended the arity of a LF definition constructor to take one more argument. The error originated from a pattern match on this constructor further down the file, but it was carrying a ghost location. I therefore decided to keep the relevant location at hand.

However, I do not know the reason for the previous solution of using the locations of the arguments instead. Consequently, I did not modify the existing code to use the newly-available locations.

Before merging, somebody should
- pull this branch into a working branch
- take a look and use the added `loc_o` operation locations where appropriate