### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,25 @@
-    language: c
-    script: bash -ex .travis-ci.sh
-    env:
-      - OCAML_VERSION=4.06.1
-      - OCAML_VERSION=4.05.0
-      - OCAML_VERSION=4.04.0
-    notifications:
-      email:
-        - beluga-commit@cs.mcgill.ca
-      #irc: # reenable this when n mode is removed from #beluga channel
-      #  channels:
-      #    - "chat.freenode.net#beluga"
-      #  on_success: change
-      #  on_failure: change
-      #  skip_join: true
-    addons:
-      apt:
-        sources:
-          - avsm
-        packages:
-          - ocaml
-          - opam
-          - zsh
+language: c
+script: bash -ex .travis-ci.sh
+env:
+  - OCAML_VERSION=4.06.1
+  - OCAML_VERSION=4.05.0
+  - OCAML_VERSION=4.04.0
+notifications:
+  email:
+    - beluga-commit@cs.mcgill.ca
+  irc:
+    channels:
+      - "chat.freenode.net#beluga"
+    on_success: always
+    on_failure: always
+addons:
+  apt:
+    sources:
+      - avsm
+    packages:
+      - ocaml
+      - opam
+      - zsh
+cache:
+  directories:
+    - $HOME/.opam


### PR DESCRIPTION
* Travis will now send notifications to the IRC channel #beluga on Freenode for build successes and failures.
* Travis will cache the `$HOME/.opam` directory between builds.
  Since the Beluga dependencies are unchanging, this should considerably speed up builds since they won't need to be rebuilt from scratch on each build.
  Typical builds average 10 minutes without caching. I expect builds to complete within less than a minute with caching.