### PR TITLE
Add equality check for built-in ctype Bool

### DIFF
--- a/src/core/opsem.ml
+++ b/src/core/opsem.ml
@@ -228,6 +228,8 @@ let rec eval_syn i (theta, eta) =
           else
             Comp.BoolValue false
 
+        | ((Comp.BoolValue b1), (Comp.BoolValue b2)) -> Comp.BoolValue (b1 == b2)
+
         | ( _ , _ ) -> raise (Error.Violation "Expected atomic object")
       end
 


### PR DESCRIPTION
Mutually exclusive with #27 

Consistent with `src/core/check.ml:799`

```
let x : Bool = ttrue == ffalse
   ===> ffalse
```