### PR TITLE
Fix 46

### DIFF
--- a/src/core/command.ml
+++ b/src/core/command.ml
@@ -305,24 +305,40 @@ let split =
 let intro =
   { name = "intro"
   ; run = (fun ppf args ->
-    try
-      let strat_s = List.hd args in
-      let strat = Holes.unsafe_parse_lookup_strategy strat_s in
-      match (Interactive.intro strat) with
-      | None -> fprintf ppf "- Nothing to introduce in hole %s;\n" strat_s
-      | Some exp ->
-         let { Holes.cD
-             ; Holes.cG
-             ; _ } =
-           match Holes.get strat with
-           | None -> failwith "No such hole."
-           | Some (_, h) -> h in
-         Pretty.Control.printNormal := true;
-         fprintf ppf "%s;\n" (expChkToString cD cG exp);
-         Pretty.Control.printNormal := false
-    with
-    | Failure s -> fprintf ppf "- Error in intro: %s;\n" s
-    |  _ ->      fprintf ppf "- Error in intro;\n")
+      match args with
+      | [strat_s] ->
+         begin
+           let open Either in
+           Holes.parse_lookup_strategy strat_s |>
+             Maybe.of_option |>
+             of_maybe'
+               (fun () ->
+                 fprintf ppf "- Invalid hole specifier '%s';\n" strat_s) $
+             fun strat ->
+             Holes.get strat |>
+               Maybe.of_option |>
+               of_maybe'
+                 (fun () ->
+                   fprintf ppf "- No such hole %s;\n" (Holes.string_of_lookup_strategy strat)) $
+               fun (i, h) ->
+               let exp = Interactive.intro h in
+               let { Holes.cD;
+                     Holes.cG;
+                     _ } = h
+               in
+               pure
+                 begin
+                   Pretty.Control.printNormal := true;
+                   fprintf ppf "%s;\n" (expChkToString cD cG exp);
+                   Pretty.Control.printNormal := false
+                 end
+         end |>
+           Either.eliminate
+             (fun () -> ())
+             (fun () -> ())
+      | _ ->
+         fprintf ppf "- Invalid command syntax. See help.\n"
+  )
   ; help = "- intro n tries to introduce variables in the nth hole"
   }
 

--- a/src/core/interactive.ml
+++ b/src/core/interactive.ml
@@ -102,92 +102,60 @@ let rec compgctxTogctx ccG = match ccG with
     let cG' = compgctxTogctx ccG' in
     (x,tau,tag)::cG'
 
-
-
-let locCount = ref 0
-
-let locCount () =
-  let e = !locCount in
-  locCount := e + 1;
-  e
-
-let nextLoc loc =
-            let (file_name,
-                 start_line,
-                 _start_bol,
-                 start_off,
-                 stop_line,
-                 stop_bol,
-                 stop_off,
-                 _ghost) = Loc.to_tuple loc in
-            Loc.of_tuple (file_name, start_line, min_int + locCount(), start_off, stop_line, stop_bol, stop_off, true)
-
-
 (* loc -> (LF.mctx * cov_goal * LF.msub) list -> (Comp.typ x LF.msub) -> Comp.branch list *)
 (*  branchCovGoals loc n cG0 tA cgs =
     cD', cD0 |- tA with |cD0| = n
     for all (cD_i , cg_i, ms_i)  in cg,
       cD_i |- ms_i : cD'
 *)
-let branchCovGoals loc i cG0 tau cgs =
-  let loc' = nextLoc loc in
+let branchCovGoals i cG0 tau cgs =
   let f = fun (cD, cg, ms) ->
+    let make_branch patt =
+      Comp.Branch
+        ( Loc.ghost,
+          cD,
+          LF.Empty,
+          patt,
+          ms,
+          Comp.Hole
+            ( Loc.ghost,
+              None,
+              fun () -> failwith "tried to look up fresh hole"
+            )
+        )
+    in
     match cg with
     | Cover.CovCtx cPsi ->
