### PR TITLE
Change pragma syntax to double-dash

### DIFF
--- a/examples/arith/arith.bel
+++ b/examples/arith/arith.bel
@@ -1,5 +1,5 @@
 
-nat :  type.     %name nat N x.
+nat :  type.     --name nat N x.
 z : nat.
 s : nat -> nat.
 

--- a/examples/back/tc.bel
+++ b/examples/back/tc.bel
@@ -1,4 +1,4 @@
-exp  : type.   %name exp E x.
+exp  : type.   --name exp E x.
 z    : exp.
 suc  : exp -> exp.
 
@@ -6,7 +6,7 @@ letv : exp -> (exp -> exp) -> exp.
 lam  : (exp -> exp) -> exp.
 app  : exp -> exp -> exp.
 
-tp   : type.   %name tp T.
+tp   : type.   --name tp T.
 nat  : tp.
 even : tp.
 odd : tp.
@@ -15,7 +15,7 @@ sect   : tp -> tp -> tp.
 
 
 % Evaluation
-eval : exp -> exp -> type.  %name eval F.
+eval : exp -> exp -> type.  --name eval F.
 ev_z : eval z z.
 
 ev_s : eval E V -> eval (suc E) (suc V).
@@ -29,8 +29,8 @@ ev_app: eval E1 (lam (\x. E x)) -> eval E2 V2 -> eval (E V2) V
 
 % Typing
 
-oft : exp -> tp -> type.  %name oft D u.
-subtype : tp -> tp -> type.  %name subtype SUB sub.
+oft : exp -> tp -> type.  --name oft D u.
+subtype : tp -> tp -> type.  --name subtype SUB sub.
 
 boolean : type.
 true : boolean.

--- a/examples/bigstep-deterministic/bigstep-deterministic.bel
+++ b/examples/bigstep-deterministic/bigstep-deterministic.bel
@@ -4,7 +4,7 @@
 notLam : exp -> type.
 notLam : notLam (app M N).
 
-eval : exp -> exp -> type. %name eval E.
+eval : exp -> exp -> type. --name eval E.
 eval_lam : ({x:exp} eval x x -> notLam x -> eval (M x) (N x))
            -> eval (lam M) (lam N).
 eval_app1 : eval M (lam M') -> eval (M' N) R -> eval (app M N) R.

--- a/examples/bigstep-deterministic/eq.bel
+++ b/examples/bigstep-deterministic/eq.bel
@@ -1,11 +1,11 @@
 % Equality lemmas
 % Author: Andrew Cave
 
-exp : type. %name exp M.
+exp : type. --name exp M.
 app : exp -> exp -> exp.
 lam : (exp -> exp) -> exp.
 
-eq : exp -> exp -> type. %name eq D.
+eq : exp -> exp -> type. --name eq D.
 eq_lam : ({x:exp} eq x x -> eq (M x) (N x)) -> eq (lam M) (lam N).
 eq_app : eq M M' -> eq N N' -> eq (app M N) (app M' N').
 

--- a/examples/church-rosser/par-red.bel
+++ b/examples/church-rosser/par-red.bel
@@ -2,7 +2,7 @@
 %%% Author: Frank Pfenning
 
 pred : term -> term -> type.  % infix none 10 =>.
