### PR TITLE
Fix %:lochole incorrect output for bogus hole identifiers

### DIFF
--- a/src/core/command.ml
+++ b/src/core/command.ml
@@ -147,7 +147,9 @@ let lochole =
              file_name
              start_line start_bol start_off
              stop_line stop_bol stop_off
-        | None -> fprintf ppf "- Error no such hole;\n"
+        | None ->
+           fprintf ppf "- No such hole %s;\n"
+             (Holes.string_of_lookup_strategy strat)
       with
       | Failure s ->
          fprintf ppf "- Error occured when analyzing argument list: %s\n" s)

--- a/src/core/holes.ml
+++ b/src/core/holes.ml
@@ -222,10 +222,10 @@ let by_id (i : hole_id) : lookup_strategy =
   { repr = Printf.sprintf "by id '%d'" i
   ; action =
       fun () ->
-      try
+      if i < DynArray.length holes then
         Some (i, DynArray.get holes i)
-      with
-      | Invalid_argument _ -> None
+      else
+        None
   }
 
 let lookup (name : string) : (hole_id * hole) option =

--- a/t/interactive/53.bel
+++ b/t/interactive/53.bel
@@ -1,0 +1,9 @@
+% A test for issue #53
+rec foo : Bool = ttrue;
+
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:lochole 0
+- No such hole by id '0';
+%:lochole foo
+- No such hole by name 'foo';


### PR DESCRIPTION
Issue #53 is fixed, and a Replay-test is added to guard against this happening again. 