### PR TITLE
Remove spurious ctype Bool clause in equality checking

### DIFF
--- a/src/core/check.ml
+++ b/src/core/check.ml
@@ -796,7 +796,6 @@ let useIH loc cD cG cIH_opt e2 = match cIH_opt with
            if Whnf.convCTyp (tau1,t1) (tau2,t2) then
              begin match Whnf.cwhnfCTyp (tau1,t1) with
                | (TypBox _ , _ ) ->  (None, TypBool, C.m_id)
-               | (TypBool, _ )   ->  (None, TypBool, C.m_id)
                | (tau1,t1)       ->  raise (Error (loc, EqTyp (cD, (tau1,t1))))
              end
 


### PR DESCRIPTION
Mutually exclusive with #26 

In `src/core/opsem.ml:231`, equality is only defined for `Comp.BoxValue`, not
for any ctypes.

```
let x : Bool = (ttrue == ttrue) ;
```
```
## Type Reconstruction: /home/philipp/su/opsem/indexed/minimal_bool.bel ##
File "/home/philipp/su/opsem/indexed/minimal_bool.bel", line 1, characters 22-30:
Equality comparison only possible at base types.
    Expected type: base type
    Actual type: Bool
```