-      (* Printf.printf "CovGoal %s with msub =  %s and i = %s\n"  (P.dctxToString cD cPsi) (P.msubToString cD ms) (string_of_int i); *)
-      Holes.stage
-        { Holes.loc = loc';
-          Holes.name = Holes.Anonymous;
-          Holes.cD = cD;
-          Holes.cG = Whnf.cnormCtx(cG0, ms);
-          Holes.goal = (tau, ms);
-        };
-      let patt = PatMetaObj ( Loc.ghost, (Loc.ghost, LF.CObj cPsi)) in
-      Comp.Branch
-        ( Loc.ghost
-        , cD
-        , LF.Empty
-        , patt
-        , ms
-        , Comp.Hole (loc', None, (fun () -> Holes.at loc' |> Option.get |> fst))
-        )
+       (* Printf.printf "CovGoal %s with msub =  %s and i = %s\n"  (P.dctxToString cD cPsi) (P.msubToString cD ms) (string_of_int i); *)
+       make_branch
+         ( PatMetaObj
+             ( Loc.ghost,
+               ( Loc.ghost,
+                 LF.CObj cPsi
+               )
+             )
+         )
+
     | Cover.CovGoal(cPsi, tR, _tau' ) ->
-      (* Printf.printf "CovGoal: %s \n"  (P.msubToString cD ms); flush stderr; *)
-      (* _tau'  = tau[ms] *)
-      Holes.stage
-        { Holes.loc = loc';
-          Holes.name = Holes.Anonymous;
-          Holes.cD = cD;
-          Holes.cG = Whnf.cnormCtx(cG0, ms);
-          Holes.goal = (tau, ms);
-        };
-      let patt = PatMetaObj ( Loc.ghost, (Loc.ghost, LF.ClObj (Context.dctxToHat cPsi, LF.MObj tR))) in
-      Comp.Branch
-        ( Loc.ghost
-        , cD
-        , LF.Empty
-        , patt
-        , ms
-        , Comp.Hole (loc', None, (fun () -> Holes.at loc' |> Option.get |> fst))
+       (* Printf.printf "CovGoal: %s \n"  (P.msubToString cD ms); flush stderr; *)
+       (* _tau'  = tau[ms] *)
+      make_branch
+        (PatMetaObj
+           ( Loc.ghost,
+             ( Loc.ghost,
+               LF.ClObj
+                 ( Context.dctxToHat cPsi,
+                   LF.MObj tR
+                 )
+             )
+           )
         )
 
     | Cover.CovPatt (cG, patt, (_tau',ms')) ->
-      (* Printf.printf "CovPat %s \n" (P.msubToString cD ms); *)
-       Holes.stage
-         { Holes.loc = loc';
-           Holes.name = Holes.Anonymous;
-           Holes.cD = cD;
-           Holes.cG = gctxToCompgctx cG;
-           Holes.goal = (tau, ms);
-         };
-       Comp.Branch
-         ( Loc.ghost
-         , cD
-         , gctxToCompgctx cG
-         , patt
-         , ms
-         , Comp.Hole (loc', None, (fun () -> Holes.at loc' |> Option.get |> fst))
-         )
+       (* Printf.printf "CovPat %s \n" (P.msubToString cD ms); *)
+       make_branch patt
+    | _ ->
+       failwith "unable to handle coverage goal"
   in
   List.map f cgs
 
@@ -341,70 +309,95 @@ let replaceHole (s : Holes.lookup_strategy) exp =
 
 
 
-(* intro: int -> Comp.exp_chk option *)
 let is_inferred = function
 | LF.Decl(_, ctyp, dep) ->
-    begin match dep with
-      | LF.No -> false
-      | LF.Maybe -> true
-    end
+   begin
+     match dep with
+     | LF.No -> false
+     | LF.Maybe -> true
+   end
 | _ -> false
 
-let  intro (s : Holes.lookup_strategy) =
-  let used = ref false in
+let intro1 (h : Holes.hole) =
+  let { Holes.loc;
+        Holes.name;
+        Holes.cD = cD;
+        Holes.cG = cG;
+        Holes.goal = (tau, mS);
+      } = h
+  in
+  let new_hole =
+    Comp.Hole
+      ( Loc.ghost,
+        None,
+        fun () -> failwith "tried to retrieve fresh hole"
+      )
+  in
+  let gen_var_for_typ =
+    function
+    | Comp.TypBox (l, LF.ClTyp (LF.MTyp tA, psi)) ->
+       Id.mk_name (Id.BVarName (genVarName tA))
+    | Comp.TypBox (l, LF.ClTyp (LF.PTyp tA, psi)) ->
+       Id.mk_name (Id.PVarName (genVarName tA))
+    | _ ->
+       Id.mk_name Id.NoName
+  in
+  (* We can only introduce an argument if the goal type of the hole is
+  a (dependent) function space *)
+  match tau with
+  | Comp.TypArr (t1, t2) ->
+     let v = gen_var_for_typ t1 in
+     Comp.Fn (Loc.ghost, v, new_hole)
+  | Comp.TypPiBox (tdec, t') when not (is_inferred tdec) ->
+     let name = nameOfLFcTypDecl tdec in
+     Comp.MLam (Loc.ghost, name, new_hole)
+  (* Otherwise, we simply reconstruct the original hole. *)
+  | t ->
+     Comp.Hole
+       ( loc,
+         Holes.option_of_name name,
+         fun () -> Holes.at loc |> Option.get |> fst
+       )
+
+(* intro: int -> Comp.exp_chk option *)
+let intro (h : Holes.hole) =
   let { Holes.loc;
         Holes.name;
         Holes.cD = cDT;
         Holes.cG = cGT;
         Holes.goal = (tau, mS);
-      } =
-    match Holes.get s with
-    | None -> failwith "no such hole"
-    | Some (_, h) -> h in
-
-  let rec crawl cD cG  = (function
- | Comp.TypArr (t1,t2) ->
-     ( match t1 with
-     | Comp.TypBox (l, LF.ClTyp (LF.MTyp tA,psi)) ->
-         used := true;
-         let nam = Id.mk_name (Id.BVarName (genVarName tA)) in
-         let Some exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1,false))) t2  in
-         Some (Comp.Fn(l, nam, exp))
-     | Comp.TypBox (l, LF.ClTyp (LF.PTyp tA,psi)) ->
-         used := true;
-         let nam = Id.mk_name (Id.PVarName (genVarName tA)) in
-         let Some exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1,false))) t2  in
-         Some (Comp.Fn(l, nam, exp))
-     | _ ->
-         used := true;
-         let nam = Id.mk_name (Id.NoName) in
-         let Some exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1,false))) t2  in
-         Some (Comp.Fn(Loc.ghost, nam, exp))
-           )
- | Comp.TypPiBox (tdec, t') when not (is_inferred tdec) ->
-     used := true;
-     let nam = nameOfLFcTypDecl tdec in
-     let Some exp = crawl (LF.Dec (cD, tdec)) cG t' in
-     Some (Comp.MLam (Loc.ghost, nam , exp))
- | t ->
-     if !used then
-       let loc' = nextLoc loc in
-       Holes.stage
-         { Holes.loc = loc';
-           Holes.name = Holes.Anonymous;
-           Holes.cD = cD;
-           Holes.cG = cG;
-           Holes.goal = (t, mS);
-         };
-       Some (Comp.Hole  (loc', None, (fun () -> Holes.at loc' |> Option.get |> fst)))
-     else None
-         ) in
+      } = h
+  in
+  let rec crawl cD cG =
+    function
+    | Comp.TypArr (t1,t2) ->
+       begin
+         match t1 with
+         | Comp.TypBox (l, LF.ClTyp (LF.MTyp tA, psi)) ->
+            let nam = Id.mk_name (Id.BVarName (genVarName tA)) in
+            let exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1, false))) t2  in
+            Comp.Fn(l, nam, exp)
+         | Comp.TypBox (l, LF.ClTyp (LF.PTyp tA,psi)) ->
+            let nam = Id.mk_name (Id.PVarName (genVarName tA)) in
+            let exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1, false))) t2 in
+            Comp.Fn(l, nam, exp)
+         | _ ->
+            let nam = Id.mk_name (Id.NoName) in
+            let exp = crawl cD (LF.Dec (cG, Comp.CTypDecl (nam, t1, false))) t2  in
+            Comp.Fn(Loc.ghost, nam, exp)
+       end
+    | Comp.TypPiBox (tdec, t') when not (is_inferred tdec) ->
+       let nam = nameOfLFcTypDecl tdec in
+       let exp = crawl (LF.Dec (cD, tdec)) cG t' in
+       Comp.MLam (Loc.ghost, nam , exp)
+    | t ->
+       Comp.Hole
+         ( Loc.ghost,
+           None,
+           fun () -> failwith "tried to retrieve fresh hole"
+         )
+  in
   crawl cDT cGT tau
-
-
-
-
-
 
 (* search: Int.LF.typ -> string option *)
 
@@ -459,7 +452,7 @@ let genCGoals cD' cd cD_tail =
 
 (* split : String -> Holes.look -> Comp.exp_chk  option *)
 let split (e : string) (hi : Holes.hole_id * Holes.hole) : Comp.exp_chk option =
-  let ( i,
+  let ( hole_id,
         { Holes.loc;
           Holes.name;
           Holes.cD = cD0;
@@ -481,7 +474,7 @@ let split (e : string) (hi : Holes.hole_id * Holes.hole) : Comp.exp_chk option =
            | Comp.TypBox (l, _)
            | Comp.TypBase (l, _, _) -> (* tA:typ, cPsi: dctx *)
               let cgs = Cover.genPatCGoals cD0 (compgctxTogctx cG0) tau [] in
-              let bl = branchCovGoals loc 0 cG0 tau0 cgs in
+              let bl = branchCovGoals 0 cG0 tau0 cgs in
               Some (matchFromPatterns l (Comp.Var(l, i)) bl)
            | Comp.TypClo (tau, t) -> matchTyp (Whnf.cnormCTyp (tau, t))
            | _ ->
@@ -501,7 +494,7 @@ let split (e : string) (hi : Holes.hole_id * Holes.hole) : Comp.exp_chk option =
     | LF.Dec (cD', (LF.Decl (n, mtyp, dep) as cd)) ->
 	     if (Id.string_of_name n) = e then
 	       let cgs = genCGoals cD' cd cD_tail in
-	       let bl  = branchCovGoals loc i cG0 tau0 cgs in
+	       let bl  = branchCovGoals i cG0 tau0 cgs in
 	       let mtyp' = Whnf.cnormMTyp (mtyp, LF.MShift i) in  (* cD0 |- mtyp' *)
 	       let m0  =
            match  mtyp with

--- a/t/interactive/46.bel
+++ b/t/interactive/46.bel
@@ -1,0 +1,24 @@
+tm : type.
+true : tm.
+false : tm.
+if_then_else : tm -> tm -> tm.
+
+rec f : [ |- tm] -> [ |- tm] =
+fn m => ?foo;
+
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:split foo m
+ case m of
+| [ |- true] => ?
+| [ |- false] => ?
+| [ |- if_then_else X Z] => ?
+;
+%:numholes
+1;
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:numholes
+1;


### PR DESCRIPTION
If we stage new holes that are generated (by splitting or by intro),
then we need to eventually commit those holes and delete the holes
they replace. Otherwise, these holes will be become erroneously
committed on the next file load.
Instead, we can simply avoid staging the holes at all. In this case,
the new holes simply exist to be pretty-printed. Indeed, the split and
intro commands simply generate a small chunk of Beluga internal syntax
and pretty-print it; they don't _modify_ the AST of the currently
loaded program.

To pull this off, we have to make an assumption about these so-called
"fresh holes". Recall that the internal syntax `Hole` constructor has
three fields: its location, its name, and a thunk that will compute
the number of the hole.
We can't give a legitimate thunk to compute the hole number, since we
never stage (and hence never commit) the fresh holes. This isn't a
problem though: that thunk will never be evaluated. So we use a thunk
that simply raises an exception.

This fixes #46 which caused bogus hole locations to appear for the new
holes. The specific sequence of events that caused #46 is the
following:
1. Load a file with one hole.
2. Split on that hole.
   Now the problem happens: splitting will generate new holes, which
   will be staged but not committed. Hence, they will just stay in the
   staged holes array until the next %:load command.
3. Load a file. (Doesn't necessarily need to be the same one.)
   When loading a file, only the committed holes are cleared, so the
   staged holes array from before has persisted.
   Holes in the new file are staged during parsing, and once parsing
   completes, all holes are committed, including the fresh holes from
   before. Those holes now have bogus locations since hole locations
   are the only way to uniquely identify holes.

As of this PR, we no longer stage the holes generated by the split or intro commands, and we don't do this
bogus hole location trick to identify the holes anymore. In fact, it
wasn't necessary to identify the fresh holes at all, so we use
exceptions.