### PR TITLE
Replace lex_dump bash glue with bona fide OCaml program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,13 @@ OCAMLBUILD = ocamlbuild -r -use-ocamlfind \
 
 .PHONY: all clean
 
-all: bin/lex_dump bin/beluga bin/replay
+all: bin/lex_dump bin/beluga bin/replay bin/lex_check
 
 bin/beluga: src/beluga/main.$(EXT)
+	mkdir -p bin
+	cp _build/$< $@
+
+bin/lex_check: src/beluga/lex_check.$(EXT)
 	mkdir -p bin
 	cp _build/$< $@
 

--- a/TEST
+++ b/TEST
@@ -29,7 +29,7 @@ echo -e "\t" BELUGADIR: ${BELUGADIR:=$(dirname $0)}
 echo -e "\t" EXE: ${EXE:=$BELUGADIR/bin/beluga}
 
 # Tool for dumping lexer data.
-echo -e "\t" LEX_DUMP: ${LEX_DUMP:=$BELUGADIR/bin/lex_dump}
+echo -e "\t" LEX_CHECK: ${LEX_CHECK:=$BELUGADIR/bin/lex_check}
 
 # Tool for testing the interactive mode.
 echo -e "\t" REPLAY: ${REPLAY:=$BELUGADIR/bin/replay}
@@ -70,30 +70,6 @@ sort_cases() {
     print -C1 ${(M)cases#*.cfg}
 }
 
-# use lex_dump to calculate where Beluga thinks the file ends.
-beluga-eoi() {
-    # The lex_dump output looks like:
-    # EOI: 21-21
-    $LEX_DUMP "$1" | grep EOI | head -n 1 | cut -d " " -f2 | cut -d "-" -f1
-}
-
-true-eoi() {
-    # wc output looks like:
-    # 21 foo.bel
-    # We use `wc -m` to count *characters* (UTF-8-encoded unicode code
-    # points) so that the thing we're counting here coincides with
-    # Beluga's notion of "character" (i.e. unicode code points, as per
-    # the use of ulex.)
-    LANG=en_US.UTF-8 wc -m "$1" | cut -d " " -f1
-}
-
-lex-check() {
-    local FILE="$1"
-    local BELUGA_COUNT=$(beluga-eoi "$FILE")
-    local TRUE_COUNT=$(true-eoi "$FILE")
-    test $BELUGA_COUNT -eq $TRUE_COUNT
-}
-
 do_testing() {
     local n=0 success=0 fail=0 timeout=0 admissible=0 lexer_fail=0 replay_fail=0
 
@@ -104,7 +80,7 @@ do_testing() {
         n=$((n+1))
         echo -ne "$C[start]**$CEND TEST $n: $i ... "
 
-        if ! lex-check "$i" ; then
+        if ! $LEX_CHECK "$i" ; then
             lexer_fail=$((lexer_fail+1))
             echo -en "$C[lex_fail]LEXER FAILURE$CEND "
         fi

--- a/src/beluga/_tags
+++ b/src/beluga/_tags
@@ -1,1 +1,2 @@
-<replay.ml> : package(extlib)
+<{replay,lex_check}.ml> : package(extlib)
+<lex_check.ml> : package(ulex)

--- a/src/beluga/lex_check.ml
+++ b/src/beluga/lex_check.ml
@@ -1,0 +1,51 @@
+(**
+ * usage: lex_check FILE
+ * synopsis: verifies that the Beluga EOI token appears at the actual
+   end of the input, as measured by counting the Unicode code points
+   in the file.
+   Traditionally, this was done directly in the TEST script (by
+   calling out to wc -m to count code points), but for portability
+   reasons, this is now implemented in OCaml.
+   Exit status:
+     - 0: FILE passes the check
+     - 1: FILE fails the check (diagnose the issue by using lex_dump)
+     - 2: unhandled OCaml exception
+ *)
+
+module Loc = Lexer.Loc
+
+(** From a token stream, finds to location of the EOI token. *)
+let rec find_eoi (s : (Token.t * Loc.t) Stream.t) : Loc.t option =
+  let o =
+    try
+      Some (Stream.next s)
+    with
+    | Stream.Failure -> None
+  in
+  match o with
+  | None -> None
+  | Some (Token.EOI, l) -> Some l
+  | _ -> find_eoi s
+
+
+let passes_check (path : string) : bool =
+  let input = Std.input_file ?bin:(Some true) path in
+  let real_end = Ulexing.from_utf8_string input |> Ulexing.get_buf |> Array.length in
+  let stream = Stream.of_string input in
+  let out = Lexer.mk () (Loc.mk path) stream in
+  match find_eoi out with
+  | None -> false
+  | Some l -> Loc.start_off l = real_end
+
+let main () =
+  match Array.to_list Sys.argv with
+  | [_; path] ->
+     if passes_check path then
+       exit 0
+     else
+       exit 1
+  | _ ->
+     print_string "Invalid number of command-line arguments.\n";
+     exit 1
+
+let _ = main ()


### PR DESCRIPTION
Instead of using `lex_dump` (which generates output suitable for *debugging* lexer issues) only to mangle its output in bash in mysteriously non-portable ways (@pientka tells me that she gets `LEXER FAILURE` errors when running `./TEST` locally), we instead replace this chunk of `./TEST` with a call to a new OCaml program called `lex_check`, which verifies that the number of Unicode code points in a file (as measured by constructing a `Ulexing.lexbuf` for the whole file and getting the buffer's length) matches the location of the `EOI` token generated by processing the file with Beluga's lexer.