-                            %name pred R.
+                            --name pred R.
 
 beta : ({x:term} pred x x -> pred (M1 x) (M1' x))
      ->                      pred M2 M2'
@@ -18,7 +18,7 @@ lm   : ({x:term} pred x x -> pred (M x)  (M' x))
 % Parallel, multi-step reduction
 
 pred* : term -> term -> type.  % infix none 10 =>*.
-                               %name pred* R*.
+                               --name pred* R*.
 
 id*   :   pred* M  M.
 
@@ -31,7 +31,7 @@ next    :  pred M  M' -> pred* M' M'' ->  pred* M  M''.
 % Parallel conversion
 
 pred= : term -> term -> type.  % infix none 10 <=>.
-                             %name pred= C.
+                             --name pred= C.
 
 reduce :  pred*  M  M'
        -> pred= M  M'.

--- a/examples/codatatypes/bisimulation/invariant.bel
+++ b/examples/codatatypes/bisimulation/invariant.bel
@@ -119,4 +119,4 @@ rec invSim : (g:ctx) Inv [g |- P] [g |- Q] -> SimInv [g |- P] [g |- Q] = ?
 %     | BInvRUp => mlam X => mlam M  => fn t => SInvUp s2 [ |- X] [g,x:n |-  M..x] t
 % ;
 
-% %rec invImpliesBisim : (g:ctx) Inv [g |- P..] [g |- Q..] -> Bisim [g |- P..] [g |- Q..] =
+% --rec invImpliesBisim : (g:ctx) Inv [g |- P..] [g |- Q..] -> Bisim [g |- P..] [g |- Q..] =

--- a/examples/copy/copy-crec.bel
+++ b/examples/copy/copy-crec.bel
@@ -1,9 +1,9 @@
-tp: type.   %name tp T.
+tp: type.   --name tp T.
 bool: tp.
 nat: tp.
 arrow: tp -> tp -> tp.
 
-term : tp -> type.  %name term E x.
+term : tp -> type.  --name term E x.
 
 z    : term nat.
 s    : term nat -> term nat.

--- a/examples/copy/copy.bel
+++ b/examples/copy/copy.bel
@@ -1,9 +1,9 @@
-tp: type.   %name tp T.
+tp: type.   --name tp T.
 bool: tp.
 nat: tp.
 arrow: tp -> tp -> tp.
 
-term : tp -> type.  %name term E x.
+term : tp -> type.  --name term E x.
 
 z    : term nat.
 s    : term nat -> term nat.

--- a/examples/count-var/cntvar-2.bel
+++ b/examples/count-var/cntvar-2.bel
@@ -1,14 +1,14 @@
-%nostrengthen
+--nostrengthen
 % Variable counting (see Pientka [POPL'08])
 % Author:  Brigitte Pientka
 %
 % This example only uses weak higher-order abstract syntax.
 
-tp  : type.   %name tp T.
+tp  : type.   --name tp T.
 nat : tp.
 bool: tp.
 
-exp : tp -> type.  %name exp E x.
+exp : tp -> type.  --name exp E x.
 z   : exp nat.
 s   : exp nat -> exp nat.
 

--- a/examples/count-var/cntvar-crec.bel
+++ b/examples/count-var/cntvar-crec.bel
@@ -1,12 +1,12 @@
-%nostrengthen
+--nostrengthen
 % Variable counting (see Pientka [POPL'08])
 % Author:  Brigitte Pientka
 
-tp  : type.   %name tp T.
+tp  : type.   --name tp T.
 nat : tp.
 bool: tp.
 
-exp : tp -> type.   %name exp E x.
+exp : tp -> type.   --name exp E x.
 z   : exp nat.
 s   : exp nat -> exp nat.
 tt  : exp bool.

--- a/examples/count-var/cntvar-explicit.bel
+++ b/examples/count-var/cntvar-explicit.bel
@@ -3,11 +3,11 @@
 %
 % This example only uses weak higher-order abstract syntax.
 
-tp  : type.   %name tp T.
+tp  : type.   --name tp T.
 nat : tp.
 bool: tp.
 
-exp : tp -> type.  %name exp E.
+exp : tp -> type.  --name exp E.
 z   : exp nat.
 s   : exp nat -> exp nat.
 

--- a/examples/count-var/cntvar-simple-crec.bel
+++ b/examples/count-var/cntvar-simple-crec.bel
@@ -3,7 +3,7 @@
 %
 % This example only uses weak higher-order abstract syntax.
 
-exp : type.   %name exp E x.
+exp : type.   --name exp E x.
 z   : exp.
 s   : exp -> exp.
 

--- a/examples/count-var/cntvar-simple.bel
+++ b/examples/count-var/cntvar-simple.bel
@@ -3,7 +3,7 @@
 %
 % This example only uses weak higher-order abstract syntax.
 
-exp : type.   %name exp E x.
+exp : type.   --name exp E x.
 %{ z   : exp.
 s   : exp -> exp.
 

--- a/examples/count-var/cntvar-str.bel
+++ b/examples/count-var/cntvar-str.bel
@@ -1,11 +1,11 @@
 % Variable counting (see Pientka [POPL'08])
 % Author:  Brigitte Pientka
 
-tp  : type.   %name tp T.
+tp  : type.   --name tp T.
 nat : tp.
 bool: tp.
 
-exp : tp -> type.   %name exp E x.
+exp : tp -> type.   --name exp E x.
 z   : exp nat.
 s   : exp nat -> exp nat.
 tt  : exp bool.

--- a/examples/count-var/cntvar.bel
+++ b/examples/count-var/cntvar.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 % Variable counting (see Pientka [POPL'08])
 % Author:  Brigitte Pientka
 %
@@ -8,14 +8,14 @@ LF tp  : type =
 | nat : tp
 | bool: tp
 ;
-%name tp T.
+--name tp T.
 
 inductive Int : ctype =
 | Zero : Int
 | Suc : Int -> Int
 ;
 
-exp : tp -> type.   %name exp E x.
+exp : tp -> type.   --name exp E x.
 z   : exp nat.
 s   : exp nat -> exp nat.
 tt  : exp bool.

--- a/examples/cpp13/cc.bel
+++ b/examples/cpp13/cc.bel
@@ -5,7 +5,7 @@
 
 
 % PRAGMA FOR CHECKING COVERAGE
-%coverage
+--coverage
 
 % ----------------------------------------------------------
 % Types 
@@ -16,7 +16,7 @@ LF tp: type =
 | cross : tp -> tp -> tp
 | unit  : tp
 ;
-%name tp T.
+--name tp T.
 
 % ----------------------------------------------------------
 % Source language M,N
@@ -31,7 +31,7 @@ LF source: tp -> type =
 | rst  : source (cross T S) -> source S
 | cons : source T -> source S -> source (cross T S)
 ;
-%name source M.
+--name source M.
 
 % ----------------------------------------------------------
 % Target language P,Q
@@ -51,7 +51,7 @@ LF target: tp -> type =
 | cz    : target nat
 | csuc  : target nat -> target nat
 ;
-%name target P.
+--name target P.
 
 % ----------------------------------------------------------       
 % Context schema declarations for source and target context

--- a/examples/cpp13/cchoist.bel
+++ b/examples/cpp13/cchoist.bel
@@ -4,7 +4,7 @@
 % date: 2012-2013
 
 % PRAGMA FOR CHECKING COVERAGE
-%coverage
+--coverage
 % ----------------------------------------------------------
 % Types T
 LF tp: type =
@@ -14,7 +14,7 @@ LF tp: type =
 | cross : tp -> tp -> tp
 | unit  : tp
 ;
-%name tp T.
+--name tp T.
 
 % ----------------------------------------------------------
 % Source language M,N
@@ -29,7 +29,7 @@ LF source: tp -> type =
 | rst  : source (cross T S) -> source S
 | cons : source T -> source S -> source (cross T S)
 ;
-%name source M.
+--name source M.
 
 % ----------------------------------------------------------
 % Target language P,Q
@@ -50,7 +50,7 @@ LF target: tp -> type =
 | cz    : target nat
 | csuc  : target nat -> target nat
 ;
-%name target P.
+--name target P.
 
 % ----------------------------------------------------------       
 % Context schema declarations for source and target context

--- a/examples/cpp13/cps.bel
+++ b/examples/cpp13/cps.bel
@@ -14,7 +14,7 @@ LF tp: type =
 | cross : tp -> tp -> tp
 | unit  : tp
 ;
-%name tp T.
+--name tp T.
 
 LF source   : tp -> type =
 | app   : source (arr S T) -> source S -> source T

--- a/examples/cpp13/sfcps.bel
+++ b/examples/cpp13/sfcps.bel
@@ -16,7 +16,7 @@ LF tp: type =
 | unit  : tp
 | all   : (tp -> tp) -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF source   : tp -> type =
 | app   : source (arr S T) -> source S -> source T

--- a/examples/cut-elim-crec-cover.bel
+++ b/examples/cut-elim-crec-cover.bel
@@ -2,9 +2,9 @@
 % Author: Brigitte Pientka
 
 i : type.  % individuals
-%name i S.
+--name i S.
 o : type.  % formulas
-%name o A.
+--name o A.
 
 imp    : o -> o -> o.
 not    : o -> o.

--- a/examples/cut-elim-crec.bel
+++ b/examples/cut-elim-crec.bel
@@ -4,9 +4,9 @@
 % See cut-elim-crec-cover.bel .
 
 i : type.  % individuals
-%name i S.
+--name i S.
 o : type.  % formulas
-%name o A.
+--name o A.
 
 imp    : o -> o -> o.
 not    : o -> o.

--- a/examples/cut-elim.bel
+++ b/examples/cut-elim.bel
@@ -2,9 +2,9 @@
 % Author: Brigitte Pientka
 
 i : type.  % individuals
-%name i S.
+--name i S.
 o : type.  % formulas
-%name o A.
+--name o A.
 
 imp    : o -> o -> o.
 not    : o -> o.

--- a/examples/debruijn1/mini-ml.bel
+++ b/examples/debruijn1/mini-ml.bel
@@ -2,7 +2,7 @@
 %%% Version restricted to pure lambda-calculus
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-exp  : type.  %name exp E.
+exp  : type.  --name exp E.
 
 lam   : (exp -> exp) -> exp.
 app   : exp -> exp -> exp.
@@ -12,7 +12,7 @@ app   : exp -> exp -> exp.
 %%% Version restricted to pure lambda-calculus
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-eval : exp -> exp -> type.  %name eval D.
+eval : exp -> exp -> type.  --name eval D.
 
 % Functions
 ev_lam  : eval (lam (\x. E x)) (lam (\x. E x)).
@@ -28,17 +28,17 @@ ev_app  : eval (app E1 E2) V
 
 % Expressions
 
-exp'   : type.  %name exp' F.
+exp'   : type.  --name exp' F.
 
 one      : exp'.
-shift    : exp' -> exp'.  %postfix 20 ^.
+shift    : exp' -> exp'.  --postfix 20 ^.
 lam'     : exp' -> exp'.
 app'     : exp' -> exp' -> exp'.
 
 % Environments and values
 
-env    : type.  %name env K.
-val    : type.  %name val W.
+env    : type.  --name env K.
+val    : type.  --name val W.
 
 empty  : env.
 cons   : env -> val -> env.   % infix left 10 ;.
@@ -51,7 +51,7 @@ clo    : env -> exp' -> val.
 %%% Version restricted to pure lambda-calculus
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-feval : env -> exp' -> val -> type.  %name feval D.
+feval : env -> exp' -> val -> type.  --name feval D.
 
 % Variables
 fev_1 : feval (cons K W) one W.
@@ -71,8 +71,8 @@ fev_app : feval K (app' F1 F2) W
 %%% Version restricted to pure lambda-calculus
 %%% Author: Frank Pfenning, based on [Hannan & Pfenning 92]
 
-trans  : env -> exp' -> exp -> type.  %name trans C.
-vtrans : val -> exp -> type.          %name vtrans U.
+trans  : env -> exp' -> exp -> type.  --name trans C.
+vtrans : val -> exp -> type.          --name vtrans U.
 
 % Functions
 tr_lam : trans K (lam' F) (lam (\x. E x))

--- a/examples/equal/alg-equal-ctxrel.bel
+++ b/examples/equal/alg-equal-ctxrel.bel
@@ -15,10 +15,10 @@
 term : type.
 app : term -> term -> term.
 lam : (term -> term) -> term.
-%name term M x.
+--name term M x.
 
 % Algorithmic Equality
-aeq: term -> term -> type.   %name aeq Q u.
+aeq: term -> term -> type.   --name aeq Q u.
 ae_a : aeq M1 N1 -> aeq M2 N2
     -> aeq (app M1 M2) (app N1 N2).
 ae_l :  ({x:term} aeq x x -> aeq (M x) (N x))

--- a/examples/equal/alg-equal-datatypes-adeq.bel
+++ b/examples/equal/alg-equal-datatypes-adeq.bel
@@ -5,12 +5,12 @@ LF term: type =
 | app : term -> term -> term
 | lam : (term -> term) -> term
 ;
-%name term M x.
+--name term M x.
 
 schema tctx = term;
 
 % Algorithmic Equality
-aeq: term -> term -> type.   %name aeq Q u.
+aeq: term -> term -> type.   --name aeq Q u.
 ae_a : aeq E1 F1 -> aeq E2 F2
     -> aeq (app E1 E2) (app F1 F2).
 ae_l :  ({x:term} aeq x x -> aeq (E x) (F x))

--- a/examples/equal/alg-equal-datatypes.bel
+++ b/examples/equal/alg-equal-datatypes.bel
@@ -2,7 +2,7 @@ LF term: type =
 | app : term -> term -> term
 | lam : (term -> term) -> term
 ;
-%name term M x.
+--name term M x.
 
 schema tctx = term;
 

--- a/examples/equal/eq-proof-1.bel
+++ b/examples/equal/eq-proof-1.bel
@@ -14,11 +14,11 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 
 eq_lam :  ({x : exp} eq x x -> eq (E x) (F x))

--- a/examples/equal/eq-proof-2.bel
+++ b/examples/equal/eq-proof-2.bel
@@ -14,11 +14,11 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 
 eq_lam :  ({x : exp} eq x x -> eq (E x) (F x))

--- a/examples/equal/eq-proof-crec.bel
+++ b/examples/equal/eq-proof-crec.bel
@@ -7,14 +7,14 @@ LF exp: type =
 | lam: (exp -> exp) -> exp
 ;
 
-%name exp E x.
+--name exp E x.
 
 LF eq: exp -> exp -> type =
 | eq_app : eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2)
 | eq_lam :  ({x : exp} eq x x -> eq (E x) (F x))
             -> eq (lam E) (lam F)
 ;
-%name eq D u.
+--name eq D u.
 
 
 LF equal: exp -> exp -> type =

--- a/examples/equal/eq-proof-full-crec.bel
+++ b/examples/equal/eq-proof-full-crec.bel
@@ -2,14 +2,14 @@
 % Author: Brigitte Pientka
 
 
-exp: type.    %name exp M x.
+exp: type.    --name exp M x.
 
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
 % ------------------------------------------------------------------------------
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : eq M1 N1 -> eq M2 N2 -> eq (app M1 M2) (app N1 N2).
 
 eq_lam :  ({x : exp} eq x x -> eq (M x) (N x))

--- a/examples/equal/eq-proof-tuple.bel
+++ b/examples/equal/eq-proof-tuple.bel
@@ -14,11 +14,11 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : % {E1:exp} {F1:exp} {E2:exp} {F2:exp}
          eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 
@@ -49,11 +49,11 @@ rec eqfun : {g:w} {U:[g |- exp]} [g |- eq U U] =
 ;
 
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : {E1:exp} {F1:exp} {E2:exp} {F2:exp}
          eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 

--- a/examples/equal/eq-proof.bel
+++ b/examples/equal/eq-proof.bel
@@ -14,11 +14,11 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 
 eq_lam :  ({x : exp} eq x x -> eq (E x) (F x))

--- a/examples/fol/fol.bel
+++ b/examples/fol/fol.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 schema ctx = !v A;
 
 rec identity : {P: [ |- atm]}  [ |- !^ (imp (atom P ) (atom P))] =

--- a/examples/free-vars/fvnat-crec.bel
+++ b/examples/free-vars/fvnat-crec.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 
 tp: type.
 nat: tp.

--- a/examples/free-vars/fvnat.bel
+++ b/examples/free-vars/fvnat.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 
 tp: type.
 nat: tp.

--- a/examples/freshML/conv-untyped.bel
+++ b/examples/freshML/conv-untyped.bel
@@ -1,12 +1,12 @@
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/freshML/cps-crec.bel
+++ b/examples/freshML/cps-crec.bel
@@ -1,7 +1,7 @@
 %%% The Mini-ML Language
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-exp  : type.  %name exp E.
+exp  : type.  --name exp E.
 z     : exp.
 s     : exp -> exp.
 lam   : (exp -> exp) -> exp.

--- a/examples/freshML/cps-popl-tutorial1-crec.bel
+++ b/examples/freshML/cps-popl-tutorial1-crec.bel
@@ -3,12 +3,12 @@
 % Adapted from Twelf's POPL tutorial
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/freshML/cps-popl-tutorial1.bel
+++ b/examples/freshML/cps-popl-tutorial1.bel
@@ -4,12 +4,12 @@
 % Adapted from Twelf's POPL tutorial
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/freshML/cps.bel
+++ b/examples/freshML/cps.bel
@@ -1,7 +1,7 @@
 %%% The Mini-ML Language
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-exp  : type.  %name exp E.
+exp  : type.  --name exp E.
 z     : exp.
 s     : exp -> exp.
 lam   : (exp -> exp) -> exp.

--- a/examples/freshML/debruijn-1.bel
+++ b/examples/freshML/debruijn-1.bel
@@ -7,13 +7,13 @@ z: nat.
 s: nat -> nat.
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/freshML/debruijn-1a.bel
+++ b/examples/freshML/debruijn-1a.bel
@@ -9,12 +9,12 @@ z: nat.
 s: nat -> nat.
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 all : (tp -> tp) -> tp.
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/freshML/debruijn-uniform.bel
+++ b/examples/freshML/debruijn-uniform.bel
@@ -12,13 +12,13 @@
 
 }%
 % Types or Terms
-term_or_typ : type.                %name term_or_typ T.
+term_or_typ : type.                --name term_or_typ T.
 typ: term_or_typ.
 term : term_or_typ.
 
 
 % Intrinsically well-typed expressions
-obj   :  term_or_typ -> type.        %name obj E.
+obj   :  term_or_typ -> type.        --name obj E.
 
 app   : obj term -> obj T_or_K -> obj term.
 lam   : (obj T_or_K  -> obj term) -> obj term.

--- a/examples/higher-order/jpath.bel
+++ b/examples/higher-order/jpath.bel
@@ -2,18 +2,18 @@
 % definition.
 % Authors: Andrew Cave, Brigitte Pientka
 
-tm: type. %name tm T.
+tm: type. --name tm T.
 lam: (tm -> tm) -> tm.
 app: tm -> tm -> tm.
 rdx : (tm -> tm) -> tm -> tm.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> tm -> type. %name is_path I.
+is_path: path -> tm -> type. --name is_path I.
 
 p_lam: is_path (bind P) (lam E)
        <- ({x:tm}{q:path}is_path q x -> is_path (P q) (E x)).

--- a/examples/lincx_mechanization/syntax.bel
+++ b/examples/lincx_mechanization/syntax.bel
@@ -1,4 +1,4 @@
-%coverage
+--coverage
 
 % ------------------------
 % Terms

--- a/examples/literate_beluga/0Beginner/Close_Terms.bel
+++ b/examples/literate_beluga/0Beginner/Close_Terms.bel
@@ -2,7 +2,7 @@
 % Authors: Rohan Jacob-Rao & Matthias Puech 
 % Last edited: 26 Aug 2014
 
-%coverage
+--coverage
 
 %{{#Closing terms with free variables
 

--- a/examples/literate_beluga/0Beginner/Parallel_Reduction.bel
+++ b/examples/literate_beluga/0Beginner/Parallel_Reduction.bel
@@ -16,11 +16,11 @@ The mechanization highlights several aspects:
 ## Syntax
 We encode the simply-typed lambda-calculus in the logical framework LF using Twelf-style syntax.<br>
 }}%
-tp: type. %name tp T.
+tp: type. --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-tm: type. %name tm M x.
+tm: type. --name tm M x.
 app: tm -> tm -> tm.
 lam: (tm -> tm) -> tm.
 
@@ -47,7 +47,7 @@ pr_a : pr M M' -> pr N N'
 ### Typing judgement
 Following the judgements-as-types principle, we define the type family <code>oft</code> which is indexed by terms <code>tm</code> and types <code>tp</code>. Constructors <code>of_app</code> and <code>of_lam</code> encode the typing rules for application and abstraction, respectively.
 }}%
-oft: tm -> tp -> type. %name oft H.
+oft: tm -> tp -> type. --name oft H.
 of_app: oft M1 (arr T2 T) -> oft M2 T2
        -> oft (app M1 M2) T.
 of_lam: ({x:tm}oft x T1 -> oft (M x) T2)

--- a/examples/literate_beluga/0Beginner/Polymorphic_Algorithmic_Equality.bel
+++ b/examples/literate_beluga/0Beginner/Polymorphic_Algorithmic_Equality.bel
@@ -14,11 +14,11 @@ The mechanization highlights several aspects:
 
 ## Syntax
 The polymorphic lambda-calculus is introduced with the following declarations: }}%
-tp : type. %name tp T a.
+tp : type. --name tp T a.
 arr : tp -> tp -> tp.
 all : (tp -> tp) -> tp.
 
-term: type. %name term M x.
+term: type. --name term M x.
 app : term -> term -> term.
 lam : (term -> term) -> term.
 tlam: (tp -> term) -> term.
@@ -31,7 +31,7 @@ We describe algorithmic and declarative equality for the polymorphic lambda-calc
 
 %{{### Algorithmic Equality for types
 We add the judgement for type equality <code>atp</code> of type <code>tm -> tm -> type</code> along with inference rules for universal quantifiers <code>at_al</code> and arrow types <code>at_arr</code>.}}%
-atp: tp -> tp -> type. %name atp Q u.
+atp: tp -> tp -> type. --name atp Q u.
 at_al : ({a:tp} atp a a -> atp (T a) (S a))
 -> atp (all T) (all S).
 at_arr: atp T1 T2 -> atp S1 S2
@@ -39,7 +39,7 @@ at_arr: atp T1 T2 -> atp S1 S2
 
 %{{### Algorithmic Equality for terms
 We extend the term equality judgement given for the untyped lambda-calculus with rules for type abstraction <code>ae_tl</code> and type application <code>ae_ta</code>.}}%
-aeq: term -> term -> type. %name aeq D u.
+aeq: term -> term -> type. --name aeq D u.
 ae_a : aeq M1 N1 -> aeq M2 N2
     -> aeq (app M1 M2) (app N1 N2).
 ae_l : ({x:term} aeq x x -> aeq (M x) (N x))
@@ -52,7 +52,7 @@ ae_ta : aeq M N -> atp T S
 % ----------------------------------------------------------------- %
 %{{### Declarative Equality for types
 We define declarative equality for types in order to establish its equivalence with algorithmic equality and prove completeness. Rules for reflexivity, transitivity, and symmetry are explicitly derived.}}%
-dtp: tp -> tp -> type. %name atp P u.
+dtp: tp -> tp -> type. --name atp P u.
 dt_al : ({a:tp}dtp a a -> dtp (T a) (S a))
 -> dtp (all T) (all S).
 dt_arr: dtp T1 T2 -> dtp S1 S2

--- a/examples/literate_beluga/1Intermediate/Poplmark.bel
+++ b/examples/literate_beluga/1Intermediate/Poplmark.bel
@@ -23,7 +23,7 @@ LF tp : type =
   | forall: tp -> (tp -> tp) -> tp       % Universal Type: forall x>:A1. A2    forall A1 ([x] A2 x)
 ;             
 
-%name tp T.
+--name tp T.
 
 
 

--- a/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
+++ b/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
@@ -12,11 +12,11 @@ This case study shows how to implement a type-preserving normalizer using normal
 The setup is a standard intrinsically-typed lambda calculus: 
 }}%
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 b : tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
@@ -26,8 +26,8 @@ schema tctx = tm T;
 Below, we describe $\eta$-long normal forms. Notice that we allow embedding of neutral terms into normal terms only at base type `b`: this enforces $\eta$-longness.
 }}%
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut b -> norm b.

--- a/examples/literate_beluga/2Advanced/Weak_Normalization.bel
+++ b/examples/literate_beluga/2Advanced/Weak_Normalization.bel
@@ -12,9 +12,9 @@ LF tp : type =
 | b :  tp
 | arr : tp -> tp -> tp
 ;
-%name tp T.        
+--name tp T.        
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 c : tm b.
@@ -42,15 +42,15 @@ Finally, we define:
 - `halts` to encode that a term halts if it steps into a value.
 }}%
 
-mstep : tm A -> tm A -> type.  %name mstep S.
+mstep : tm A -> tm A -> type.  --name mstep S.
 refl : mstep M M.
 onestep : step M M' -> mstep M' M'' -> mstep M M''.
 
-val : tm A -> type. %name val V.
+val : tm A -> type. --name val V.
 val/c : val c.
 val/lam : val (lam M).
 
-halts : tm A -> type.  %name halts H.
+halts : tm A -> type.  --name halts H.
 halts/m : mstep M M' -> val M' -> halts M.
 
 %{{

--- a/examples/logrel/algeq-simplified.bel
+++ b/examples/logrel/algeq-simplified.bel
@@ -2,19 +2,19 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory 
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -30,7 +30,7 @@ schema tctx = some [t:tp] block x:tm, y:algeqNeu x x t;
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:tctx) [g |- tmpair] -> [ |- tp] -> ctype   =
 | LogBase : [g |- algeq M N i]
@@ -313,7 +313,7 @@ dctx : type.
 nil : dctx.
 & : dctx -> tp -> dctx.
 
-%infix & 5 right.
+--infix & 5 right.
 
 inductive Lookup : {G:[|-dctx]}(g:ctx)[g |-  tm] -> [ |- tp] -> ctype  =
 | Top : Lookup [|- G & T] [g,x:tm |-  x] [ |- T]

--- a/examples/logrel/algeq-simplified1.bel
+++ b/examples/logrel/algeq-simplified1.bel
@@ -2,19 +2,19 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -306,7 +306,7 @@ dctx : type.
 nil : dctx.
 & : dctx -> tp -> dctx.
 
-%infix & 5 right.
+--infix & 5 right.
 
 inductive Lookup : {G:[|-dctx]}(g:ctx)[g |-  tm] -> [ |- tp] -> ctype  =
 | Top : Lookup [|- G & T] [g,x:tm |-  x] [ |- T]

--- a/examples/logrel/algeq-typing.bel
+++ b/examples/logrel/algeq-typing.bel
@@ -2,15 +2,15 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory 
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
@@ -18,7 +18,7 @@ oft : tm -> tp -> type.
 t_app : oft M (arr T S) -> oft N T -> oft (app M N) S.
 t_lam : ({x:tm} oft x T -> oft (M x) S) -> oft (lam (\x. M x)) (arr T S).
  
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -34,7 +34,7 @@ schema tctx = some [t:tp] block x:tm, y:oft x t, z:algeqr x x t;
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:tctx) [g |- tmpair] -> [ |- tp] -> ctype   =
 | LogBase : [g |- algeqn M N i]

--- a/examples/logrel/weak-norm-closed-ideal.bel
+++ b/examples/logrel/weak-norm-closed-ideal.bel
@@ -5,13 +5,13 @@
 LF tp : type =
 | i :  tp
 | arr: tp -> tp -> tp;
- %name tp T.
+ --name tp T.
 
 LF tm : tp -> type =
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 | c : tm i;
-%name tm E.
+--name tm E.
 
 schema ctx = tm T;
 
@@ -20,16 +20,16 @@ LF mstep : tm A -> tm A -> type =
 | stepapp : mstep M M' -> mstep N N' -> mstep (app M N) (app M' N')
 | refl : mstep M M
 | trans : mstep M M' -> mstep M' M'' -> mstep M M'';
-%name mstep S.
+--name mstep S.
 
 LF val : tm A -> type =
 | val/c : val c
 | val/lam : val (lam M);
-%name val V.
+--name val V.
 
 LF halts : tm A -> type =
 halts/m : mstep M M' -> val M' -> halts M;
-%name halts H.
+--name halts H.
 
 stratified Reduce : {A:[ |- tp]} {M:[ |- tm A]} ctype  =
 | I : [ |- halts M] -> Reduce [ |- i] [ |- M]

--- a/examples/logrel/weak-norm-total-mix-lf-inductive.bel
+++ b/examples/logrel/weak-norm-total-mix-lf-inductive.bel
@@ -20,14 +20,14 @@ LF tp : type =
 | b :  tp
 | arr : tp -> tp -> tp
 ;
-%name tp T.        
+--name tp T.        
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 | c : tm b
 ;
-%name tm M.
+--name tm M.
 
 %{{ The type `tm` defines our family of simply-typed lambda terms
 indexed by their type as an LF signature. In typical higher-order

--- a/examples/logrel/weak-norm-total-products-explicit-typing.bel
+++ b/examples/logrel/weak-norm-total-products-explicit-typing.bel
@@ -3,9 +3,9 @@ LF tp : type =
 | arr : tp -> tp -> tp
 | prod : tp -> tp -> tp
 ;
-%name tp T.        
+--name tp T.        
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 fst : tm -> tm.
@@ -23,16 +23,16 @@ prod2 : step (snd (pair M N)) N.
 steppair1 : step M M' -> step (pair M N) (pair M' N).
 steppair2 : step N N' -> step (pair M N) (pair M N').
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 onestep : step M M' -> mstep M' M'' -> mstep M M''.
 
-val : tm -> type. %name val V.
+val : tm -> type. --name val V.
 val/c : val c.
 val/lam : val (lam M).
 val/pair : val M -> val N -> val (pair M N).
 
-halts : tm -> type.  %name halts H.
+halts : tm -> type.  --name halts H.
 halts/m : mstep M M' -> val M' -> halts M.
 
 stratified Reduce : {A:[⊢ tp]}{M:[ |- tm]} ctype =

--- a/examples/logrel/weak-norm-total-products.bel
+++ b/examples/logrel/weak-norm-total-products.bel
@@ -21,7 +21,7 @@ LF tp : type =
 | arr  : tp -> tp -> tp
 | cross: tp -> tp -> tp
 ;
-%name tp T.        
+--name tp T.        
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
@@ -31,7 +31,7 @@ LF tm : tp -> type =
 | fst : tm (cross T S) -> tm T
 | snd : tm (cross T S) -> tm S
 ;
-%name tm M.
+--name tm M.
 
 %{{ The type `tm` defines our family of simply-typed lambda terms
 indexed by their type as an LF signature. In typical higher-order
@@ -68,19 +68,19 @@ LF mstep : tm A -> tm A -> type =
 | refl : mstep M M
 | onestep : step M M' -> mstep M' M'' -> mstep M M''
 ;
-%name mstep S.
+--name mstep S.
 
 LF val : tm A -> type = 
 | val/c : val c
 | val/lam : val (lam M)
 | val/pair: val M -> val N -> val (pair M N)
 ;
-%name val V.
+--name val V.
 
 LF halts : tm A -> type = 
 | halts/m : mstep M M' -> val M' -> halts M
 ;
-%name halts H.
+--name halts H.
 
 %{{
 

--- a/examples/logrel/weak-norm-total.bel
+++ b/examples/logrel/weak-norm-total.bel
@@ -20,14 +20,14 @@ LF tp : type =
 | b :  tp
 | arr : tp -> tp -> tp
 ;
-%name tp T.        
+--name tp T.        
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 | c : tm b
 ;
-%name tm M.
+--name tm M.
 
 %{{ The type `tm` defines our family of simply-typed lambda terms
 indexed by their type as an LF signature. In typical higher-order
@@ -58,18 +58,18 @@ LF mstep : tm A -> tm A -> type =
 | refl : mstep M M
 | onestep : step M M' -> mstep M' M'' -> mstep M M''
 ;
-%name mstep S.
+--name mstep S.
 
 LF val : tm A -> type = 
 | val/c : val c
 | val/lam : val (lam M)
 ;
-%name val V.
+--name val V.
 
 LF halts : tm A -> type = 
 | halts/m : mstep M M' -> val M' -> halts M
 ;
-%name halts H.
+--name halts H.
 
 %{{
 

--- a/examples/logrel/weak-norm-under-binders-beta-only.bel
+++ b/examples/logrel/weak-norm-under-binders-beta-only.bel
@@ -9,13 +9,13 @@ LF tp : type =
 | i :  tp
 | arr: tp -> tp -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 ;
-%name tm E.
+--name tm E.
 
 schema ctx = tm T;
 % ----------------------------------------------------------------------------
@@ -31,7 +31,7 @@ LF mstep : tm A -> tm A -> type =
 | s_trans : step M M' -> mstep M' M'' -> mstep M M''
 ;
 
-%name step S.
+--name step S.
 % -----------------------------------------------------------------------------
 % Defining Normal and Neutral Terms
 % We define them in LF. We do not enforce eta-longness here, although this can in principle be done.

--- a/examples/logrel/weak-norm-under-binders-simplified.bel
+++ b/examples/logrel/weak-norm-under-binders-simplified.bel
@@ -9,13 +9,13 @@ LF tp : type =
 | i :  tp
 | arr: tp -> tp -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 ;
-%name tm E.
+--name tm E.
 
 schema ctx = tm T;
 % ----------------------------------------------------------------------------
@@ -32,7 +32,7 @@ LF mstep : tm A -> tm A -> type =
 | s_trans : step M M' -> mstep M' M'' -> mstep M M''
 ;
 
-%name step S.
+--name step S.
 % -----------------------------------------------------------------------------
 % Defining Normal and Neutral Terms
 % We define them in LF. We do not enforce eta-longness here, although this can in principle be done.

--- a/examples/logrel/weak-norm-under-binders.bel
+++ b/examples/logrel/weak-norm-under-binders.bel
@@ -9,13 +9,13 @@ LF tp : type =
 | i :  tp
 | arr: tp -> tp -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type = 
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 ;
-%name tm E.
+--name tm E.
 
 schema ctx = tm T;
 % ----------------------------------------------------------------------------
@@ -28,7 +28,7 @@ LF step : tm A -> tm A -> type =
 | s_refl : step M M
 | s_trans : step M M' -> step M' M'' -> step M M''
 ;
-%name step S.
+--name step S.
 % -----------------------------------------------------------------------------
 % Defining Normal and Neutral Terms
 % We define them using inductive types rather than using LF to not clutter 

--- a/examples/logrel/weak-norm.bel
+++ b/examples/logrel/weak-norm.bel
@@ -20,14 +20,14 @@ LF tp : type =
 | b :  tp
 | arr : tp -> tp -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type =
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 | c : tm b
 ;
-%name tm E.
+--name tm E.
 
 %{{ The type `tm` defines our family of simply-typed lambda terms
 indexed by their type as an LF signature. In typical higher-order
@@ -57,18 +57,18 @@ LF mstep : tm A -> tm A -> type =
 | refl : mstep M M
 | onestep : step M M' -> mstep M' M'' -> mstep M M''
 ;
-%name mstep S.
+--name mstep S.
 
 LF val : tm A -> type =
 | val/c : val c
 | val/lam : val (lam M)
 ;
-%name val V.
+--name val V.
 
 LF halts : tm A -> type =
 | halts/m : mstep M M' -> val M' -> halts M
 ;
-%name halts H.
+--name halts H.
 
 %{{
 

--- a/examples/mini-ml/eval-sub.bel
+++ b/examples/mini-ml/eval-sub.bel
@@ -13,7 +13,7 @@ LF exp: type =
 | letv: exp -> (exp -> exp) -> exp
 | fix : (exp -> exp) -> exp
 ;
- %name exp E.
+ --name exp E.
 
 % Call-By-Name evaluation
 rec eval : [ |- exp] -> [ |- exp] =

--- a/examples/mini-ml/tps.bel
+++ b/examples/mini-ml/tps.bel
@@ -2,11 +2,11 @@
 % Author: Brigitte Pientka
 %
 
-tp   : type.   %name tp T.
+tp   : type.   --name tp T.
 nat  : tp.
 arrow  : tp -> tp -> tp.
 
-exp  : type.   %name exp E.
+exp  : type.   --name exp E.
 z    : exp.
 suc  : exp -> exp.
 match: exp -> exp -> (exp -> exp) -> exp.   
@@ -15,7 +15,7 @@ lam  : tp -> (exp -> exp) -> exp.
 app  : exp -> exp -> exp.
 
 % Evaluation
-eval : exp -> exp -> type.  %name eval F.
+eval : exp -> exp -> type.  --name eval F.
 ev_z : eval z z.
 
 ev_s : eval E V -> eval (suc E) (suc V).
@@ -38,7 +38,7 @@ ev_app: eval E1 (lam T (\x. E x)) -> eval E2 V2 -> eval (E V2) V
 
 % Typing
 
-oft : exp -> tp -> type.  %name oft D u.
+oft : exp -> tp -> type.  --name oft D u.
 
 tp_z     : oft z nat.
 tp_s     : oft E nat ->
@@ -62,12 +62,12 @@ tp_letv : ({x:exp} oft x T1 -> oft (E2 x) T2) ->
 
 % Gives type-checking error, 'Substitution not well-typed'
 
-%query 1 * D : oft (suc (suc z)) nat.
-%query 1 * D : oft (lam T (\x.x)) S.
-%query 1 * D : oft (letv (suc (suc z)) (\x. app (lam nat (\y.y)) x) ) T.
-%query 1 * D : oft (lam T (\x.x)) S.
+--query 1 * D : oft (suc (suc z)) nat.
+--query 1 * D : oft (lam T (\x.x)) S.
+--query 1 * D : oft (letv (suc (suc z)) (\x. app (lam nat (\y.y)) x) ) T.
+--query 1 * D : oft (lam T (\x.x)) S.
 
-%query * 5 P : oft X nat -> oft (suc X) nat.
+--query * 5 P : oft X nat -> oft (suc X) nat.
 
 % Type preservation proof
 rec tps :  [ |- eval E V] -> [ |- oft E T]

--- a/examples/mini-ml/vsound-explicit.bel
+++ b/examples/mini-ml/vsound-explicit.bel
@@ -3,16 +3,16 @@
 %
 
 
-exp  : type.    %name exp E.
+exp  : type.    --name exp E.
 z    : exp.
 suc  : exp -> exp.
 letv : exp -> (exp -> exp) -> exp.
 
-value : exp -> type.  %name value F.
+value : exp -> type.  --name value F.
 v_z   : value z.
 v_s   : {E:exp} value E -> value (suc E).
 
-eval : exp -> exp -> type.  %name eval D.
+eval : exp -> exp -> type.  --name eval D.
 ev_z : eval z z.
 ev_s : {E:exp} {V:exp} eval E V -> eval (suc E) (suc V).
 ev_l : {E1:exp} {E2:exp -> exp} {V1:exp} {V:exp}

--- a/examples/mini-ml/vsound.bel
+++ b/examples/mini-ml/vsound.bel
@@ -2,19 +2,19 @@
 % Author: Brigitte Pientka
 %
 
-exp  : type.   %name exp E.
+exp  : type.   --name exp E.
 z    : exp.
 suc  : exp -> exp.
 letv : exp -> (exp -> exp) -> exp.
 lam  : (exp -> exp) -> exp.
 app  : exp -> exp -> exp.
 
-value : exp -> type. %name value F.
+value : exp -> type. --name value F.
 v_z   : value z.
 v_s   : value E -> value (suc E).
 v_lam   : value (lam (\x. E x)).
 
-eval : exp -> exp -> type.   %name eval D.
+eval : exp -> exp -> type.   --name eval D.
 ev_z : eval z z.
 
 ev_s : eval E V -> eval (suc E) (suc V).

--- a/examples/path/bred-nf.bel
+++ b/examples/path/bred-nf.bel
@@ -9,20 +9,20 @@ LF tm: type =
 | app: tm -> tm -> tm
 | beta: (tm -> tm) -> tm -> tm
 ;
-%name tm M.
+--name tm M.
 
 LF nf: type =
 | nabs: (nf -> nf) -> nf
 | napp: nf -> nf -> nf
 ;
-%name nf U.
+--name nf U.
 
 LF p : type =
 | left : p -> p
 | right: p -> p
 | bnd  : (p -> p) -> p
 ;
-%name p P.
+--name p P.
 
 LF bred : tm -> nf -> type =
 | r_abs : ({x:tm}{y:nf}  bred x y -> bred (M x) (N y))
@@ -32,7 +32,7 @@ LF bred : tm -> nf -> type =
 | r_beta: ({x:tm} ({u:nf} bred N u -> bred x u) -> bred (R x) V)
       -> bred (beta R N) V
 ;
-%name bred R.
+--name bred R.
 
 LF path : tm -> p -> type =
 | p_abs   : ({x:tm}{p:p} path x p -> path (M x) (P p))
@@ -45,7 +45,7 @@ LF path : tm -> p -> type =
            -> path (beta R N) P
 ;
 
-%name path Pf.
+--name path Pf.
 
 LF npath : nf -> p -> type =
 | np_abs   : ({x:nf}{p:p} npath x p -> npath (M x) (P p))
@@ -56,7 +56,7 @@ LF npath : nf -> p -> type =
          -> npath (napp M N) (right P)
 
 ;
-%name path Qf.
+--name path Qf.
 
 schema tctx = tm ;
 

--- a/examples/path/path-typed.bel
+++ b/examples/path/path-typed.bel
@@ -1,12 +1,12 @@
-tp:type. %name tp T a.
+tp:type. --name tp T a.
 arr: tp -> tp -> tp. % infix right 10 => .
 
-exp: type. %name exp E x.
+exp: type. --name exp E x.
 
 lam: tp -> (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 
-type_of: exp -> tp -> type. %name type_of D u.
+type_of: exp -> tp -> type. --name type_of D u.
 
 tof_lam: type_of (lam T E) (arr T T')
 	 <- ({x:exp}type_of x T -> type_of (E x) T').
@@ -15,13 +15,13 @@ tof_app: type_of (app E1 E2) T
 	 <- type_of E1 (arr T2 T)
 	 <- type_of E2 T2.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: tp -> (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> exp -> type. %name is_path I.
+is_path: path -> exp -> type. --name is_path I.
 
 p_lam: is_path (bind T P) (lam T E)
        <- ({x:exp}{q:path}type_of x T -> is_path q x -> is_path (P q) (E x)).
@@ -34,7 +34,7 @@ p_right: is_path (right P) (app M N)
 
 p_done: is_path done M.
 
-eq: exp -> exp -> type.  %name eq E.
+eq: exp -> exp -> type.  --name eq E.
 e_ref: eq T T.
 %{e_lam: ({x:exp}eq x x -> eq (E x) (E' x))
         -> eq (lam T E) (lam T E').

--- a/examples/path/path.bel
+++ b/examples/path/path.bel
@@ -1,14 +1,14 @@
-tm: type. %name tm T.
+tm: type. --name tm T.
 lam: (tm -> tm) -> tm.
 app: tm -> tm -> tm.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> tm -> type. %name is_path I.
+is_path: path -> tm -> type. --name is_path I.
 
 p_lam: is_path (bind P) (lam E)
        <- ({x:tm}{q:path}is_path q x -> is_path (P q) (E x)).
@@ -21,7 +21,7 @@ p_right: is_path (right P) (app M N)
 
 p_done: is_path done M.
 
-eq: tm -> tm -> type.  %name eq E.
+eq: tm -> tm -> type.  --name eq E.
 e_ref: eq T T.
 
 schema ctx = block x:tm,p:path , _t:is_path p x ;

--- a/examples/popl12/closconv.bel
+++ b/examples/popl12/closconv.bel
@@ -4,7 +4,7 @@ LF tm:type  =
 | lam: (tm -> tm) -> tm
 | app: tm -> tm -> tm
 ;
-%name tm M.
+--name tm M.
 
 LF nat:type =
 | z : nat

--- a/examples/popl12/copy.bel
+++ b/examples/popl12/copy.bel
@@ -1,4 +1,4 @@
-exp: type. %name exp E.
+exp: type. --name exp E.
 lam: (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 z: exp.

--- a/examples/popl12/nbe.bel
+++ b/examples/popl12/nbe.bel
@@ -1,18 +1,18 @@
 
 
 atomic_tp : type.
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 atomic : atomic_tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut (atomic P) -> norm (atomic P).

--- a/examples/popl12/normeval-abbrev.bel
+++ b/examples/popl12/normeval-abbrev.bel
@@ -6,13 +6,13 @@ LF tp : type =
 | atomic : atomic_tp -> tp
 | arr: tp -> tp -> tp;
 
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type =
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S);
 
-%name tm E.
+--name tm E.
 
 schema tctx = some [t:tp] tm t;
 
@@ -21,8 +21,8 @@ LF neut : tp -> type =
 and norm : tp -> type =
 | nlam : (neut T -> norm S) -> norm (arr T S)
 | embed : neut (atomic P) -> norm (atomic P);
-%name neut R.
-%name norm M.
+--name neut R.
+--name norm M.
 schema ctx = neut T;
 
 inductive NeutVar : {g:ctx} [ |- tp] -> ctype =

--- a/examples/popl12/normeval-subst.bel
+++ b/examples/popl12/normeval-subst.bel
@@ -15,13 +15,13 @@ LF tp : type =
 | atomic : atomic_tp -> tp
 | arr: tp -> tp -> tp;
 
-%name tp T.
+--name tp T.
 
 LF tm : tp -> type =
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S);
 
-%name tm E.
+--name tm E.
 
 schema tctx = some [t:tp] tm t;
 
@@ -30,8 +30,8 @@ LF neut : tp -> type =
 and norm : tp -> type =
 | nlam : (neut T -> norm S) -> norm (arr T S)
 | embed : neut (atomic P) -> norm (atomic P);
-%name neut R.
-%name norm M.
+--name neut R.
+--name norm M.
 schema ctx = neut T;
 
 inductive TmVar : {g:tctx} [ |- tp] -> ctype =

--- a/examples/popl12/normeval-total.bel
+++ b/examples/popl12/normeval-total.bel
@@ -1,18 +1,18 @@
 % #opts +strengthen;
 
 atomic_tp : type.
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 atomic : atomic_tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut (atomic P) -> norm (atomic P).

--- a/examples/popl12/normeval.bel
+++ b/examples/popl12/normeval.bel
@@ -1,18 +1,18 @@
 
 
 atomic_tp : type.
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 atomic : atomic_tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut (atomic P) -> norm (atomic P).

--- a/examples/poplmark/pearl.bel
+++ b/examples/poplmark/pearl.bel
@@ -16,7 +16,7 @@
 % --------------------------------------------------------------------------
 % Definition of types
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 top   : tp.
 arr   : tp -> tp -> tp.			% Functions: A1 => A2
@@ -73,7 +73,7 @@ schema as_ctx =  some [u:tp]  block a:tp, w: subtype a U;
 % ------------------------------------------------------------------
 %   G |- (forall a < S1. S2)  < (forall a < T1. T2)
 
-sub : tp -> tp -> type.                %name sub S.
+sub : tp -> tp -> type.                --name sub S.
 
 
 sa_top : sub S top.

--- a/examples/poplmark/poplmark.bel
+++ b/examples/poplmark/poplmark.bel
@@ -7,14 +7,14 @@
 % --------------------------------------------------------------------------
 % Definition of types
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 top   : tp.
 arr   : tp -> tp -> tp.			% Functions: A1 => A2
 forall: tp -> (tp -> tp) -> tp.           % Universal Type: forall x>:A1. A2
                                         % forall A1 ([x] A2 x)
 
-% => = arrow.  %infix right 11 =>.
+% => = arrow.  --infix right 11 =>.
 
 schema a_ctx = tp;
 assm : tp -> tp -> type.  %% subtyping assumptions

--- a/examples/small-step/lam.bel
+++ b/examples/small-step/lam.bel
@@ -1,7 +1,7 @@
 % Progress and preservation for the Church-style simply-typed lambda calculus
 
-tp : type.  %name tp T.
-tm : type.  %name tm M.
+tp : type.  --name tp T.
+tm : type.  --name tm M.
 
 % Types
 arr : tp -> tp -> tp.
@@ -11,7 +11,7 @@ app : tm -> tm -> tm.
 lam : tp -> (tm -> tm) -> tm.
 
 % Typing
-has_type : tm -> tp -> type.  %name has_type D.
+has_type : tm -> tp -> type.  --name has_type D.
 
 is_app : has_type E1 (arr T1 T2) ->
          has_type E2 T1 ->
@@ -23,13 +23,13 @@ is_lam : ({x:tm} has_type x T1 -> has_type (E x) T2) ->
          has_type (lam T1 (\x. E x)) (arr T1 T2).
 
 % Values
-value : tm -> type.  %name value V.
+value : tm -> type.  --name value V.
 
 value_lam : value (lam T (\x. E x)).
 
 % Operational semantics
 
-step: tm -> tm -> type.  %name step S.
+step: tm -> tm -> type.  --name step S.
 
 s_app1 : step E1 E1' ->
       % --------------------------

--- a/examples/subject-red-crec.bel
+++ b/examples/subject-red-crec.bel
@@ -1,12 +1,12 @@
-tp:type. %name tp T a.
+tp:type. --name tp T a.
 arr: tp -> tp -> tp. % infix right 10 => .
 
-exp: type. %name exp E x.
+exp: type. --name exp E x.
 
 lam: tp -> (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 
-type_of: exp -> tp -> type. %name type_of D u.
+type_of: exp -> tp -> type. --name type_of D u.
 
 tof_lam: type_of (lam T E) (arr T T')
 	 <- ({x:exp}type_of x T -> type_of (E x) T').

--- a/examples/subject-red.bel
+++ b/examples/subject-red.bel
@@ -1,12 +1,12 @@
-tp:type. %name tp T.
+tp:type. --name tp T.
 arr: tp -> tp -> tp. % infix right 10 => .
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 
 lam: tp -> (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 
-type_of: exp -> tp -> type. %name type_of D.
+type_of: exp -> tp -> type. --name type_of D.
 
 tof_lam: type_of (lam T E) (arr T T')
 	 <- ({x:exp}type_of x T -> type_of (E x) T').

--- a/examples/tapl/ch14.bel
+++ b/examples/tapl/ch14.bel
@@ -5,7 +5,7 @@
 LF tp: type =
 | nat: tp
 | arr: tp -> tp -> tp;
-%name tp  T.
+--name tp  T.
 
 LF term: type =
 | app: term -> term -> term
@@ -13,16 +13,16 @@ LF term: type =
 | raise : term -> term   % (raise e)
 | trywith: term -> (term -> term) -> term
 ;
-%name term M.
+--name term M.
 
 LF value:  term -> type =
 | v_lam: value (lam T M);
-%name value V.
+--name value V.
 
 LF error : term -> type =
 | er_raise : value V -> error (raise V)
 ;
-%name error E.
+--name error E.
 % ---------------------------------------------------------- %
 % Small-step operational semantics
 
@@ -55,7 +55,7 @@ LF step: term -> term -> type =
 
 | step_try_error: value V -> step (trywith (raise V) E2) (E2 V)
 ;
-%name step S.
+--name step S.
 % ---------------------------------------------------------- %
 LF oft: term -> tp -> type =
 | t_lam : ({x:term} oft x T -> oft (E x) S)

--- a/examples/tapl/ch3+arith+leq/exp.bel
+++ b/examples/tapl/ch3+arith+leq/exp.bel
@@ -31,12 +31,12 @@ let v2 = [ |- iszero (pred (succ z))]  ;
 let v3 = [ |- switch (succ z) (succ z) false]  ;
 
 % Examples : Invalid Terms
-% (use keyword %not to say that the subsequent line is not true)
+% (use keyword --not to say that the subsequent line is not true)
 
-%not
+--not
 let w1 = [ |- iszero] ;
 
-%not
+--not
 let w2 = [ |- switch z z] ;
 
 

--- a/examples/tapl/ch3+arith/evaluation.bel
+++ b/examples/tapl/ch3+arith/evaluation.bel
@@ -16,7 +16,7 @@ LF term  : type =
 | iszero: term -> term
 ;
 
-%name term M.
+--name term M.
 % ----------------------------------------------------------------------------
 % Examples : Valid Terms
 
@@ -31,12 +31,12 @@ let v2 = [ |- iszero (pred (succ z))]  ;
 let v3 = [ |- switch (succ z) (succ z) false ] ;
 
 % Examples : Invalid Terms
-% (use keyword %not to say that the subsequent line is not true)
+% (use keyword --not to say that the subsequent line is not true)
 
-%not
+--not
 let w1 = [ |- iszero] ;
 
-%not
+--not
 let w2 = [ |- switch z z] ;
 
 % ----------------------------------------------------------------------------
@@ -109,7 +109,7 @@ LF tp : type =
 | nat : tp
 | bool : tp
 ;
-%name tp T.
+--name tp T.
 
 LF hastype: term -> tp -> type =
 | t_zero : hastype z nat

--- a/examples/tapl/ch3+arith/exp.bel
+++ b/examples/tapl/ch3+arith/exp.bel
@@ -30,10 +30,10 @@ let v2 = [ |- iszero (pred (succ z))]  ;
 let v3 = [ |- switch (succ z) (succ z) false ] ;
 
 % Examples : Invalid Terms
-% (use keyword %not to say that the subsequent line is not true)
+% (use keyword --not to say that the subsequent line is not true)
 
-%not
+--not
 let w1 = [ |- iszero] ;
 
-%not
+--not
 let w2 = [ |- switch z z] ;

--- a/examples/tapl/ch3/exp.bel
+++ b/examples/tapl/ch3/exp.bel
@@ -17,7 +17,7 @@ LF term  : type =
 let v1 = [ |- if_then_else false true (if_then_else true false true)] ;
 
 
-%not
+--not
 let w2 = [ |- if_then_else true false] ;
 
 

--- a/examples/tpcert.bel
+++ b/examples/tpcert.bel
@@ -1,10 +1,10 @@
-%nostrengthen
-tp   : type.  %name tp T.
+--nostrengthen
+tp   : type.  --name tp T.
 nat  : tp.
 bool : tp.
 arr  : tp -> tp -> tp.
 
-term : type.  %name term M.
+term : type.  --name term M.
 z    : term.
 tt   : term.
 ff   : term.
@@ -13,7 +13,7 @@ letv : term -> (term -> term) -> term.
 lam  : tp -> (term -> term) -> term.
 app  : term -> term -> term.
 
-oft  : term -> tp -> type.  %name oft D.
+oft  : term -> tp -> type.  --name oft D.
 o_tt : oft tt bool.
 o_ff : oft ff bool.
 o_z  : oft z nat.

--- a/examples/typed-compilation/cps-popl-tutorial1-crec.bel
+++ b/examples/typed-compilation/cps-popl-tutorial1-crec.bel
@@ -3,12 +3,12 @@
 % Adapted from Twelf's POPL tutorial
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/typed-compilation/debruijn.bel
+++ b/examples/typed-compilation/debruijn.bel
@@ -7,13 +7,13 @@ z: nat.
 s: nat -> nat.
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/examples/typed-eval/tpeval-val.bel
+++ b/examples/typed-eval/tpeval-val.bel
@@ -4,12 +4,12 @@
 %
 % TODO extend with functions and function application
 
-tp   : type. %name tp T.
+tp   : type. --name tp T.
 nat  : tp.
 bool : tp.
 
-exp  : tp -> type.  %name exp E.
-val   : tp -> type. %name val V.
+exp  : tp -> type.  --name exp E.
+val   : tp -> type. --name val V.
 
 tt   : exp bool.
 ff   : exp bool.

--- a/examples/typed-eval/tpeval.bel
+++ b/examples/typed-eval/tpeval.bel
@@ -4,11 +4,11 @@
 %
 % TODO extend with functions and function application
 
-tp   : type. %name tp T.
+tp   : type. --name tp T.
 nat  : tp.
 bool : tp.
 
-exp  : tp -> type.  %name exp E.
+exp  : tp -> type.  --name exp E.
 
 tt   : exp bool.
 ff   : exp bool.

--- a/examples/unique/unique-crec.bel
+++ b/examples/unique/unique-crec.bel
@@ -1,15 +1,15 @@
 
 % Definition of types and expressions
-tp: type.  %name tp T.
+tp: type.  --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 lam : tp -> (exp -> exp) -> exp.
 app : exp -> exp -> exp.
 
 % Typing judgment
-type_of: exp -> tp -> type. %name type_of H.
+type_of: exp -> tp -> type. --name type_of H.
 
 t_lam: ({x:exp}type_of x T1 -> type_of (E x) T2)
         -> type_of (lam T1 E) (arr T1 T2).

--- a/examples/unique/unique-eval.bel
+++ b/examples/unique/unique-eval.bel
@@ -1,9 +1,9 @@
 % Definition of types and expressions
-tp: type.  %name tp T.
+tp: type.  --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 % lam : tp -> (exp -> exp) -> exp.
 lam :  (exp -> exp) -> exp.
 app : exp -> exp -> exp.

--- a/examples/unique/unique-standard.bel
+++ b/examples/unique/unique-standard.bel
@@ -8,13 +8,13 @@ LF tp: type =
 | arr: tp -> tp -> tp
 | nat: tp
 ;
-%name tp T.
+--name tp T.
 
 LF term: type = 
 | lam : tp -> (term -> term) -> term
 | app : term -> term -> term
 ;
-%name term E.
+--name term E.
 
 % Typing judgment
 LF hastype: term -> tp -> type = 
@@ -23,7 +23,7 @@ LF hastype: term -> tp -> type =
 | t_app: hastype E1 (arr T2 T) -> hastype E2 T2
        -> hastype (app E1 E2) T
 ;
-%name hastype H.
+--name hastype H.
 
 % Equality predicate
 LF eq: tp -> tp -> type = 

--- a/examples/unique/unique.bel
+++ b/examples/unique/unique.bel
@@ -6,13 +6,13 @@ LF tp: type =
 | arr: tp -> tp -> tp
 | nat: tp
 ;
-%name tp T.
+--name tp T.
 
 LF exp: type = 
 | lam : tp -> (exp -> exp) -> exp
 | app : exp -> exp -> exp
 ;
-%name exp E.
+--name exp E.
 
 % Typing judgment
 LF type_of: exp -> tp -> type = 
@@ -21,7 +21,7 @@ LF type_of: exp -> tp -> type =
 | t_app: type_of E1 (arr T2 T) -> type_of E2 T2
        -> type_of (app E1 E2) T
 ;
-%name type_of H.
+--name type_of H.
 
 % Equality predicate
 

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -261,11 +261,11 @@ GLOBAL: sgn;
   sgn_global_prag:
   [
     [
-        "%nostrengthen" -> Sgn.GlobalPragma(_loc, Sgn.NoStrengthen)
+        "--nostrengthen" -> Sgn.GlobalPragma(_loc, Sgn.NoStrengthen)
       |
-        "%coverage" -> Sgn.GlobalPragma(_loc, Sgn.Coverage(`Error))
+        "--coverage" -> Sgn.GlobalPragma(_loc, Sgn.Coverage(`Error))
       |
-        "%warncoverage" -> Sgn.GlobalPragma(_loc, Sgn.Coverage(`Warn))
+        "--warncoverage" -> Sgn.GlobalPragma(_loc, Sgn.Coverage(`Warn))
     ]
   ];
 
@@ -299,17 +299,17 @@ GLOBAL: sgn;
   sgn_decl:
     [
       [
-          "%name"; w = SYMBOL ; mv = UPSYMBOL ; x = OPT [ y = SYMBOL -> y ]; "." ->
+          "--name"; w = SYMBOL ; mv = UPSYMBOL ; x = OPT [ y = SYMBOL -> y ]; "." ->
             [Sgn.Pragma (_loc, Sgn.NamePrag (Id.mk_name (Id.SomeString w), mv, x))]
 
-        | "%query" ; e = bound ; t = bound ; x = OPT [ y = UPSYMBOL ; ":" -> y ] ; a = lf_typ ; "." ->
+        | "--query" ; e = bound ; t = bound ; x = OPT [ y = UPSYMBOL ; ":" -> y ] ; a = lf_typ ; "." ->
             if Option.is_some x then
               let p = Id.mk_name (Id.SomeString (Option.get x)) in
               [Sgn.Query (_loc, Some p, a, e, t)]
             else
               [Sgn.Query (_loc, None, a, e, t)]
 
-        | "%not" ->
+        | "--not" ->
             [Sgn.Pragma (_loc, Sgn.NotPrag)]
 
         | "module"; n = UPSYMBOL; "="; "struct"; decls = LIST1 sgn_decl; "end" ; ";"  ->
@@ -341,7 +341,7 @@ GLOBAL: sgn;
 (*      | "total" ; x = total_order ; "("; r = SYMBOL ; args = LIST0 call_args ; ")" ;  ";" ->
           [Sgn.Pragma (_loc, Sgn.Total (x, Id.mk_name (Id.SomeString r), args))] *)
 
-      | "%name"; w = SYMBOL ; mv = UPSYMBOL ; x = OPT [ y = SYMBOL -> y ]; "." ->
+      | "--name"; w = SYMBOL ; mv = UPSYMBOL ; x = OPT [ y = SYMBOL -> y ]; "." ->
         [Sgn.Pragma (_loc, Sgn.NamePrag (Id.mk_name (Id.SomeString w), mv, x))]
 
       |
@@ -357,7 +357,7 @@ GLOBAL: sgn;
             [Sgn.Rec (_loc, f)]
 
       |
-        "%infix"; i = SYMBOL; p = INTLIT; assoc = OPT[x = SYMBOL -> x]; "."->
+        "--infix"; i = SYMBOL; p = INTLIT; assoc = OPT[x = SYMBOL -> x]; "."->
           begin
             match assoc with
             | Some "left" -> [Sgn.Pragma (_loc, Sgn.FixPrag(Id.mk_name (Id.SomeString i), Sgn.Infix, int_of_string p, Some Sgn.Left))]
@@ -370,10 +370,10 @@ GLOBAL: sgn;
         "#postfix"; i = SYMBOL; p = INTLIT; "." ->
           [Sgn.Pragma (_loc, Sgn.FixPrag(Id.mk_name (Id.SomeString i), Sgn.Postfix, int_of_string p, Some Sgn.Left))]
    *)    |
-        "%prefix"; i = SYMBOL; p = INTLIT; "."->
+        "--prefix"; i = SYMBOL; p = INTLIT; "."->
           [Sgn.Pragma (_loc, Sgn.FixPrag(Id.mk_name (Id.SomeString i), Sgn.Prefix, int_of_string p, Some Sgn.Left))]
 
-      | "%assoc"; assoc = SYMBOL; "." ->
+      | "--assoc"; assoc = SYMBOL; "." ->
         begin match assoc with
         | "left" -> [Sgn.Pragma(_loc, Sgn.DefaultAssocPrag Sgn.Left)]
         | "right" -> [Sgn.Pragma(_loc, Sgn.DefaultAssocPrag Sgn.Right)]
@@ -387,12 +387,12 @@ GLOBAL: sgn;
         [Sgn.Val (_loc, Id.mk_name (Id.SomeString "it"), None, i)]
 
       |
-        "%open"; n = [n = UPSYMBOL_LIST -> n | n = UPSYMBOL -> n] ->
+        "--open"; n = [n = UPSYMBOL_LIST -> n | n = UPSYMBOL -> n] ->
           let (l,last) = split '.' n in
           [Sgn.Pragma(_loc, Sgn.OpenPrag(l@[last]))]
       |
 
-        "%abbrev"; n = [n = UPSYMBOL_LIST -> n | n = UPSYMBOL -> n]; abbrev = UPSYMBOL ->
+        "--abbrev"; n = [n = UPSYMBOL_LIST -> n | n = UPSYMBOL -> n]; abbrev = UPSYMBOL ->
           let (l,last) = split '.' n in
           [Sgn.Pragma(_loc, Sgn.AbbrevPrag(l@[last], abbrev))]
       |
@@ -1072,7 +1072,7 @@ GLOBAL: sgn;
 
   case_pragma:
     [[
-      "%not" -> Pragma.PragmaNotCase
+      "--not" -> Pragma.PragmaNotCase
     | -> Pragma.RegularCase
     ]];
 

--- a/src/core/pretty.ml
+++ b/src/core/pretty.ml
@@ -1211,7 +1211,7 @@ module Int = struct
             fprintf ppf "@ %s@[<v>case @[%a@] of%s%a@]@,%s"
               (l_paren_if cond)
               (fmt_ppr_cmp_exp_syn cD cG 0) (strip_mapp_args cD cG i)
-              (match prag with Pragma.RegularCase -> " " | Pragma.PragmaNotCase -> " %not ")
+              (match prag with Pragma.RegularCase -> " " | Pragma.PragmaNotCase -> " --not ")
               (fmt_ppr_cmp_branches cD cG 0) bs
               (r_paren_if cond)
 
@@ -1222,7 +1222,7 @@ module Int = struct
             fprintf ppf "@ %s@[<v>case @[%a@] of%s%a@]@,%s"
               (l_paren_if cond)
               (fmt_ppr_cmp_exp_syn cD cG 0) (strip_mapp_args cD cG i)
-              (match prag with Pragma.RegularCase -> " " | Pragma.PragmaNotCase -> " %not ")
+              (match prag with Pragma.RegularCase -> " " | Pragma.PragmaNotCase -> " --not ")
               (fmt_ppr_cmp_branches cD cG 0) bs
               (r_paren_if cond)
 
@@ -1610,7 +1610,7 @@ module Int = struct
       | Sgn.Pragma (LF.OpenPrag n) ->
           let n' = Store.Modules.name_of_id n in
           let _ = Store.Modules.open_module n' in
-          fprintf ppf "@\n%%open %s@\n" (String.concat "." n')
+          fprintf ppf "@\n--open %s@\n" (String.concat "." n')
 
       | Sgn.Pragma _ -> ()
 

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -56,7 +56,7 @@ let _ = Error.register_printer
 	  Format.fprintf ppf "Totality declaration for %s takes too many arguments.\n" (Id.render_name f)
 
       	| UnexpectedSucess ->
-      	  Format.fprintf ppf "Unexpected success: expected failure of type reconstruction for %%not'ed declaration."
+      	  Format.fprintf ppf "Unexpected success: expected failure of type reconstruction for --not'ed declaration."
         | IllegalOptsPrag s ->
           Format.fprintf ppf "\"%s\" pragma must appear before any declarations." s
         | IllegalOperatorPrag(n, f, actual) -> begin
@@ -68,9 +68,9 @@ let _ = Error.register_printer
             (actual)
             (expected) end
       | InvalidOpenPrag s ->
-        Format.fprintf ppf "Invalid module in pragma '%%open %s'" s
+        Format.fprintf ppf "Invalid module in pragma '--open %s'" s
       | InvalidAbbrev (l, s) ->
-        Format.fprintf ppf "Invalid module in pragma '%%abbrev %s %s'"
+        Format.fprintf ppf "Invalid module in pragma '--abbrev %s %s'"
       	  (String.concat "." l) s
 				  )
   )
@@ -151,7 +151,7 @@ let recSgnDecls decls =
 	    let _ = recSgnDecl not'd_decl in true
 	  with _ ->
 	    if !Debug.chatter != 0 then
-              print_string ("Reconstruction fails for %not'd declaration\n");
+              print_string ("Reconstruction fails for --not'd declaration\n");
             false
         end in
       if not'd_decl_succeeds
@@ -162,11 +162,11 @@ let recSgnDecls decls =
     | [Ext.Sgn.Pragma(_, Ext.Sgn.NotPrag)] -> []
 
     | Ext.Sgn.GlobalPragma(loc, Ext.Sgn.Coverage `Warn ) :: rest ->
-      raise (Error (loc, IllegalOptsPrag "%warncoverage"))
+      raise (Error (loc, IllegalOptsPrag "--warncoverage"))
     | Ext.Sgn.GlobalPragma(loc, Ext.Sgn.Coverage `Error ) :: rest ->
-      raise (Error (loc, IllegalOptsPrag "%coverage"))
+      raise (Error (loc, IllegalOptsPrag "--coverage"))
     | Ext.Sgn.GlobalPragma(loc, Ext.Sgn.NoStrengthen) :: rest ->
-      raise (Error (loc, IllegalOptsPrag "%nostrengthen"))
+      raise (Error (loc, IllegalOptsPrag "--nostrengthen"))
 
     | decl :: rest ->
       let decl' = recSgnDecl decl in

--- a/t/error/appchkmismatch.bel
+++ b/t/error/appchkmismatch.bel
@@ -2,25 +2,25 @@ LF tp: type =
 | unit: tp
 | cross: tp -> tp -> tp
 ;
-%name tp T.
+--name tp T.
 
 LF term: tp -> type =
 ;
-%name term M.
+--name term M.
 
 % Target language
 LF target: tp -> type =
 | tunit: target unit
 | tpair: target T -> target S -> target (cross T S)
 ;
-%name target Q.
+--name target Q.
 
 % Natural Numbers
 LF nat: type =
 | z: nat
 | suc: nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 
 % List of free variables occurring in a term
@@ -28,7 +28,7 @@ LF fvlist: tp -> type =
 | nil: fvlist unit
 | cons: term T -> fvlist S -> fvlist (cross T S)
 ;
-%name fvlist F.
+--name fvlist F.
 
 % ----------------------------------------------------------------------
 

--- a/t/error/assoc_prag.bel
+++ b/t/error/assoc_prag.bel
@@ -6,16 +6,16 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2.
+app : tm -> tm -> tm.           --infix app 2.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 1.
+step: tm -> tm -> type.         --infix step 1.
 
-%assoc invalid.
+--assoc invalid.
 
 s_app1 : (E1 step E1') -> 
          (E1 app E2) step (E1' app E2). 
@@ -33,12 +33,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/error/brokencconv.bel
+++ b/t/error/brokencconv.bel
@@ -7,7 +7,7 @@ LF tp: type =
 | cross: tp -> tp -> tp
 | unit :tp
 ;
-%name tp T.
+--name tp T.
 
 
 % Target language
@@ -29,14 +29,14 @@ LF target: tp -> type =
 | tz: target int
 | tsuc: target int -> target int
 ;
-%name target Q.
+--name target Q.
 
 % Natural Numbers
 LF nat: type =
 | z:nat
 | suc: nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 %{
 %  member N R P is true iff

--- a/t/error/coverage/c-empty.bel
+++ b/t/error/coverage/c-empty.bel
@@ -2,7 +2,7 @@
 %
 %   a trivial example of an empty (or "absurd") case
 
-%coverage
+--coverage
 constructorless : type.
 
 nat : type.

--- a/t/error/coverage/cov-unsound.bel
+++ b/t/error/coverage/cov-unsound.bel
@@ -1,5 +1,5 @@
 % PRAGMA FOR COVERAGE CHECKING
-%coverage
+--coverage
 target:type.
 z: target.
 tlam: (target → target) → target.

--- a/t/error/coverage/match-param.bel
+++ b/t/error/coverage/match-param.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 elam:(term -> term) -> term.

--- a/t/error/coverage/match-param2.bel
+++ b/t/error/coverage/match-param2.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/error/coverage/small-step.bel
+++ b/t/error/coverage/small-step.bel
@@ -381,7 +381,7 @@ fn ms => case ms of
 
 rec terminate : {M:[ |- term]} [ |- steps_to_val M] =
 / total m (terminate m)/
-mlam M => case [ |- M] of %not
+mlam M => case [ |- M] of --not
 | [ |- true] =>
    [ |- result ms_ref v_true]
 
@@ -389,7 +389,7 @@ mlam M => case [ |- M] of %not
     [ |- result ms_ref v_false]
 
 | [ |- switch T T1 T2] =>
-  (case terminate [ |- T ] of %not
+  (case terminate [ |- T ] of --not
    | [ |- result MS v_true] =>
        let [ |- result MS1 V1] = terminate [ |- T1 ] in
        let [ |- MS']           = mstep_switch [ |- T1 ] [ |- T2 ] [ |- MS] in

--- a/t/error/coverage/systemf.bel
+++ b/t/error/coverage/systemf.bel
@@ -4,14 +4,14 @@
 LF ty_f: type =
    | arr : ty_f -> ty_f -> ty_f
    | all : (ty_f -> ty_f) -> ty_f;
-%name ty_f A.
+--name ty_f A.
 
 LF tm_f: type =
    | app : tm_f -> tm_f -> tm_f
    | lam : ty_f -> (tm_f -> tm_f) -> tm_f
    | tapp: tm_f -> ty_f -> tm_f
    | tlam: (ty_f -> tm_f) -> tm_f;
-%name tm_f M.
+--name tm_f M.
 
 LF hastype: tm_f -> ty_f -> type =
    | f_app : hastype M (arr A B) -> hastype N A

--- a/t/error/coverage/unsound-param.bel
+++ b/t/error/coverage/unsound-param.bel
@@ -1,4 +1,4 @@
-%coverage
+--coverage
 term : type.
 foo : term.
 

--- a/t/error/ctx-match-param.bel
+++ b/t/error/ctx-match-param.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/error/defaultAssocError.bel
+++ b/t/error/defaultAssocError.bel
@@ -11,8 +11,8 @@ nil : list z.
 @ : bool -> list N -> list (s N).
 
 
-%assoc left.
-%infix @ 5.
+--assoc left.
+--infix @ 5.
 
 let l1 = [ |- t @ t @ t @ nil];
 

--- a/t/error/infix/infix_assoc.bel
+++ b/t/error/infix/infix_assoc.bel
@@ -11,6 +11,6 @@ LF list : nat -> type =
 | @ : bool -> list N -> list (s N);
 
 % This would work if it was right associative
-%infix @ 1 left.
+--infix @ 1 left.
 
 let test = [ |- f @ f @ f @ nil];

--- a/t/error/infix/infix_misplaced_op.bel
+++ b/t/error/infix/infix_misplaced_op.bel
@@ -6,14 +6,14 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2 left.
+app : tm -> tm -> tm.           --infix app 2 left.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 1 left.
+step: tm -> tm -> type.         --infix step 1 left.
 
 s_app1 : (E1 step E1') -> 
          (E1 app E2) step (app E1' E2). 
@@ -29,12 +29,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/error/infix/infix_misplaced_op2.bel
+++ b/t/error/infix/infix_misplaced_op2.bel
@@ -6,14 +6,14 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2 left.
+app : tm -> tm -> tm.           --infix app 2 left.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 1 left.
+step: tm -> tm -> type.         --infix step 1 left.
 
 s_app1 : (E1 step E1') -> 
          (E1 app E2) step (E1' app E2). 
@@ -29,12 +29,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/error/infix/infix_precedence.bel
+++ b/t/error/infix/infix_precedence.bel
@@ -6,14 +6,14 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2 left.
+app : tm -> tm -> tm.           --infix app 2 left.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 3 left.
+step: tm -> tm -> type.         --infix step 3 left.
 
 s_app1 : (E1 step E1') -> 
          (E1 app E2) step (E1' app E2). 
@@ -30,12 +30,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/error/infix/same_precedence_invalid.bel
+++ b/t/error/infix/same_precedence_invalid.bel
@@ -1,9 +1,9 @@
 nat : type.
 z : nat.
-s : nat -> nat. %prefix s 5.
+s : nat -> nat. --prefix s 5.
 
 t : type.
-test : nat -> nat -> t. %infix test 5.
+test : nat -> nat -> t. --infix test 5.
 
 
 rec test_fun : [ |- nat ] -> [ |- t] =

--- a/t/error/misnamedctxvarproj.bel
+++ b/t/error/misnamedctxvarproj.bel
@@ -1,11 +1,11 @@
 % Equality lemmas
 % Author: Andrew Cave
 
-exp : type. %name exp M.
+exp : type. --name exp M.
 app : exp -> exp -> exp.
 lam : (exp -> exp) -> exp.
 
-eq : exp -> exp -> type. %name eq D.
+eq : exp -> exp -> type. --name eq D.
 eq_lam : ({x:exp} eq x x -> eq (M x) (N x)) -> eq (lam M) (lam N).
 eq_app : eq M M' -> eq N N' -> eq (app M N) (app M' N').
 

--- a/t/error/misnamedproj.bel
+++ b/t/error/misnamedproj.bel
@@ -1,11 +1,11 @@
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/t/error/modules/invalid_abbrev.bel
+++ b/t/error/modules/invalid_abbrev.bel
@@ -10,7 +10,7 @@ module Nats = struct
   let three = suc two;
 end;
 
-%abbrev UnboundModule U
+--abbrev UnboundModule U
 
 
 

--- a/t/error/modules/invalid_abbrev.bel.out
+++ b/t/error/modules/invalid_abbrev.bel.out
@@ -1,1 +1,1 @@
-Invalid module in pragma '%abbrev UnboundModule U'
+Invalid module in pragma '--abbrev UnboundModule U'

--- a/t/error/modules/invalid_call.bel
+++ b/t/error/modules/invalid_call.bel
@@ -11,7 +11,7 @@ module Arith = struct
 	  let three = suc two;
 	end;
 
-	%open Nats
+	--open Nats
 
 	rec add : [ |- nat ] -> [ |- nat ] -> [ |- nat ] =
 	fn x, y => case x of

--- a/t/error/modules/wrong_open.bel
+++ b/t/error/modules/wrong_open.bel
@@ -25,7 +25,7 @@ cons : Nats.nat -> list N -> list (Nats.s N).
 let l1 = [ |- cons Nats.z (cons (Nats.s Nats.z) nil)];
 
 module Arith = struct
-	%open WrongModule
+	--open WrongModule
 
 	rec add : [ |- nat ] -> [ |- nat ] -> [ |- nat ] =
 	fn x, y => case x of

--- a/t/error/modules/wrong_open.bel.out
+++ b/t/error/modules/wrong_open.bel.out
@@ -1,1 +1,1 @@
-Invalid module in pragma '%open WrongModule'
+Invalid module in pragma '--open WrongModule'

--- a/t/error/nostrengthen.bel
+++ b/t/error/nostrengthen.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 
 i : type.
 o : type.
@@ -11,7 +11,7 @@ true   : o.
 forall : (i -> o) -> o.
 
 pf : o -> type.  % natural deductions
-%name pf D. % E
+--name pf D. % E
 
 andel   : pf (& A B) -> pf A.
 

--- a/t/error/param.bel
+++ b/t/error/param.bel
@@ -1,4 +1,4 @@
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
@@ -6,7 +6,7 @@ nat: type.
 z: nat. 
 s: nat -> nat.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 elem: tm.
 
 oft : tm -> tp -> type.

--- a/t/error/recon-simple.bel
+++ b/t/error/recon-simple.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/error/recon.bel
+++ b/t/error/recon.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/error/schema_check/bred-nf.bel
+++ b/t/error/schema_check/bred-nf.bel
@@ -9,20 +9,20 @@ LF tm: type =
 | app: tm -> tm -> tm
 | beta: (tm -> tm) -> tm -> tm
 ;
-%name tm M.
+--name tm M.
 
 LF nf: type =
 | nabs: (nf -> nf) -> nf
 | napp: nf -> nf -> nf
 ;
-%name nf U.
+--name nf U.
 
 LF p : type =
 | left : p -> p
 | right: p -> p
 | bnd  : (p -> p) -> p
 ;
-%name p P.
+--name p P.
 
 LF bred : tm -> nf -> type =
 | r_abs : ({x:tm}{y:nf}  bred x y -> bred (M x) (N y))
@@ -32,7 +32,7 @@ LF bred : tm -> nf -> type =
 | r_beta: ({x:tm} ({u:nf} bred N u -> bred x u) -> bred (R x) V)
       -> bred (beta R N) V
 ;
-%name bred R.
+--name bred R.
 
 LF path : tm -> p -> type =
 | p_abs   : ({x:tm}{p:p} path x p -> path (M x) (P p))
@@ -45,7 +45,7 @@ LF path : tm -> p -> type =
            -> path (beta R N) P
 ;
 
-%name path Pf.
+--name path Pf.
 
 LF npath : nf -> p -> type =
 | np_abs   : ({x:nf}{p:p} npath x p -> npath (M x) (P p))
@@ -56,7 +56,7 @@ LF npath : nf -> p -> type =
          -> npath (napp M N) (right P)
 
 ;
-%name path Qf.
+--name path Qf.
 
 schema tctx = tm ;
 

--- a/t/error/stratify/s1.bel
+++ b/t/error/stratify/s1.bel
@@ -1,7 +1,7 @@
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 
-neut : tp -> type.       %name neut R.
+neut : tp -> type.       --name neut R.
 
 schema ctx = neut T;
 

--- a/t/error/subst-vars-simple.bel
+++ b/t/error/subst-vars-simple.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/error/subst-vars-simple1.bel
+++ b/t/error/subst-vars-simple1.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/error/total/param4.bel
+++ b/t/error/total/param4.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/error/total/wf-wrongarg.bel
+++ b/t/error/total/wf-wrongarg.bel
@@ -4,7 +4,7 @@ LF nat : type =
 | z : nat
 | s : nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 % The sub-term relation on naturals
 

--- a/t/error/total/wf-wrongarg2.bel
+++ b/t/error/total/wf-wrongarg2.bel
@@ -4,7 +4,7 @@ LF nat : type =
 | z : nat
 | s : nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 % The sub-term relation on naturals
 

--- a/t/error/total/wf.bel
+++ b/t/error/total/wf.bel
@@ -4,7 +4,7 @@ LF nat : type =
 | z : nat
 | s : nat -> nat
 ;
-%name nat N.
+--name nat N.
 % The sub-term relation on naturals
 
 LF le : nat -> nat -> type =

--- a/t/error/trec.bel
+++ b/t/error/trec.bel
@@ -1,10 +1,10 @@
 
-tp: type.  %name tp T a.
+tp: type.  --name tp T a.
 nat: tp.
 all: (tp -> tp) -> tp.
 arr: tp -> tp -> tp.
 
-exp: tp -> type.  %name exp E x.
+exp: tp -> type.  --name exp E x.
 z: exp nat.
 s: exp nat -> exp nat.
 tlam: ({a:tp}exp (T a)) -> exp (all (\a. T a)).

--- a/t/success/LFHoles/cntvar-explicit.bel
+++ b/t/success/LFHoles/cntvar-explicit.bel
@@ -3,11 +3,11 @@
 %
 % This example only uses weak higher-order abstract syntax.
 
-tp  : type.   %name tp T.
+tp  : type.   --name tp T.
 nat : tp.
 bool: tp.
 
-exp : tp -> type.  %name exp E.
+exp : tp -> type.  --name exp E.
 z   : exp nat.
 s   : exp nat -> exp nat.
 

--- a/t/success/LFHoles/cps-popl-tutorial1-crec.bel
+++ b/t/success/LFHoles/cps-popl-tutorial1-crec.bel
@@ -3,12 +3,12 @@
 % Adapted from Twelf's POPL tutorial
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).
@@ -147,5 +147,5 @@ cpse/ret : cpse (ret (V:value A)) ([c:ccont A] cthrow c V')
 
 % block cpsb : some {A : tp} block {x : value A} {x' : cvalue A} {d : cps x x'}.
 % worlds (cpsb) (cps _ _) (cpse _ _).
-%total (E V) (cps E _) (cpse V _).
+--total (E V) (cps E _) (cpse V _).
 }%

--- a/t/success/LFHoles/debruijn.bel
+++ b/t/success/LFHoles/debruijn.bel
@@ -5,13 +5,13 @@ z: nat.
 s: nat -> nat.
 
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/t/success/LFHoles/jpath.bel
+++ b/t/success/LFHoles/jpath.bel
@@ -2,18 +2,18 @@
 % definition.
 % Authors: Andrew Cave, Brigitte Pientka
 
-tm: type. %name tm T.
+tm: type. --name tm T.
 lam: (tm -> tm) -> tm.
 app: tm -> tm -> tm.
 rdx : (tm -> tm) -> tm -> tm.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> tm -> type. %name is_path I.
+is_path: path -> tm -> type. --name is_path I.
 
 p_lam: is_path (bind P) (lam E)
        <- ({x:tm}{q:path}is_path q x -> is_path (P q) (E x)).

--- a/t/success/LFHoles/pearl-lfhole.bel
+++ b/t/success/LFHoles/pearl-lfhole.bel
@@ -16,7 +16,7 @@
 % --------------------------------------------------------------------------
 % Definition of types
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 top   : tp.
 arr   : tp -> tp -> tp.			% Functions: A1 => A2
@@ -73,7 +73,7 @@ schema as_ctx =  some [u:tp]  block a:tp, w: subtype a U;
 % ------------------------------------------------------------------
 %   G |- (forall a < S1. S2)  < (forall a < T1. T2)
 
-sub : tp -> tp -> type.                %name sub S.
+sub : tp -> tp -> type.                --name sub S.
 
 
 sa_top : sub S top.

--- a/t/success/LFHoles/tpcert.bel
+++ b/t/success/LFHoles/tpcert.bel
@@ -1,10 +1,10 @@
-%nostrengthen
-tp   : type.  %name tp T.
+--nostrengthen
+tp   : type.  --name tp T.
 nat  : tp.
 bool : tp.
 arr  : tp -> tp -> tp.
 
-term : type.  %name term M.
+term : type.  --name term M.
 z    : term.
 tt   : term.
 ff   : term.
@@ -13,7 +13,7 @@ letv : term -> (term -> term) -> term.
 lam  : tp -> (term -> term) -> term.
 app  : term -> term -> term.
 
-oft  : term -> tp -> type.  %name oft D.
+oft  : term -> tp -> type.  --name oft D.
 o_tt : oft tt bool.
 o_ff : oft ff bool.
 o_z  : oft z nat.

--- a/t/success/LFHoles/tps.bel
+++ b/t/success/LFHoles/tps.bel
@@ -2,11 +2,11 @@
 % Author: Brigitte Pientka
 %
 
-tp   : type.   %name tp T.
+tp   : type.   --name tp T.
 nat  : tp.
 arrow  : tp -> tp -> tp.
 
-exp  : type.   %name exp E x.
+exp  : type.   --name exp E x.
 z    : exp.
 suc  : exp -> exp.
 match: exp -> exp -> (exp -> exp) -> exp.
@@ -17,7 +17,7 @@ app  : exp -> exp -> exp.
 
 
 % Evaluation
-eval : exp -> exp -> type.  %name eval F.
+eval : exp -> exp -> type.  --name eval F.
 ev_z : eval z z.
 
 ev_s : eval E V -> eval (suc E) (suc V).
@@ -40,7 +40,7 @@ ev_app: eval E1 (lam T (\x. E x)) -> eval E2 V2 -> eval (E V2) V
 
 % Typing
 
-oft : exp -> tp -> type.  %name oft D u.
+oft : exp -> tp -> type.  --name oft D u.
 
 tp_z     : oft z nat.
 tp_s     : oft E nat ->
@@ -64,12 +64,12 @@ tp_letv : ({x:exp} oft x T1 -> oft (E2 x) T2) ->
 
 % Gives type-checking error, 'Substitution not well-typed'
 
-%query 1 *  D : oft (suc (suc z)) T.
-%query 1 * D : oft (lam T (\x.x)) S.
-%query 1 *  D : oft (letv (suc (suc z)) (\x. app (lam nat (\y.y)) x) ) T.
-%query 1 * D : oft (lam T (\x.x)) S.
+--query 1 *  D : oft (suc (suc z)) T.
+--query 1 * D : oft (lam T (\x.x)) S.
+--query 1 *  D : oft (letv (suc (suc z)) (\x. app (lam nat (\y.y)) x) ) T.
+--query 1 * D : oft (lam T (\x.x)) S.
 
-%query * 5 P : oft X nat -> oft (suc X) nat.
+--query * 5 P : oft X nat -> oft (suc X) nat.
 
 % Type preservation proof
 rec tps :  [ |- eval E V] -> [ |- oft E T]

--- a/t/success/base/alpha.bel
+++ b/t/success/base/alpha.bel
@@ -11,7 +11,7 @@ schema tps = tp;
 schema tpblock = block t:tp, _t:tp;
 
 %{
-%not
+--not
 rec ffff3 : {h:(tps)*} tp[h] -> tp[h] =
   FN h => fn eTp =>
     case eTp of [h] #pp.1[..] => [h] #pp.1[..]       % Fails: tps doesn't include any Sigmas
@@ -24,7 +24,7 @@ rec ffff4 : {g:(wblock)*} {h:(tps)*} nat[g] -> nat[g] =
 ;
 }%
 
-%not
+--not
 rec ffff3 : {h:tps} [h |- tp] -> [h |- tp] =
 % / total e (ffff3 h e)/
   mlam h => fn eTp =>
@@ -34,7 +34,7 @@ rec ffff3 : {h:tps} [h |- tp] -> [h |- tp] =
 rec ffff4 : {g:wblock} {h:tps} [g |- nat] -> [g |- nat] =
 % / total e (ffff4 h e)/
   mlam g => mlam h => fn eNat =>
-    case eNat of %not
+    case eNat of --not
 %    | [g] #pppppp.1[..] => [g] z
     | [g |- #pp.1[..]] => [g |- z]        % works if pp is renamed to something else!
 ;

--- a/t/success/base/backarrow.bel
+++ b/t/success/base/backarrow.bel
@@ -8,7 +8,7 @@ lam  : (exp -> exp) -> exp.
 app  : exp -> exp -> exp.
 
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 nat   : tp.				% Natural Numbers
 cross : tp -> tp -> tp.			% Pairs
@@ -34,7 +34,7 @@ ev_app : eval (app E1 E2) V
 	  <- eval E2 V2
 	  <- eval (E1' V2) V.
 
-has_type : exp -> tp -> type.  %name has_type P u.
+has_type : exp -> tp -> type.  --name has_type P u.
 
 % Natural Numbers
 tp_z     : has_type z nat.

--- a/t/success/base/c-cut-elim.bel
+++ b/t/success/base/c-cut-elim.bel
@@ -1,7 +1,7 @@
 i : type.
-%name i S.
+--name i S.
 o : type.
-%name o A.
+--name o A.
 
 imp    : o -> o -> o.
 % not    : o -> o.

--- a/t/success/base/c-unique.bel
+++ b/t/success/base/c-unique.bel
@@ -1,14 +1,14 @@
 % Definition of types and expressions
-tp: type.  %name tp T.
+tp: type.  --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 lam : tp -> (exp -> exp) -> exp.
 app : exp -> exp -> exp.
 
 % Typing judgment
-type_of: exp -> tp -> type. %name type_of H.
+type_of: exp -> tp -> type. --name type_of H.
 
 t_lam: ({x:exp}type_of x T1 -> type_of (E x) T2)
         -> type_of (lam T1 E) (arr T1 T2).

--- a/t/success/base/c2.bel
+++ b/t/success/base/c2.bel
@@ -7,7 +7,7 @@ schema termCtx = some [] term;
 rec copyBad : {g:termCtx} [g |- term] -> [g |- term] =
 / total e (copyBad g e)/
 mlam g => fn e =>
- (case e of %not
+ (case e of --not
   | [g |- z]     => [g |- z]
 );
 
@@ -22,7 +22,7 @@ mlam g => fn e =>
 rec copyXBad1 : {g:termCtx} [g, x:term |-  term] -> [g, x:term |-  term] =
 / total e (copyXBad1 g e)/
 mlam g => fn e =>
- (case e of %not
+ (case e of --not
   | [g,x:term |-  z]     => [g,x:term |-  z]
   | [g,x:term |-  x]     => [g,x:term |-  x]
 );
@@ -30,7 +30,7 @@ mlam g => fn e =>
 rec copyXBad2 : {g:termCtx} [g, x:term |-  term] -> [g, x:term |-  term] =
 / total e (copyXBad2 g e)/
 mlam g => fn e =>
- case e of %not
+ case e of --not
  | [g,x:term |-  z]     => [g,x:term |-  z]
  | [g,x:term |-  #p[..]] => [g,x:term |-  #p[..]]
 ;

--- a/t/success/base/c3x1.bel
+++ b/t/success/base/c3x1.bel
@@ -5,7 +5,7 @@ suc  : term -> term.
 schema termCtx = some [] term;
 
 rec copy : [ |- term] -> [ |- term] = fn e =>
-  case e of %not
+  case e of --not
   | [ |- z]     => [ |- z]
 %  | [] suc U => let [] V = copy ([] U) in [] suc V
 ;

--- a/t/success/base/c3x2.bel
+++ b/t/success/base/c3x2.bel
@@ -6,7 +6,7 @@ schema termCtx = some [] term;
 
 
 rec copy : [ |- term] -> [ |- term] = fn e =>
-  case e of %not
+  case e of --not
 %  | []  z     => [] z
   | [ |- suc U] => let [ |- V] = copy [ |- U] in [ |- suc V]
 ;

--- a/t/success/base/c5x1.bel
+++ b/t/success/base/c5x1.bel
@@ -6,7 +6,7 @@ fiver  : term -> term -> term -> term -> term
 schema termCtx = some [] term;
 
 rec fff : [ |- term] -> [ |- term] = fn e =>
-  case e of %not
+  case e of --not
 %  | [] z         => [] z
   | [ |- fiver U V W X Y] => [ |- z]
 ;

--- a/t/success/base/c5x2.bel
+++ b/t/success/base/c5x2.bel
@@ -6,7 +6,7 @@ fiver  : term -> term -> term -> term -> term
 schema termCtx = some [] term;
 
 rec fff : [ |- term] -> [ |- term] = fn e =>
-  case e of %not
+  case e of --not
   | [ |- z]         => [ |- z]
 %  | [] fiver U V W X Y => [] z
 ;

--- a/t/success/base/c5x3.bel
+++ b/t/success/base/c5x3.bel
@@ -6,7 +6,7 @@ fiver  : term -> term -> term -> term -> term
 schema termCtx = some [] term;
 
 rec fff : [ |- term] -> [ |- term] = fn e =>
-  case e of %not
+  case e of --not
   | [ |- z]         => [ |- z]
   | [ |- fiver U V z X Y] => [ |- z]
 ;

--- a/t/success/base/case1-explicit.bel
+++ b/t/success/base/case1-explicit.bel
@@ -11,7 +11,7 @@ rec copynat1 : {g:w} [g |- nat] -> [g |- nat] =
 rec copynat : {g:w} [g |- nat] -> [g |- nat] =
 mlam g =>
  fn e =>
-  case e of %not
+  case e of --not
     [g |- z] : [g |- nat] => [g |- z]
   | {U : [g |- nat]} [g |- suc (U[..])]   : [g |- nat] => copynat [g] [g |- (U[..])]
 ;

--- a/t/success/base/case2-explicit.bel
+++ b/t/success/base/case2-explicit.bel
@@ -9,7 +9,7 @@ schema w = nat;
 
 rec copynat : {g:w} [g |- nat] -> [g |- nat] =
 mlam g => fn e =>
- case e of %not
+ case e of --not
     [g |- z] : [g |- nat] => [g |- z]
   | {U:[g |- nat]}
      [g |- suc (U[..])] : [g |- nat] => copynat [g] [g |- (U[..])]

--- a/t/success/base/case2.bel
+++ b/t/success/base/case2.bel
@@ -9,7 +9,7 @@ schema w = some [ ] nat;
 
 rec copynat : {g:w} [g |- nat] -> [g |- nat] =
    mlam g => fn e =>
-     case e of %not
+     case e of --not
        [g |- z] => [g |- z]
      | [g |- suc (U[..])] => copynat [g] [g |- (U[..])]
 ;

--- a/t/success/base/cc1.bel
+++ b/t/success/base/cc1.bel
@@ -19,7 +19,7 @@ mlam g => fn e =>
 
 rec fffForgotConcreteVarCase : {g:termCtx} [g, x:term |-  term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, x:term |-  z]     => [g |- z]
   | [g, x:term |-  suc (U)]   => [g |- z]
   | [g, x:term |-  #p[..]]   => [g |- z]
@@ -51,21 +51,21 @@ mlam g => fn e =>
 
 rec fffEmptyMVar : {g:termCtx} [g, x:term |-  term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, x:term |-  U] => [g |- z]
 ;
 
 
 rec fffConcreteOmittedFromMVar : {g:termCtx} [g, x:term |-  term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, x:term |-  U[..]] => [g |- z]
 ;
 
 
 rec fffSplitCasesBad : {g:termCtx} [g, x:term |-  term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, x:term |-  U[..]]   => [g |- z]
   | [g, x:term |-  x]      => [g |- z]
   % Doesn't cover suc (suc x)
@@ -82,7 +82,7 @@ mlam g => fn e =>
 
 rec fffForgotParamVarCase : {g:termCtx} [g |- term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
 
   | [g |- suc (U[..])]   => [g |- z]

--- a/t/success/base/ccdep.bel
+++ b/t/success/base/ccdep.bel
@@ -44,21 +44,21 @@ fn d => case d of
 ;
 
 rec depsplitWrong : {g:dep-ctx} (dep (B[..]))[g]  ->  bool[ ] =
-fn d => case d of  %not
+fn d => case d of  --not
  | [h, x:dep tt] U[..] => [] tt
 ;
 }%
 
 
 rec depsplitWrong1asdfasdfadsf : {g:dep-ctx} [g, x : dep T |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep ff |-  UU] => [ |- ff]
 ;
 
 
 
 rec depsplitWrong1 : {g:dep-ctx} [g, x : dep T |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep ff |-  UU] => [ |- ff]
 % | [g, xx:dep tt] VVx => [] tt
 %   msub': has the `ff' in `xx:dep ff'
@@ -133,12 +133,12 @@ mlam g => fn d => case d of
 
 
 rec depsplitTwoWrong1 : {g:dep-ctx} [g, x : dep TX, y : dep TY |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep XX1, yy:dep ff |-  UU] => [ |- ff]
 ;
 
 rec depsplitTwoWrong2 : {g:dep-ctx} [g, x : dep TX, y : dep TY |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep tt, yy:dep YY2 |-  UU] => [ |- ff]
 ;
 

--- a/t/success/base/ccdep2.bel
+++ b/t/success/base/ccdep2.bel
@@ -30,12 +30,12 @@ schema bool-ctx = bool;
 
 
 rec depsplitWrong1 : {g:dep-ctx} [g, x : dep T1 T2 |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep ff ff |-  UUx] => [ |- ff]
 ;
 
 rec depsplitWrong2 : {g:dep-ctx} [g, x : dep T1 T2 |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep ff ff |-  UU1x] => [ |- ff]
  | [g, xx:dep ff tt |-  UU2x] => [ |- ff]
 ;
@@ -50,7 +50,7 @@ mlam g => fn d => case d of
 ;
 
 rec depsplitWrong3 : {g:dep-ctx} [g, x : dep T1 T2 |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep tt ff |-  UU1x] => [ |- ff]
  | [g, xx:dep ff tt |-  UU2x] => [ |- ff]
 % | [g, xx:dep tt tt] UU3x => [] ff
@@ -65,7 +65,7 @@ mlam g => fn d => case d of
 ;
 
 rec depsplitWrongConstrained2 : {g:dep-ctx} [g, x : dep tt T2 |-  bool]  ->  [ |- bool] =
-mlam g => fn d => case d of %not
+mlam g => fn d => case d of --not
  | [g, xx:dep tt ff |-  UU1x] => [ |- ff]
 ;
 

--- a/t/success/base/ccm.bel
+++ b/t/success/base/ccm.bel
@@ -5,7 +5,7 @@ nat: type.
 z: nat.
 s: nat -> nat.
 
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 arr : tp -> tp -> tp.
 card : nat -> tp.
 
@@ -41,7 +41,7 @@ rec length : {g:nat-ctx} [ |- nat] = mlam g => length' [g] [g |- z]
 
 
 rec length'2 : {g:nat-ctx} [g |- nat]  -> [ |- nat] =
-mlam g => fn v => case v of %not
+mlam g => fn v => case v of --not
  | [h,x:nat |-  U] => let [ |- N] = length'2 [h] [h |- z] in [ |- s N]
 ;
 
@@ -59,7 +59,7 @@ fn v => case v of
 
 
 rec aaa1Wrong : (g:natORtp-ctx) [g |- tp]  -> [ |- nat] =
-fn v => case v of %not
+fn v => case v of --not
  | [h,x:tp |-  x] => [ |- z]
  | [h1,y:tp,x:tp |-  y]  =>  [ |- z]
  | [h,y:tp,x:tp |-  #p[..]]  =>  [ |- z]
@@ -69,7 +69,7 @@ fn v => case v of %not
 
 
 rec aaa1Wrong2 : (g:natORtp-ctx) [g |- tp]  -> [ |- nat] =
-fn v => case v of  %not
+fn v => case v of  --not
  | [h,x:tp |-  x] => [ |- z]
  | [h,x:tp |-  #p[..]]  =>  [ |- z]
  | [h,n:nat |-  #p[..]]  =>  [ |- z]
@@ -91,7 +91,7 @@ fn v => case v of
 
 
 rec fff2Wrong : (g:tp-ctx) [g |- tp]  -> [ |- nat] =
-fn v => case v of %not
+fn v => case v of --not
  | [h,x:tp |-  x] => [ |- z]
  | [h,y:tp,x:tp |-  y]  =>  [ |- z]
  | [h,q1:tp,y:tp,x:tp |-  #p[..]]  =>  [ |- z]  % misses q1

--- a/t/success/base/ccunify.bel
+++ b/t/success/base/ccunify.bel
@@ -7,6 +7,6 @@ schema termCtx = some [] term;
 
 rec fffConcreteOmittedFromMVar : {g:termCtx} [g, x:term |-  term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, x:term |-  V[..]] => [g |- z]
 ;

--- a/t/success/base/cd1.bel
+++ b/t/success/base/cd1.bel
@@ -20,7 +20,7 @@ rec nillist : [ |- list z] -> [ |- nat] = fn e =>
 
 
 % following rejected by reconstruction, doesn't reach coverage
-%not
+--not
 rec nillistBad : [ |- list z] -> [ |- nat] = fn e =>
   case e of
   | [ |- cons U]        => [ |- z]

--- a/t/success/base/cd2.bel
+++ b/t/success/base/cd2.bel
@@ -13,7 +13,7 @@ rec conslist : {G':[ |- nat]} [ |- list (suc G')] -> [ |- nat] = mlam G => fn e 
 ;
 
 rec conslist2 : {G':[ |- nat]} [ |- list (suc G')] -> [ |- nat] = mlam G => fn e =>
-  case e of %not
+  case e of --not
   | [ |- cons (cons (cons T))]          => [ |- z]
 ;
 
@@ -27,7 +27,7 @@ rec conslist3 : [ |- list (suc G')] -> [ |- nat] = fn e =>
 
 % let blah = conslist2 <. z> ([] cons nil);
 
-%not
+--not
 rec badlist : {G':[ |- nat]} [ |- list (suc G')] -> [ |- nat] = mlam G => fn e =>
   case e of
   | [ |- nil]          => [ |- z]

--- a/t/success/base/cp.bel
+++ b/t/success/base/cp.bel
@@ -20,7 +20,7 @@ mlam g => fn e =>
 
 rec fffForgotParamVarCase : {g:termCtx} [g |- term] -> [g |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
 
   | [g |- suc (U[..])]   => [g |- z]

--- a/t/success/base/cp2.bel
+++ b/t/success/base/cp2.bel
@@ -22,7 +22,7 @@ mlam g => fn e =>
 
 rec fffForgotParamVarCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
 
   | [g |- suc (U[..])]   => [g |- z]

--- a/t/success/base/cross.bel
+++ b/t/success/base/cross.bel
@@ -8,7 +8,7 @@ lam  : (exp -> exp) -> exp.
 app  : exp -> exp -> exp.
 
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 nat   : tp.                             % Natural Numbers
 cross : tp -> tp -> tp.                 % Pairs

--- a/t/success/base/cs.bel
+++ b/t/success/base/cs.bel
@@ -23,7 +23,7 @@ mlam g => fn e =>
 
 rec fffRedundantWrongProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.2[..]]   => [g |- z]
@@ -34,7 +34,7 @@ mlam g => fn e =>
 
 rec fffRedundantWrongProjCases' : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- #p.1[..]]   => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
@@ -46,7 +46,7 @@ mlam g => fn e =>
 
 rec fffForgotBothProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
 ;
@@ -54,7 +54,7 @@ mlam g => fn e =>
 
 rec fffForgot1stProjCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.2[..]]   => [g |- z]
@@ -63,7 +63,7 @@ mlam g => fn e =>
 
 rec fffForgot2ndProjCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.1[..]]   => [g |- z]

--- a/t/success/base/cs2.bel
+++ b/t/success/base/cs2.bel
@@ -22,7 +22,7 @@ mlam g => fn e =>
 
 rec fffRedundantWrongProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.2[..]]   => [g |- z]
@@ -34,7 +34,7 @@ mlam g => fn e =>
 
 rec fffRedundantWrongProjCases' : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- #p.1[..]]   => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
@@ -48,7 +48,7 @@ mlam g => fn e =>
 
 rec fffForgotBothProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.2[..]]   => [g |- z]
@@ -57,7 +57,7 @@ mlam g => fn e =>
 
 rec fffForgot1stProjCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.2[..]]   => [g |- z]
@@ -67,7 +67,7 @@ mlam g => fn e =>
 
 rec fffForgot2ndProjCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.1[..]]   => [g |- z]

--- a/t/success/base/cs3.bel
+++ b/t/success/base/cs3.bel
@@ -25,7 +25,7 @@ mlam g => fn e =>
 
 rec fffRedundantWrongProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.1[..]]   => [g |- z]
@@ -36,7 +36,7 @@ mlam g => fn e =>
 
 rec fffForgotBothProjCases : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
 ;
@@ -44,7 +44,7 @@ mlam g => fn e =>
 
 rec fffForgot1stProjCase : {g:termCtx} [g |- term nat] -> [g |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g |- z]     => [g |- z]
   | [g |- suc (U[..])]   => [g |- z]
   | [g |- #p.3[..]]   => [g |- z]

--- a/t/success/base/cs4.bel
+++ b/t/success/base/cs4.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 irrel : type.
 irrel_ctor : irrel.
 
@@ -28,7 +28,7 @@ mlam g => fn e =>
 
 rec fff2 : {g:termCtx} [g, b : block yyy:term nat, www:irrel, _t:term nat |-  term nat] -> [ |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  z]     => [ |- z]
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  suc U]   => [ |- z]
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  #p.1[..]]   => [ |- z]
@@ -40,7 +40,7 @@ mlam g => fn e =>
 
 rec fff3 : {g:termCtx} [g, b : block yyy:term nat, www:irrel, _t:term nat |-  term nat] -> [ |- term nat] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  z]     => [ |- z]
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  suc U]   => [ |- z]
   | [g, b:block yyy:term nat, www:irrel, _t:term nat |-  #p.1[..]]   => [ |- z]

--- a/t/success/base/ctxmatching.bel
+++ b/t/success/base/ctxmatching.bel
@@ -21,7 +21,7 @@ fn n  => case n of
 
 
 rec cmatch_incorrect1 : (g:nctx) [g |- nat] -> [g |- nat] =
-fn n  => case n of  %not
+fn n  => case n of  --not
  | [g |- z] => [g |- z]
 % | [h,x:nat] x => [h,x:nat] x
  | [g,x:nat |-  #p[..]] => [g,x:nat |-  #p[..]]
@@ -29,7 +29,7 @@ fn n  => case n of  %not
 ;
 
 rec cmatch_incorrect2 : (g:nctx) [g |- nat] -> [g |- nat] =
-fn n  => case n of %not
+fn n  => case n of --not
 % | [g] z => [g] z
  | [h,x:nat |-  x] => [h,x:nat |-  x]
  | [g,x:nat |-  #p[..]] => [g,x:nat |-  #p[..]]
@@ -40,7 +40,7 @@ fn n  => case n of %not
 % PVAR CASE NOT IMPLEMENTED IN COVERAGE ???
 
 rec cmatch_incorrect3 : {g:nctx} [g |- nat] -> [g |- nat] =
-mlam g => fn n  => case n of %not
+mlam g => fn n  => case n of --not
  | [g |- z] => [g |- z]
  | [h,x:nat  |-  x] => [h,x:nat |-  x]
 % | [g,x:nat] #p[..] => [g,x:nat] #p[..]

--- a/t/success/base/depctxmatching.bel
+++ b/t/success/base/depctxmatching.bel
@@ -37,7 +37,7 @@ fn n  => case n of
 
 
 rec cmatch_incorrect2 : (g:tctx) [g |- term T] -> [g |- term T] =
-fn n  => case n of  %not
+fn n  => case n of  --not
 % | [g] z => [g] z
  | [h,x:term S |-  x] => [h,x:term S |-  x]
  |  {#p:[g |- term T]}
@@ -47,7 +47,7 @@ fn n  => case n of  %not
 
 
 rec cmatch_incorrect3 : (g:tctx) [g |- term T] -> [g |- term T] =
-fn n  => case n of  %not
+fn n  => case n of  --not
  | [g |- z] => [g |- z]
  | [h,x:term S  |-  x] => [h,x:term S |-   x]
 %{ |  {#p::(term T)[g]}
@@ -59,7 +59,7 @@ fn n  => case n of  %not
 
 
 rec cmatch_incorrect1 : (g:tctx) [g |- term T] -> [g |- term T] =
-fn n  => case n of  %not
+fn n  => case n of  --not
  | [g |- z] => [g |- z]
 % | [h,x:term S] x => [h,x:term S] x
  |  {#p:[g |- term T]}

--- a/t/success/base/dependency.bel
+++ b/t/success/base/dependency.bel
@@ -1,6 +1,6 @@
 
-o:type. %name o A p.
-i:type. %name i T x.
+o:type. --name o A p.
+i:type. --name i T x.
 
 z: i.
 

--- a/t/success/base/id-simple.bel
+++ b/t/success/base/id-simple.bel
@@ -18,7 +18,7 @@ rec identity : [ |- nat] -> [ |- nat] =
 
 rec plus : [ |- nat] -> [ |- nat] -> [ |- nat] =
  fn x => fn y =>
-  case x of %not
+  case x of --not
      [ |- z]  => y
   |  [ |- s U]  =>
      let
@@ -30,7 +30,7 @@ rec plus : [ |- nat] -> [ |- nat] -> [ |- nat] =
 
 rec plus' : [ |- nat] -> [ |- nat] -> [ |- nat] =
    fn x => fn y =>
-     case x of %not
+     case x of --not
        [ |- z]  => y
      | [ |- s U] =>
        let [ |- V] = plus' [ |- U] y in

--- a/t/success/base/mlamctxmatch.bel
+++ b/t/success/base/mlamctxmatch.bel
@@ -1,4 +1,4 @@
-%coverage
+--coverage
 
 nat : type.
 z : nat.

--- a/t/success/base/parred.bel
+++ b/t/success/base/parred.bel
@@ -3,12 +3,12 @@
 
 % ---------------------------------------------------------------------------
 % Definition of lambda-terms
-tm: type. %name tm M x.
+tm: type. --name tm M x.
 app: tm -> tm -> tm.
 lam: (tm -> tm) -> tm.
 
 % Definition of types and expressions
-tp: type. %name tp T.
+tp: type. --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
@@ -30,7 +30,7 @@ schema rCtx = block x:tm, pr_v: pr x x;
 
 % ---------------------------------------------------------------------------
 % Typing judgment
-oft: tm -> tp -> type. %name oft H.
+oft: tm -> tp -> type. --name oft H.
 of_lam: ({x:tm}oft x T1 -> oft (M x) T2)
 -> oft (lam M) (arr T1 T2).
 

--- a/t/success/base/recon.bel
+++ b/t/success/base/recon.bel
@@ -1,11 +1,11 @@
 % The following are a bunch of test-case raising errors (correctly!)
 
-tp: type. %name tp T.
+tp: type. --name tp T.
 nat: tp.
 bool:tp.
 arr: tp -> tp -> tp.
 
-exp: tp -> type.  %name exp E.
+exp: tp -> type.  --name exp E.
 z : exp nat.
 s : exp nat -> exp nat.
 tt: exp bool.

--- a/t/success/base/remove.bel
+++ b/t/success/base/remove.bel
@@ -1,17 +1,17 @@
 % Types
-tp: type.   %name tp T.
+tp: type.   --name tp T.
 arr  : tp -> tp -> tp.
 code : tp -> tp -> tp.
 cross: tp -> tp -> tp.
 unit :tp.
 
 % source lang
-term: tp -> type.   %name term M.
+term: tp -> type.   --name term M.
 elam: (term T -> term S) -> term (arr T S).
 eapp: term (arr T S) -> term T -> term S.
 
 
-list: tp -> type. %name list F.
+list: tp -> type. --name list F.
 nil: list unit.
 cons: term T -> list S -> list (cross T S).
 

--- a/t/success/base/schema.bel
+++ b/t/success/base/schema.bel
@@ -43,7 +43,7 @@ rec expnatter : {g:expCtx} [g |- exp nat] -> [ |- exp nat] =
 
 rec cntV : {g:expCtx} [g |- exp nat] -> [ |- exp nat] =
 mlam g => fn e =>
- case e of %not
+ case e of --not
    {T1:[ |- tp]}
    [g |- typist (T1[])] : [g |- (exp nat)] =>
       expnatter [g, x:exp (T1[])] [g, x |-  typist (T1[])]

--- a/t/success/base/sigma1.bel
+++ b/t/success/base/sigma1.bel
@@ -9,7 +9,7 @@ false : boolean.
 schema nat3 = block x:nat, y:nat, _t:nat;
 schema bool = boolean;
 
-%not
+--not
 rec loop1 : {g:nat3} [ |- nat] -> [ |- nat]
  = mlam g => fn e => loop1[g, zz:block zz1:nat, _t:nat] e;
 
@@ -20,10 +20,10 @@ rec loop1 : {g:nat3} [ |- nat] -> [ |- nat]
 % rec loop2 : {g:(nat3)*} (nat)[ ] -> (nat)[ ]
 %   = FN g  => fn e => loop1 [g] e;
 %
-% %not
+% --not
 % rec loop2 : {g:(nat3)*} {bb:(bool)*} (nat)[g] -> (nat)[g]
 %   = FN g => FN bb => fn e => loop2[bb][g] e;
 %
 % rec loop3 : {g:(nat3)*} {bb:(bool)*} (nat)[g] -> (nat)[g] = FN g => FN bb => fn e => loop3 [g][bb] e;
-% %not
+% --not
 % rec loop4 : {g:(nat3)*} {bb:(bool)*} (nat)[g] -> (nat)[g] = FN g => FN bb => fn e => loop4 [bb][g] e;

--- a/t/success/base/sigma2.bel
+++ b/t/success/base/sigma2.bel
@@ -7,7 +7,7 @@ unitexp : exp unit.
 
 schema assn = block t:tp, _t:exp t;
 
-%not
+--not
 rec fff : {g:assn} [ |- tp] -> [ |- tp]
 = mlam g => fn e => fff[g, zz:block u:tp, _t:exp unit] e;
 
@@ -17,6 +17,6 @@ rec ggg : {g:assn} [ |- tp] -> [ |- tp]
 rec hhh : {g:assn} [ |- tp] -> [ |- tp]
 = mlam g => fn e => hhh[g, zz:block (u:tp, _t:exp u), zz1:block u':tp, _t:exp u'] e;
 
-%not
+--not
 rec iii : {g:assn} [ |- tp] -> [ |- tp]
  = mlam g => fn e => iii[g, zz:block (u:tp, _t:exp u), zz1:block u':tp, u':tp, _t:exp u'] e;

--- a/t/success/base/sigma3.bel
+++ b/t/success/base/sigma3.bel
@@ -10,7 +10,7 @@ schema tps = tp;
 %{
 rec f : {g:w} [g |- nat] -> [g |- nat] =
   mlam g => fn e =>
-    case e of  %not
+    case e of  --not
 %     {#p::(block x:nat. nat)[g]}
 % | [g] #p.1[..] => [g] z
 | [g |- #p.2[..]] => [g |- z]
@@ -21,20 +21,20 @@ rec f : {g:w} [g |- nat] -> [g |- nat] =
 
 rec f : {g:w} [g |- nat] -> [g |- nat] =
   mlam g => fn e =>
-    case e of  %not
+    case e of  --not
      {#p:[g |- block (x:nat, _t:nat)]}
       [g |- #p.1[..]] => [g |- #p.2[..]]
 ;
 }%
 
 rec qqqq : [x:block (y:nat,_t:nat) |-  nat] -> [x:block (y:nat,_t:nat) |-  nat] =
-fn eNat => case eNat of %not
+fn eNat => case eNat of --not
   [x:block (y:nat,_t:nat) |-  x.1] => [x:block (y:nat,_t:nat) |-  x.2]
 %  [x:block (y:nat,_t:nat) |-  x.1] => [x |- x.2]
 ;
 
 %{
-%not
+--not
 rec ffff1 : {h:tps} [h, extras:tp |-  nat] -> [h |- nat] =
    mlam h => fn eNat =>
      case eNat of
@@ -43,7 +43,7 @@ rec ffff1 : {h:tps} [h, extras:tp |-  nat] -> [h |- nat] =
 ;
 
 
-%not
+--not
 rec ffff2 : {g:w} {h:tps} [g |- nat] -> [h |- tp] -> [g |- nat] =
   mlam g => mlam h => fn eNat => fn eTp =>
     case eNat of
@@ -52,19 +52,19 @@ rec ffff2 : {g:w} {h:tps} [g |- nat] -> [h |- tp] -> [g |- nat] =
 
 rec ffff2-a : {h:tps} [h |- tp] -> [h |- tp] =
   mlam h => fn eTp =>
-    case eTp of %not
+    case eTp of --not
       [h |- #q[..]] => [h |- #q[..]]
 ;
 
 % not
 rec ffff2-a-misspell : {h:tps} [h |- tp] -> [h |- tp] =
   mlam h => fn eTp =>
-    case eTp of %not
+    case eTp of --not
       [g |- #q[..]] => [g |- #q[..]]        % Unknown context variable in context: g
 ;
 
 
-%not
+--not
 rec ffff3 : {g:w} {h:tps} [g |- nat] -> [h |- tp] -> [g |- nat] =
   mlam g => mlam h => fn eNat => fn eTp =>
     case eTp of
@@ -74,7 +74,7 @@ rec ffff3 : {g:w} {h:tps} [g |- nat] -> [h |- tp] -> [g |- nat] =
 
 rec ffff4 : {h:tps}{g:w}  [g |- nat] -> [h |- tp] -> [g |- nat] =
   mlam h => mlam g => fn eNat => fn eTp =>
-    case eNat of %not
+    case eNat of --not
       [g |- #pp'.1[..]] => [g |- #pp'.2[..]]
 ;
 

--- a/t/success/base/simple-explicit.bel
+++ b/t/success/base/simple-explicit.bel
@@ -12,7 +12,7 @@ rec id-test : {g:w} [g |- nat] -> [g |- nat] =
 rec identity1 : {g:w} [g |- nat] -> [g |- nat] =
   mlam g =>
     fn x =>
-      case x of %not
+      case x of --not
           [g |- z]   : [g |- nat] => [g |- z]
         | {U: [g |- nat]} [g |- s (U[..] )] : [g |- nat] => [g |- s (U[..] )];
 
@@ -21,7 +21,7 @@ rec identity1 : {g:w} [g |- nat] -> [g |- nat] =
 rec identity2 : {g:w} [g |- nat] -> [g |- nat] =
   mlam g =>
     fn x =>
-      case x of %not
+      case x of --not
           [g |- z]   : [g |- nat] => x
         | {U:[g |- nat]} [g |- s (U[..] )] : [g |- nat] => [g |- s (U[..] )];
 
@@ -29,7 +29,7 @@ rec identity2 : {g:w} [g |- nat] -> [g |- nat] =
 rec identity2 : {g:w} [g |- nat] -> [g |- nat] =
   mlam g =>
     fn x =>
-      case x of %not
+      case x of --not
           [g |- z]   : [g |- nat] => x
         | {U:[g |- nat]} [g |- s (U[..] )] : [g |- nat] => x;
 

--- a/t/success/base/subord-post.bel
+++ b/t/success/base/subord-post.bel
@@ -14,7 +14,7 @@ schema boolCtx = bool;
 
 rec fff : {g:boolCtx} [g, xx : bool |-  bool] -> [ |- term] =
 mlam g => fn e =>
-  case e of %not        % Shouldn't cover, due to "after" term constructor declared later
+  case e of --not        % Shouldn't cover, due to "after" term constructor declared later
   | [g, xx : bool |-  eq U V]     => [ |- z]
 %  | [g, xx : bool]  eq (U[..]) V     => [] z
 %  | [g, xx : bool]  eq (U[..]) (Vx)     => [] z

--- a/t/success/base/subord.bel
+++ b/t/success/base/subord.bel
@@ -40,7 +40,7 @@ mlam g => fn e =>
 
 rec fff2Wrong : {g:termCtx} [g, xx : bool |-  term] -> [ |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, xx : bool |-  z]      => [ |- z]
   | [g, xx : bool |-  suc U]  => [ |- z]
   | [g, xx : bool |-  #p[..]]  => [ |- z]

--- a/t/success/base/subord3.bel
+++ b/t/success/base/subord3.bel
@@ -36,7 +36,7 @@ mlam g => fn e =>
 
 rec fff0'fail : {g:termCtx} [g, xx : block t1 : term, t2 : term, t3 : term, _t:term |-  term] -> [ |- term] =
 mlam g => fn e =>
-  case e of %not
+  case e of --not
   | [g, xx : block t1 : term, t2 : term, t3 : term, _t:term |-  U[..,xx.1,xx.3,xx.4]] => [ |- z]
 %  | [g, xx : block t1 : term, t2 : term, t3 : term |-  term] U[..]  => [] z
 ;

--- a/t/success/base/test.bel
+++ b/t/success/base/test.bel
@@ -1,8 +1,8 @@
-tp: type.   %name tp T.
+tp: type.   --name tp T.
 nat: tp.
 arr: tp -> tp -> tp.
 
-exp : tp -> type.   %name exp E x.
+exp : tp -> type.   --name exp E x.
 
 z : exp nat.
 s  : exp nat -> exp nat.

--- a/t/success/caseonpairs-leftovercnstrs.bel
+++ b/t/success/caseonpairs-leftovercnstrs.bel
@@ -22,11 +22,11 @@ LF biDer : exp -> tp -> type =
 | chk : check M T -> biDer M T
 ;
 
-%name tp T.
-%name exp M.
-%name oft D.
-%name check C.
-%name biDer B.
+--name tp T.
+--name exp M.
+--name oft D.
+--name check C.
+--name biDer B.
 
 rec completenessGood : (g:ctx) [g |- oft M T] -> [g |- biDer M T] =
 fn e => case e of

--- a/t/success/coverage/param.bel
+++ b/t/success/coverage/param.bel
@@ -1,9 +1,9 @@
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 oft : tm -> tp -> type.
 
 schema ctx = some [t:tp] block x:tm,y:oft x t;

--- a/t/success/coverage/subord.bel
+++ b/t/success/coverage/subord.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 c : term.

--- a/t/success/ctx-underscore-2.bel
+++ b/t/success/ctx-underscore-2.bel
@@ -2,19 +2,19 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory 
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -30,7 +30,7 @@ schema tctx = some [t:tp] block x:tm, y:algeqr x x t;
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:tctx) [g |- tmpair] -> [ |- tp] -> ctype   =
 | LogBase : [g |- algeqn M N i]
@@ -311,7 +311,7 @@ dctx : type.
 nil : dctx.
 & : dctx -> tp -> dctx.
 
-%infix & 5 right.
+--infix & 5 right.
 
 inductive Lookup : {G:[|-dctx]}(g:ctx)[g |-  tm] -> [ |- tp] -> ctype  =
 | Top : Lookup [|- G & T] [g,x:tm |-  x] [ |- T]

--- a/t/success/ctx-underscore.bel
+++ b/t/success/ctx-underscore.bel
@@ -2,19 +2,19 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory 
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -30,7 +30,7 @@ schema tctx = some [t:tp] block x:tm, y:algeqr x x t;
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:tctx) [g |- tmpair] -> [ |- tp] -> ctype   =
 | LogBase : [g |- algeqn M N i]
@@ -311,7 +311,7 @@ dctx : type.
 nil : dctx.
 & : dctx -> tp -> dctx.
 
-%infix & 5 right.
+--infix & 5 right.
 
 inductive Lookup : {G:[|-dctx]}(g:ctx)[g |-  tm] -> [ |- tp] -> ctype  =
 | Top : Lookup [|- G & T] [g,x:tm |-  x] [ |- T]

--- a/t/success/infix/alternate.bel
+++ b/t/success/infix/alternate.bel
@@ -4,18 +4,18 @@
 
 exp : type.
 lam : (exp -> exp) -> exp.
-app : exp -> exp -> exp. %infix app 4.
+app : exp -> exp -> exp. --infix app 4.
 
-eq : exp -> exp -> type. %infix eq 5.
+eq : exp -> exp -> type. --infix eq 5.
 refl : M eq M.
 
 notLam : exp -> type.
 notLam : notLam (M app N).
 
-eval : exp -> exp -> type. %infix eval 4.
+eval : exp -> exp -> type. --infix eval 4.
 eval_lam : ({x:exp} x eval x -> notLam x -> (M x) eval (N x))
            -> (lam M) eval (lam N).
-eval_app1 : M eval (lam M') -> (M' N) eval R -> (M app N) eval R.   %infix eval_app1 4.
+eval_app1 : M eval (lam M') -> (M' N) eval R -> (M app N) eval R.   --infix eval_app1 4.
 eval_app2 : M eval M' -> notLam M' -> N eval N' -> (M app N) eval (M' app N').
 
 schema evctx = block x:exp, u:x eval x, _t:notLam x;

--- a/t/success/infix/assoc_prag.bel
+++ b/t/success/infix/assoc_prag.bel
@@ -6,14 +6,14 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2.
+app : tm -> tm -> tm.           --infix app 2.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 1.
+step: tm -> tm -> type.         --infix step 1.
 
 
 s_app1 : (E1 step E1') -> 
@@ -32,12 +32,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/success/infix/copy.bel
+++ b/t/success/infix/copy.bel
@@ -1,15 +1,15 @@
-tp: type.   %name tp T.
+tp: type.   --name tp T.
 bool: tp.
 nat: tp.
-arrow: tp -> tp -> tp. %infix arrow 1 left.
+arrow: tp -> tp -> tp. --infix arrow 1 left.
 
-term : tp -> type.  %name term E x.
+term : tp -> type.  --name term E x.
 
 z    : term nat. 
 s    : term nat -> term nat.
 
 lam  : (term T -> term T') -> term (T arrow T'). 
-app  : term (T arrow T') -> term T -> term T'. %infix app 1.
+app  : term (T arrow T') -> term T -> term T'. --infix app 1.
 
 
 schema tctx = some [t:tp] term t;

--- a/t/success/infix/eq-proof.bel
+++ b/t/success/infix/eq-proof.bel
@@ -14,12 +14,12 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
-app: exp -> exp -> exp. %infix app 3 right.
+exp: type.    --name exp E x.
+app: exp -> exp -> exp. --infix app 3 right.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u. %infix eq 1 left.
-eq_app : E1 eq F1 -> E2 eq F2 -> (E1 app E2) eq (F1 app F2). %infix eq_app 1.
+eq: exp -> exp -> type.   --name eq Q u. --infix eq 1 left.
+eq_app : E1 eq F1 -> E2 eq F2 -> (E1 app E2) eq (F1 app F2). --infix eq_app 1.
 
 eq_lam :  ({x : exp} x eq x -> (E x) eq (F x))
           -> (lam (\x. E x)) eq (lam (\x. F x)).

--- a/t/success/infix/infix_paren.bel
+++ b/t/success/infix/infix_paren.bel
@@ -1,9 +1,9 @@
 nat : type.
 z : nat.
-s : nat -> nat. %prefix s 5.
+s : nat -> nat. --prefix s 5.
 
 t : type.
-test : nat -> nat -> t. %infix test 2.
+test : nat -> nat -> t. --infix test 2.
 
 rec test_fun : [ |- nat ] -> [ |- t] =
 fn n =>

--- a/t/success/infix/lambda_infix.bel
+++ b/t/success/infix/lambda_infix.bel
@@ -6,14 +6,14 @@ tm : type.
 arr : tp -> tp -> tp.
 
 % Terms
-app : tm -> tm -> tm.           %infix app 2 left.
+app : tm -> tm -> tm.           --infix app 2 left.
 lam : tp -> (tm -> tm) -> tm.
 
 % Values
 value : tm -> type.
 
 
-step: tm -> tm -> type.         %infix step 1 left.
+step: tm -> tm -> type.         --infix step 1 left.
 
 s_app1 : (E1 step E1') -> 
          (E1 app E2) step (E1' app E2). 
@@ -31,12 +31,12 @@ s_app3 : value E2 ->
 
 
 % Typing
-has_type : tm -> tp -> type. %infix has_type 1 left.
+has_type : tm -> tp -> type. --infix has_type 1 left.
 
 is_app : E1 has_type (arr T1 T2) ->
          E2 has_type T1 ->
        % -------------------
-         (E1 app E2) has_type T2. %infix is_app 2 left.
+         (E1 app E2) has_type T2. --infix is_app 2 left.
 
 is_lam : ({x:tm} x has_type T1 -> (E x) has_type T2) ->
        % -----------------------------------

--- a/t/success/infix/listInfix2.bel
+++ b/t/success/infix/listInfix2.bel
@@ -10,7 +10,7 @@ list : nat -> type.
 nil : list z.
 @ : bool -> list N -> list (s N).
 
-%infix @ 5 right.
+--infix @ 5 right.
 
 let l1 = [ |- t @ t @ t @ nil];
 

--- a/t/success/infix/path.bel
+++ b/t/success/infix/path.bel
@@ -1,14 +1,14 @@
-tm: type. %name tm T.
+tm: type. --name tm T.
 lam: (tm -> tm) -> tm.
-app: tm -> tm -> tm. %infix app 5.
+app: tm -> tm -> tm. --infix app 5.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> tm -> type. %name is_path I. %infix is_path 8.
+is_path: path -> tm -> type. --name is_path I. --infix is_path 8.
 
 p_lam: (bind P) is_path (lam E)
        <- ({x:tm}{q:path} q is_path x -> (P q) is_path (E x)).
@@ -21,7 +21,7 @@ p_right: (right P) is_path (M app N)
 
 p_done: done is_path M.
 
-eq: tm -> tm -> type.  %name eq E.  %infix eq 10.
+eq: tm -> tm -> type.  --name eq E.  --infix eq 10.
 e_ref: T eq T.
 
 schema ctx = block x:tm,p:path , _t:p is_path x ;

--- a/t/success/infix/same_precedence.bel
+++ b/t/success/infix/same_precedence.bel
@@ -1,9 +1,9 @@
 nat : type.
 z : nat.
-s : nat -> nat. %prefix s 5.
- %assoc left.
+s : nat -> nat. --prefix s 5.
+ --assoc left.
 t : type.
-test : nat -> nat -> t. %infix test 5.
+test : nat -> nat -> t. --infix test 5.
 
 
 rec test_fun : [ |- nat ] -> [ |- t] =

--- a/t/success/infix/tc.bel
+++ b/t/success/infix/tc.bel
@@ -1,21 +1,21 @@
-exp  : type.   %name exp E x.
+exp  : type.   --name exp E x.
 z    : exp.
 suc  : exp -> exp.
 
-letv : exp -> (exp -> exp) -> exp. %infix letv 3 left.
+letv : exp -> (exp -> exp) -> exp. --infix letv 3 left.
 lam  : (exp -> exp) -> exp. 
-app  : exp -> exp -> exp.   %infix app 1. 
+app  : exp -> exp -> exp.   --infix app 1. 
 
-tp   : type.   %name tp T.
+tp   : type.   --name tp T.
 nat  : tp.
 even : tp.
 odd : tp.
-arrow  : tp -> tp -> tp. %infix arrow 1 right.
+arrow  : tp -> tp -> tp. --infix arrow 1 right.
 sect   : tp -> tp -> tp.
 
 
 % Evaluation
-eval : exp -> exp -> type.  %name eval F. %infix eval 1 right.
+eval : exp -> exp -> type.  --name eval F. --infix eval 1 right.
 ev_z : z eval z.
 
 ev_s : V eval E -> (suc V) eval (suc E).
@@ -29,8 +29,8 @@ ev_app: E1 eval (lam (\x. E x)) -> E2 eval V2 -> (E V2) eval V
 
 % Typing
 
-oft : exp -> tp -> type. %infix oft 1 left. %name oft D u. 
-subtype : tp -> tp -> type.  %name subtype SUB sub. %infix subtype 2 left.
+oft : exp -> tp -> type. --infix oft 1 left. --name oft D u. 
+subtype : tp -> tp -> type.  --name subtype SUB sub. --infix subtype 2 left.
 
 boolean : type.
 true : boolean.

--- a/t/success/interactive/sn-full.bel
+++ b/t/success/interactive/sn-full.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/success/interactive/sn.bel
+++ b/t/success/interactive/sn.bel
@@ -5,16 +5,16 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 % ==> : tm A -> tm A -> type.
-% %infix ==> 1 none.
+% --infix ==> 1 none.
 
 % rbeta : (app (abs M) N) ==> (M N).
 %   % | rabs  : ({x : tm A} (M x) ==> (M' x)) -> (abs M) ==> (abs M')

--- a/t/success/interactive/sn2.bel
+++ b/t/success/interactive/sn2.bel
@@ -3,13 +3,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/success/interactive/sn3.bel
+++ b/t/success/interactive/sn3.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 LF step : tm A -> tm A -> type =
   | rbeta : step (app (abs M) N) (M N)

--- a/t/success/modules/abbrev-nested.bel
+++ b/t/success/modules/abbrev-nested.bel
@@ -34,7 +34,7 @@ module Arith = struct
 
 end;
 
-%abbrev Arith.Nats N
+--abbrev Arith.Nats N
 
 let x = [ |- N.z ];
 

--- a/t/success/modules/abbrev.bel
+++ b/t/success/modules/abbrev.bel
@@ -10,7 +10,7 @@ module Nats = struct
   let three = suc two;
 end;
 
-%abbrev Nats N
+--abbrev Nats N
 
 let x = [ |- N.z ];
 
@@ -28,7 +28,7 @@ cons : N.nat -> list N -> list (N.s N).
 let l1 = [ |- cons N.z (cons (N.s N.z) nil)];
 
 module Arith = struct
-	%open N
+	--open N
 
 	rec add : [ |- nat ] -> [ |- nat ] -> [ |- nat ] =
 	fn x, y => case x of
@@ -44,6 +44,6 @@ end;
 let two' = N.two;
 
 
-%open N
+--open N
 let l2 = [ |- cons z nil];
 

--- a/t/success/modules/adapted/fvnat.bel
+++ b/t/success/modules/adapted/fvnat.bel
@@ -1,4 +1,4 @@
-%nostrengthen
+--nostrengthen
 
 module Common = struct
   tp: type.
@@ -18,7 +18,7 @@ module Common = struct
 end;
 
 module FVNat = struct
-  %open Common
+  --open Common
 
 
   arr : tp -> tp -> tp.
@@ -69,7 +69,7 @@ module FVNat = struct
 end;
 
 module FVNatCrec = struct
-  %open Common
+  --open Common
 
   arr : tp -> tp -> tp.
   app:  exp (arr T T') -> exp T -> exp T'.
@@ -113,7 +113,7 @@ module FVNatCrec = struct
 end;
 
 module FVNatExplicit = struct
-  %open Common
+  --open Common
 
   opt: type.
   nothing: opt.

--- a/t/success/modules/adapted/include.bel
+++ b/t/success/modules/adapted/include.bel
@@ -1,13 +1,13 @@
 %{
-  The purpose of this is to verify modules opened via the %open pragma are included
+  The purpose of this is to verify modules opened via the --open pragma are included
   in addition to anything declared in the module itself, i.e.
-  tp, exp, etc. should all be accessible after the '%open FVNatExplicit' because of the
-  '%open Common' in FVNatExplicit
+  tp, exp, etc. should all be accessible after the '--open FVNatExplicit' because of the
+  '--open Common' in FVNatExplicit
 
 }%
 
 
-%nostrengthen
+--nostrengthen
 
 module Common = struct
   tp: type.
@@ -26,7 +26,7 @@ end;
 
 
 module FVNatExplicit = struct
-  %open Common
+  --open Common
 
   opt: type.
   nothing: opt.
@@ -36,7 +36,7 @@ module FVNatExplicit = struct
 
 end;
 
-%open FVNatExplicit 
+--open FVNatExplicit 
 rec free_var : {g:expCtx} {T:[ |- tp]} [g |- exp (T[])] -> [g |- opt] =
   mlam g => mlam T => fn e =>
    (case e of

--- a/t/success/modules/nats.bel
+++ b/t/success/modules/nats.bel
@@ -10,7 +10,7 @@ module Nats = struct
   let three = suc two;
 end;
 
-%abbrev Nats N
+--abbrev Nats N
 
 let x = [ |- N.z ];
 
@@ -28,7 +28,7 @@ cons : N.nat -> list N -> list (N.s N).
 let l1 = [ |- cons N.z (cons (N.s N.z) nil)];
 
 module Arith = struct
-	%open N
+	--open N
 
 	rec add : [ |- nat ] -> [ |- nat ] -> [ |- nat ] =
 	fn x, y => case x of
@@ -44,6 +44,6 @@ end;
 let two' = N.two;
 
 
-%open N
+--open N
 let l2 = [ |- cons z nil];
 

--- a/t/success/modules/nested.bel
+++ b/t/success/modules/nested.bel
@@ -40,6 +40,6 @@ let y = [ |- Arith.Nats.s Arith.Nats.z];
 
 let z = Arith.Nats.suc [ |- Arith.Nats.z ];
 
-%open Arith
+--open Arith
 
 let test = Nats.suc x;

--- a/t/success/modules/nested2.bel
+++ b/t/success/modules/nested2.bel
@@ -34,7 +34,7 @@ module Arith = struct
 
 end;
 
-%open Arith.Nats
+--open Arith.Nats
 
 let x = [ |- z ];
 

--- a/t/success/multi_arg_mlam/algeq.bel
+++ b/t/success/multi_arg_mlam/algeq.bel
@@ -2,11 +2,11 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
@@ -17,11 +17,11 @@ of/lam : ({x:tm} oft x T -> oft (M x) S) -> oft (lam M) (arr T S).
 schema ctx = tm;
 schema tctx = some [t:tp] block x:tm,y:oft x t;
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 

--- a/t/success/multi_arg_mlam/unique.bel
+++ b/t/success/multi_arg_mlam/unique.bel
@@ -1,15 +1,15 @@
 
 % Definition of types and expressions
-tp: type.  %name tp T.
+tp: type.  --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 lam : tp -> (exp -> exp) -> exp.
 app : exp -> exp -> exp.
 
 % Typing judgment
-type_of: exp -> tp -> type. %name type_of H.
+type_of: exp -> tp -> type. --name type_of H.
 
 t_lam: ({x:exp}type_of x T1 -> type_of (E x) T2)
         -> type_of (lam T1 E) (arr T1 T2).

--- a/t/success/named_projections/bigstep-deterministic.bel
+++ b/t/success/named_projections/bigstep-deterministic.bel
@@ -4,7 +4,7 @@
 notLam : exp -> type.
 notLam : notLam (app M N).
 
-eval : exp -> exp -> type. %name eval E.
+eval : exp -> exp -> type. --name eval E.
 eval_lam : ({x:exp} eval x x -> notLam x -> eval (M x) (N x))
            -> eval (lam M) (lam N).
 eval_app1 : eval M (lam M') -> eval (M' N) R -> eval (app M N) R.

--- a/t/success/named_projections/bred-nf.bel
+++ b/t/success/named_projections/bred-nf.bel
@@ -4,20 +4,20 @@ inductive tm: type =
 | app: tm -> tm -> tm
 | beta: (tm -> tm) -> tm -> tm
 ;
-%name tm M.
+--name tm M.
 
 inductive nf: type =
 | nabs: (nf -> nf) -> nf
 | napp: nf -> nf -> nf
 ;
-%name nf U.
+--name nf U.
 
 inductive p : type =
 | left : p -> p
 | right: p -> p
 | bnd  : (p -> p) -> p
 ;
-%name p P.
+--name p P.
 
 inductive bred : tm -> nf -> type =
 | r_abs : ({x:tm}{y:nf}  bred x y -> bred (M x) (N y))
@@ -27,7 +27,7 @@ inductive bred : tm -> nf -> type =
 | r_beta: ({x:tm} ({u:nf} bred N u -> bred x u) -> bred (R x) V)
       -> bred (beta R N) V
 ;
-%name bred R.
+--name bred R.
 
 inductive path : tm -> p -> type =
 | p_abs   : ({x:tm}{p:p} path x p -> path (M x) (P p))
@@ -40,7 +40,7 @@ inductive path : tm -> p -> type =
            -> path (beta R N) P
 ;
 
-%name path Pf.
+--name path Pf.
 
 inductive npath : nf -> p -> type =
 | np_abs   : ({x:nf}{p:p} npath x p -> npath (M x) (P p))
@@ -51,7 +51,7 @@ inductive npath : nf -> p -> type =
          -> npath (napp M N) (right P)
 
 ;
-%name path Qf.
+--name path Qf.
 
 schema tctx = tm ;
 

--- a/t/success/named_projections/conv-untyped.bel
+++ b/t/success/named_projections/conv-untyped.bel
@@ -1,11 +1,11 @@
 % Types
-tp  : type.                %name tp T.
+tp  : type.                --name tp T.
 o   : tp.
 arr : tp -> tp -> tp.
 
 
 % Intrinsically well-typed expressions
-exp   : tp -> type.        %name exp E.
+exp   : tp -> type.        --name exp E.
 value : tp -> type.
 app   : exp (arr A B) -> exp A -> exp B.
 lam   : {A:tp}(value A -> exp B) -> value (arr A B).

--- a/t/success/named_projections/cps-crec.bel
+++ b/t/success/named_projections/cps-crec.bel
@@ -1,7 +1,7 @@
 %%% The Mini-ML Language
 %%% Author: Frank Pfenning, based on [Michaylov & Pfenning 92]
 
-exp  : type.  %name exp E.
+exp  : type.  --name exp E.
 z     : exp.
 s     : exp -> exp.
 lam   : (exp -> exp) -> exp.

--- a/t/success/named_projections/eq-proof.bel
+++ b/t/success/named_projections/eq-proof.bel
@@ -14,11 +14,11 @@
 % - also requires explicit use of "remove parameter x and u" in the
 %   definition of `extend' and the use of `extend' in `eqfun'
 
-exp: type.    %name exp E x.
+exp: type.    --name exp E x.
 app: exp -> exp -> exp.
 lam: (exp -> exp) -> exp.
 
-eq: exp -> exp -> type.   %name eq Q u.
+eq: exp -> exp -> type.   --name eq Q u.
 eq_app : eq E1 F1 -> eq E2 F2 -> eq (app E1 E2) (app F1 F2).
 
 eq_lam :  ({x : exp} eq x x -> eq (E x) (F x))

--- a/t/success/named_projections/eq.bel
+++ b/t/success/named_projections/eq.bel
@@ -1,11 +1,11 @@
 % Equality lemmas
 % Author: Andrew Cave
 
-exp : type. %name exp M.
+exp : type. --name exp M.
 app : exp -> exp -> exp.
 lam : (exp -> exp) -> exp.
 
-eq : exp -> exp -> type. %name eq D.
+eq : exp -> exp -> type. --name eq D.
 eq_lam : ({x:exp} eq x x -> eq (M x) (N x)) -> eq (lam M) (lam N).
 eq_app : eq M M' -> eq N N' -> eq (app M N) (app M' N').
 

--- a/t/success/named_projections/path-typed.bel
+++ b/t/success/named_projections/path-typed.bel
@@ -1,12 +1,12 @@
-tp:type. %name tp T a.
+tp:type. --name tp T a.
 arr: tp -> tp -> tp. % infix right 10 => .
 
-exp: type. %name exp E x.
+exp: type. --name exp E x.
 
 lam: tp -> (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 
-type_of: exp -> tp -> type. %name type_of D u.
+type_of: exp -> tp -> type. --name type_of D u.
 
 tof_lam: type_of (lam T E) (arr T T')
 	 <- ({x:exp}type_of x T -> type_of (E x) T').
@@ -15,13 +15,13 @@ tof_app: type_of (app E1 E2) T
 	 <- type_of E1 (arr T2 T)
 	 <- type_of E2 T2.
 
-path: type. %name path P.
+path: type. --name path P.
 bind: tp -> (path -> path) -> path.
 left: path -> path.
 right: path -> path.
 done: path.
 
-is_path: path -> exp -> type. %name is_path I.
+is_path: path -> exp -> type. --name is_path I.
 
 p_lam: is_path (bind T P) (lam T E)
        <- ({x:exp}{q:path}type_of x T -> is_path q x -> is_path (P q) (E x)).
@@ -34,7 +34,7 @@ p_right: is_path (right P) (app M N)
 
 p_done: is_path done M.
 
-eq: exp -> exp -> type.  %name eq E.
+eq: exp -> exp -> type.  --name eq E.
 e_ref: eq T T.
 %{e_lam: ({x:exp}eq x x -> eq (E x) (E' x))
         -> eq (lam T E) (lam T E').

--- a/t/success/named_projections/pearl.bel
+++ b/t/success/named_projections/pearl.bel
@@ -16,7 +16,7 @@
 % --------------------------------------------------------------------------
 % Definition of types
 
-tp : type.  %name tp T.
+tp : type.  --name tp T.
 
 top   : tp.
 arr   : tp -> tp -> tp.			% Functions: A1 => A2
@@ -73,7 +73,7 @@ schema as_ctx =  some [u:tp]  block a:tp, w: subtype a U;
 % ------------------------------------------------------------------
 %   G |- (forall a < S1. S2)  < (forall a < T1. T2)
 
-sub : tp -> tp -> type.                %name sub S.
+sub : tp -> tp -> type.                --name sub S.
 
 
 sa_top : sub S top.

--- a/t/success/named_projections/subject-red.bel
+++ b/t/success/named_projections/subject-red.bel
@@ -1,12 +1,12 @@
-tp:type. %name tp T a.
+tp:type. --name tp T a.
 arr: tp -> tp -> tp. % infix right 10 => .
 
-exp: type. %name exp E x.
+exp: type. --name exp E x.
 
 lam: tp -> (exp -> exp) -> exp.
 app: exp -> exp -> exp.
 
-type_of: exp -> tp -> type. %name type_of D u.
+type_of: exp -> tp -> type. --name type_of D u.
 
 tof_lam: type_of (lam T E) (arr T T')
 	 <- ({x:exp}type_of x T -> type_of (E x) T').

--- a/t/success/named_projections/unique.bel
+++ b/t/success/named_projections/unique.bel
@@ -1,14 +1,14 @@
 % Definition of types and expressions
-tp: type.  %name tp T.
+tp: type.  --name tp T.
 arr: tp -> tp -> tp.
 nat: tp.
 
-exp: type. %name exp E.
+exp: type. --name exp E.
 lam : tp -> (exp -> exp) -> exp.
 app : exp -> exp -> exp.
 
 % Typing judgment
-type_of: exp -> tp -> type. %name type_of H.
+type_of: exp -> tp -> type. --name type_of H.
 
 t_lam: ({x:exp}type_of x T1 -> type_of (E x) T2)
         -> type_of (lam T1 E) (arr T1 T2).

--- a/t/success/postpone-unificiation.bel
+++ b/t/success/postpone-unificiation.bel
@@ -2,19 +2,19 @@
 % Accompanies Mechanizing Logical Relations using Contextual Type Theory
 % by Andrew Cave and Brigitte Pientka
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 beta : step (app (lam M) N) (M N).
 stepapp : step M M' -> step (app M N) (app M' N).
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -30,7 +30,7 @@ schema tctx = some [t:tp] block x:tm, y:algeqr x x t;
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:tctx) [g |- tmpair] -> [ |- tp] -> ctype   =
 | LogBase : [g |- algeqn (M[..]) (N[..]) i]
@@ -311,7 +311,7 @@ dctx : type.
 nil : dctx.
 & : dctx -> tp -> dctx.
 
-%infix & 5 right.
+--infix & 5 right.
 
 inductive Lookup : {G:[|-dctx]}(g:ctx)[g |-  tm] -> [ |- tp] -> ctype  =
 | Top : Lookup [|- (G) & T] [g,x:tm |-  x] [ |- T]

--- a/t/success/renvars/ren1.bel
+++ b/t/success/renvars/ren1.bel
@@ -2,13 +2,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty T.
+--name ty T.
 
 LF tm : ty -> type =
   | abs : {A:ty}(tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/success/stratify/alg-equal-ctxrel.bel
+++ b/t/success/stratify/alg-equal-ctxrel.bel
@@ -15,10 +15,10 @@
 term : type.
 app : term -> term -> term.
 lam : (term -> term) -> term.
-%name term M x.
+--name term M x.
 
 % Algorithmic Equality
-aeq: term -> term -> type.   %name aeq Q u.
+aeq: term -> term -> type.   --name aeq Q u.
 ae_a : aeq M1 N1 -> aeq M2 N2
     -> aeq (app M1 M2) (app N1 N2).
 ae_l :  ({x:term} aeq x x -> aeq (M x) (N x))

--- a/t/success/subst-vars.bel
+++ b/t/success/subst-vars.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/success/substvars/comptype.bel
+++ b/t/success/substvars/comptype.bel
@@ -1,9 +1,9 @@
 % Sketch of weak normalization for STLC that goes under binders
 % Author: Andrew Cave
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 
 schema ctx = tm T;
 

--- a/t/success/substvars/coverage-subst-embedded.bel
+++ b/t/success/substvars/coverage-subst-embedded.bel
@@ -2,16 +2,16 @@
 nm : type.
 leaf : nm.
 nmbin : nm -> nm -> nm.
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 tp/nm :  tp.
 tp/unit : tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 unit : tm.
 name : nm -> tm.
 bin : tm -> tm -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 step/bin : step M1' M1 -> step M2' M2 -> step (bin M1' M2') (bin M1 M2).
 % step/bin1 : step M1' M1 -> step (bin M1' M2) (bin M1 M2).
 % step/bin2 : step M2' M2 -> step (bin M1 M2') (bin M1 M2).
@@ -20,7 +20,7 @@ oft : tm -> tp -> type.
 oft/bin : oft M1 tp/nm -> oft M2 tp/nm -> oft (bin M1 M2) tp/nm. % need???
 
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : mstep M M' -> step M' M''  -> mstep M M''.
 

--- a/t/success/substvars/eq-proof-promotion.bel
+++ b/t/success/substvars/eq-proof-promotion.bel
@@ -3,13 +3,13 @@
 %
 
 % Definition of lambda-terms
-tm: type.                         %name tm M x.
+tm: type.                         --name tm M x.
 app: tm -> tm -> tm.
 lam: (tm -> tm) -> tm.
 
 % ---------------------------------------------------------------------------
 % Algorithmic Equality
-aeq: tm -> tm -> type.   %name aeq Q u.
+aeq: tm -> tm -> type.   --name aeq Q u.
 ae_a : aeq M1 N1 -> aeq M2 N2 -> aeq (app M1 M2) (app N1 N2).
 
 ae_l :  ({x : tm} aeq x x -> aeq (M x) (N x)) 

--- a/t/success/substvars/nbe-datatype.bel
+++ b/t/success/substvars/nbe-datatype.bel
@@ -1,18 +1,18 @@
 
 
 atomic_tp : type.
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 atomic : atomic_tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut (atomic P) -> norm (atomic P).

--- a/t/success/substvars/nbe.bel
+++ b/t/success/substvars/nbe.bel
@@ -1,18 +1,18 @@
 
 
 atomic_tp : type.
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 atomic : atomic_tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut (atomic P) -> norm (atomic P).

--- a/t/success/substvars/nbe2.bel
+++ b/t/success/substvars/nbe2.bel
@@ -1,15 +1,15 @@
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 b : tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema tctx = tm T;
 
-neut : tp -> type.       %name neut R.
-norm : tp -> type.       %name norm M.
+neut : tp -> type.       --name neut R.
+norm : tp -> type.       --name norm M.
 nlam : (neut T -> norm S) -> norm (arr T S).
 rapp : neut (arr T S) -> norm T -> neut S.
 embed : neut b -> norm b.

--- a/t/success/substvars/sn.bel
+++ b/t/success/substvars/sn.bel
@@ -4,13 +4,13 @@ LF ty : type =
   | base : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty A.
+--name ty A.
 
 LF tm : ty -> type =
   | abs : (tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 schema cxt = tm A; % some [a : ty] block tm a;
 

--- a/t/success/substvars/weak-norm-closed-ideal.bel
+++ b/t/success/substvars/weak-norm-closed-ideal.bel
@@ -4,13 +4,13 @@
 LF tp : type =
 | i :  tp
 | arr: tp -> tp -> tp;
- %name tp T.
+ --name tp T.
 
 LF tm : tp -> type =
 | app : tm (arr T S) -> tm T -> tm S
 | lam : (tm T -> tm S) -> tm (arr T S)
 | c : tm i;
-%name tm E.
+--name tm E.
 
 schema ctx = tm T;
 
@@ -19,16 +19,16 @@ LF mstep : tm A -> tm A -> type =
 | stepapp : mstep M M' -> mstep N N' -> mstep (app M N) (app M' N')
 | refl : mstep M M
 | trans : mstep M M' -> mstep M' M'' -> mstep M M'';
-%name mstep S.
+--name mstep S.
 
 LF val : tm A -> type =
 | val/c : val c
 | val/lam : val (lam M);
-%name val V.
+--name val V.
 
 LF halts : tm A -> type =
 halts/m : mstep M M' -> val M' -> halts M;
-%name halts H.
+--name halts H.
 
 stratified Reduce : {A:[ |- tp]} {M:[ |- tm A]} ctype  =
 | I : [ |- halts M] -> Reduce [ |- i] [ |- M]

--- a/t/success/substvars/weak-norm-closed.bel
+++ b/t/success/substvars/weak-norm-closed.bel
@@ -1,19 +1,19 @@
-%nostrengthen
+--nostrengthen
 % Proof of weak normalization for STLC that doesn't go under binders
 % Author: Andrew Cave
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 c : tm i.
 
 schema ctx = tm T;
 
-mstep : tm A -> tm A -> type.  %name mstep S.
+mstep : tm A -> tm A -> type.  --name mstep S.
 beta : mstep (app (lam M) N) (M N).
 eta : {M:tm (arr A B)} mstep M (lam (\x. app M x)).
 stepapp : mstep M M' -> mstep N N' -> mstep (app M N) (app M' N').
@@ -115,9 +115,9 @@ mlam A => mlam M =>
 reify (eval [] [] [ |- A] [ |- M] [ |- ^ ] (Nil []))
 ;
 
-%rec weakNorm : {g:ctx}{A:[g |- tp]}{M:[g |- tm (A[..])]} Halts [g] [g |- A[..]] [g |- M[..]] =
-%mlam g => mlam A => mlam M =>
-%reify (eval [g] [g] [g |- A[..]] [g |- M[..]] [g |-[..]] ?)
+--rec weakNorm : {g:ctx}{A:[g |- tp]}{M:[g |- tm (A[..])]} Halts [g] [g |- A[..]] [g |- M[..]] =
+--mlam g => mlam A => mlam M =>
+--reify (eval [g] [g] [g |- A[..]] [g |- M[..]] [g |-[..]] ?)
 % For this I need a lemma which says that RedSub holds of the identity substitution
 %;
 

--- a/t/success/substvars/weak-norm-under-binders-explicit2.bel
+++ b/t/success/substvars/weak-norm-under-binders-explicit2.bel
@@ -1,16 +1,16 @@
 % Weak normalization under binders. Very carefully tiptoes around various gaps in the implementation
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema ctx = tm T;
 
-mstep : tm A -> tm A -> type.  %name mstep S.
+mstep : tm A -> tm A -> type.  --name mstep S.
 beta : mstep (app (lam M) N) (M N).
 eta : {M:tm (arr A B)} mstep M (lam (\x. app M x)).
 steplam : ({x:tm A} mstep (M x) (M' x)) -> mstep (lam M) (lam M').

--- a/t/success/substvars/weak-norm-under-binders.bel
+++ b/t/success/substvars/weak-norm-under-binders.bel
@@ -1,17 +1,17 @@
 
 % Weak normalization under binders.
 
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 
 schema ctx = tm T;
 
-mstep : tm A -> tm A -> type.  %name mstep S.
+mstep : tm A -> tm A -> type.  --name mstep S.
 beta : mstep (app (lam M) N) (M N).
 eta : {M:tm (arr A B)} mstep M (lam (\x. app M x)).
 steplam : ({x:tm A} mstep (M x) (M' x)) -> mstep (lam M) (lam M').

--- a/t/success/total/ctx-match.bel
+++ b/t/success/total/ctx-match.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/success/total/logrel-names-essential.bel
+++ b/t/success/total/logrel-names-essential.bel
@@ -4,13 +4,13 @@ nm : type.
 leaf : nm.
 nmbin : nm -> nm -> nm.
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 tp/nm :  tp.
 tp/unit : tp.
 prod : tp -> tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 unit : tm.
 pair : tm -> tm -> tm.
 fst : tm -> tm. % ???
@@ -20,7 +20,7 @@ bin : tm -> tm -> tm.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 step/beta : step (app (lam M) N) (M N).
 step/app : step M M' -> step (app M N) (app M' N). % stepapp
 step/betaprod1 : step (fst (pair M1 M2)) M1.
@@ -35,7 +35,7 @@ oft : tm -> tp -> type.
 oft/bin : oft M1 tp/nm -> oft M2 tp/nm -> oft (bin M1 M2) tp/nm. % need???
 
 
-mstep : tm -> tm -> type.  %name mstep MS.
+mstep : tm -> tm -> type.  --name mstep MS.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -81,7 +81,7 @@ schema rctx = some [t:tp] block x:tm, xt:oft x t, xx:algeqr x x t
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:rctx) [g |- tmpair] -> [ |- tp] -> ctype =
 | LogUnit : Log [g |- M ~ N ] [|- tp/unit]

--- a/t/success/total/logrel-names.bel
+++ b/t/success/total/logrel-names.bel
@@ -4,13 +4,13 @@ nm : type.
 leaf : nm.
 nmbin : nm -> nm -> nm.
 
-tp : type.         %name tp T.
+tp : type.         --name tp T.
 tp/nm :  tp.
 tp/unit : tp.
 prod : tp -> tp -> tp.
 arr: tp -> tp -> tp.
 
-tm : type.          %name tm E.
+tm : type.          --name tm E.
 unit : tm.
 pair : tm -> tm -> tm.
 fst : tm -> tm. % ???
@@ -20,7 +20,7 @@ bin : tm -> tm -> tm.
 app : tm -> tm -> tm.
 lam : (tm -> tm) -> tm.
 
-step : tm -> tm -> type.  %name step S.
+step : tm -> tm -> type.  --name step S.
 step/beta : step (app (lam M) N) (M N).
 step/app : step M M' -> step (app M N) (app M' N). % stepapp
 step/betaprod1 : step (fst (pair M1 M2)) M1.
@@ -40,7 +40,7 @@ oft/bin : oft M1 tp/nm -> oft M2 tp/nm -> oft (bin M1 M2) tp/nm. % need???
 % TODO: M-const is missing from the original. Why???
 oft/nm : oft (name n) tp/nm.
 
-mstep : tm -> tm -> type.  %name mstep S.
+mstep : tm -> tm -> type.  --name mstep S.
 refl : mstep M M.
 trans1 : step M M' -> mstep M' M'' -> mstep M M''.
 
@@ -90,7 +90,7 @@ schema rctx = some [t:tp] block x:tm, xt:oft x t, xx:algeqr x x t
 
 tmpair : type.
 ~ : tm -> tm -> tmpair.
-%infix ~ 5 right.
+--infix ~ 5 right.
 
 stratified Log : (g:rctx) [g |- tmpair] -> [ |- tp] -> ctype =
 | LogUnit : Log [g |- M ~ N ] [|- tp/unit]

--- a/t/success/total/param2.bel
+++ b/t/success/total/param2.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/success/total/param3.bel
+++ b/t/success/total/param3.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/success/total/param4.bel
+++ b/t/success/total/param4.bel
@@ -1,4 +1,4 @@
-%coverage 
+--coverage 
 
 term: type.
 lam:(term -> term) -> term.

--- a/t/success/total/total-block.bel
+++ b/t/success/total/total-block.bel
@@ -1,8 +1,8 @@
-exp : type. %name exp M.
+exp : type. --name exp M.
 app : exp -> exp -> exp.
 lam : (exp -> exp) -> exp.
 
-eq : exp -> exp -> type. %name eq D.
+eq : exp -> exp -> type. --name eq D.
 eq_lam : ({x:exp} eq x x -> eq (M x) (N x)) -> eq (lam M) (lam N).
 eq_app : eq M M' -> eq N N' -> eq (app M N) (app M' N').
 

--- a/t/success/total/wf-correctarg.bel
+++ b/t/success/total/wf-correctarg.bel
@@ -4,7 +4,7 @@ LF nat : type =
 | z : nat
 | s : nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 % The sub-term relation on naturals
 

--- a/t/success/total/wf.bel
+++ b/t/success/total/wf.bel
@@ -4,7 +4,7 @@ LF nat : type =
 | z : nat
 | s : nat -> nat
 ;
-%name nat N.
+--name nat N.
 
 % The sub-term relation on naturals
 

--- a/t/success/total/wf1.bel
+++ b/t/success/total/wf1.bel
@@ -3,14 +3,14 @@ LF ty : type =
   | one  : ty
   | arr  : ty -> ty -> ty
   ;
-%name ty T.
+--name ty T.
 
 LF tm : ty -> type =
   | unit : tm one
   | abs : {A:ty}(tm A -> tm B) -> tm (arr A B)
   | app : tm (arr A B) -> tm A -> tm B
   ;
-%name tm M.
+--name tm M.
 
 
 schema cxt = tm A; % some [a : ty] block tm a;

--- a/t/success/unif-nonterm.bel
+++ b/t/success/unif-nonterm.bel
@@ -1,8 +1,8 @@
-tp : type.                %name tp T.
+tp : type.                --name tp T.
 i :  tp.
 arr: tp -> tp -> tp.
 
-tm : tp -> type.          %name tm E.
+tm : tp -> type.          --name tm E.
 app : tm (arr T S) -> tm T -> tm S.
 lam : (tm T -> tm S) -> tm (arr T S).
 

--- a/tools/beluga-mode.el
+++ b/tools/beluga-mode.el
@@ -543,7 +543,7 @@ If a previous beli process already exists, kill it first."
          (concat beluga-interpreter-name
                  " "
                  (shell-quote-argument buffer-file-name))))
-  (set (make-local-variable 'comment-start) "% ")
+  (set (make-local-variable 'comment-start) "%")
   (set (make-local-variable 'comment-start-skip) "%[%{]*[ \t]*")
   (set (make-local-variable 'comment-end-skip) "[ \t]*\\(?:\n\\|}%\\)")
   (comment-normalize-vars)


### PR DESCRIPTION
Consequently, pragmas and comments use completely different syntax.
The upshot is that there is no longer a ban on comments of the form `%foo`, which previously could have possibly been (unimplemented) pragmas.