### PR TITLE
Add merlin-mode configuration

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,7 @@
+S src/core
+S src/beluga
+
+B _build/src/core
+B _build/src/beluga
+
+PKG ulex camlp4 extlib


### PR DESCRIPTION
This way, anyone using merlin-mode to develop Beluga won't need to do it
themselves.

This commit was originally part of a "misc" pull request I made earlier, but got reverted when it was noticed that certain other commits in that PR broke the test suite.