### PR TITLE
Fix 46

### DIFF
--- a/src/beluga/main.ml
+++ b/src/beluga/main.ml
@@ -157,8 +157,8 @@ let main () =
           Logic.runLogic ();
           if not (Holes.none ()) && !Debug.chatter != 0 then begin
             printf "\n## Holes: %s  ##" file_name;
-            List.iteri
-              (fun i h ->
+            List.iter
+              (fun (i, h) ->
                 print_string (Holes.format_hole i h);
                 print_newline ())
               (Holes.list ())

--- a/src/core/check.ml
+++ b/src/core/check.ml
@@ -704,13 +704,15 @@ let useIH loc cD cG cIH_opt e2 = match cIH_opt with
 
     | (Hole (loc, name), (tau, t)) ->
 	    Typeinfo.Comp.add loc (Typeinfo.Comp.mk_entry cD ttau) ("Hole" ^ " " ^ Pretty.Int.DefaultPrinter.expChkToString cD cG e);
-	    Holes.stage
-        { Holes.loc = loc;
-          Holes.name = Holes.name_of_option name;
-          Holes.cD;
-          Holes.cG;
-          Holes.goal = (tau, t);
-        };
+	    let _ =
+        Holes.add
+          { Holes.loc = loc;
+            Holes.name = Holes.name_of_option name;
+            Holes.cD;
+            Holes.cG;
+            Holes.goal = (tau, t);
+          }
+      in
 	    ()
 
   and check cD (cG, cIH) e (tau, t) =

--- a/src/core/command.ml
+++ b/src/core/command.ml
@@ -238,19 +238,7 @@ let fill =
             let intexp = Reconstruct.elExp cD cG apxexp tclo in
             (if !Debug.chatter != 0 then fprintf ppf "- Fill: INT done\n");
             Check.Comp.check cD cG intexp tclo; (* checks that exp fits the hole *)
-            let intexp' =
-              Interactive.mapHoleChk
-                (fun _ ll ->
-                  let (i, _) =
-                    match Holes.staged_at ll with
-                    | None -> failwith "No such hole."
-                    | Some h -> h in
-                  let loc' = Interactive.nextLoc loc in
-                  Holes.set_staged_hole_pos i loc';
-                  Synint.Comp.Hole (loc', Holes.option_of_name name)
-                )
-                intexp in (* makes sure that new holes have unique location *)
-            Interactive.replaceHole strat intexp'
+            Interactive.replaceHole strat intexp
           with
           | e ->
              fprintf
@@ -303,14 +291,12 @@ let intro =
          begin
            let open Either in
            Holes.parse_lookup_strategy strat_s |>
-             Maybe.of_option |>
-             of_maybe'
+             of_option'
                (fun () ->
                  fprintf ppf "- Invalid hole specifier '%s';\n" strat_s) $
              fun strat ->
              Holes.get strat |>
-               Maybe.of_option |>
-               of_maybe'
+               of_option'
                  (fun () ->
                    fprintf ppf "- No such hole %s;\n" (Holes.string_of_lookup_strategy strat)) $
                fun (i, h) ->
@@ -443,7 +429,7 @@ let lookup_hole =
     let strat = Holes.unsafe_parse_lookup_strategy (List.hd args) in
     match Holes.get strat with
     | None -> fprintf ppf "- No such hole."
-    | Some (i, _) -> fprintf ppf "%d" i)
+    | Some (i, _) -> fprintf ppf "%s" (Holes.string_of_hole_id i))
   ; help = "looks up a hole's number by its name"
   }
 

--- a/src/core/holes.mli
+++ b/src/core/holes.mli
@@ -1,6 +1,8 @@
 open Syntax.Int
 
-type hole_id = int
+type hole_id
+
+val string_of_hole_id : hole_id -> string
 
 (* Essentially the same as `string option`. *)
 type hole_name =
@@ -56,9 +58,6 @@ val string_of_name : hole_name -> string
 (** Checks whether the internal array of holes is empty. *)
 val none : unit -> bool
 
-(** Stages a new hole. *)
-val stage : hole -> unit
-
 (** Pretty-prints a single hole. *)
 val format_hole : hole_id -> hole -> string
 
@@ -68,9 +67,6 @@ val get : lookup_strategy -> (hole_id * hole) option
 (** Retrieves a single hole using the given strategy,
  * raising NoSuchHole if the hole does not exist. *)
 val unsafe_get : lookup_strategy -> hole_id * hole
-
-(** Finds the first staged hole satisfying the given predicate. *)
-val find_staged : (hole -> bool) -> (int * hole) option
 
 (** Finds the first hole satisfying the given predicate. *)
 val find : (hole -> bool) -> (int * hole) option
@@ -82,7 +78,7 @@ val lookup : string -> (int * hole) option
 val loc_within : Syntax.Loc.t -> Syntax.Loc.t -> bool
 
 (** Gets the number of the hole at the given location. *)
-val at : Syntax.Loc.t -> (int * hole) option
+val at : Syntax.Loc.t -> (hole_id * hole) option
 
 (** Counts the number of holes. *)
 val count : unit -> int
@@ -90,20 +86,11 @@ val count : unit -> int
 (** Removes all holes contained in the given location. *)
 val destroy_holes_within : Syntax.Loc.t -> unit
 
-(** Transfers all staged holes (created via 'stage') to the main hole array. *)
-val commit : unit -> unit
-
-(** Clears all staged holes. *)
-val clear_staged : unit -> unit
-
-(** Gets the staged hole at the given location. *)
-val staged_at : Syntax.Loc.t -> (hole_id * hole) option
-
-(** Set the location of the given staged hole. *)
-val set_staged_hole_pos : hole_id -> Syntax.Loc.t -> unit
+(** Adds a new hole. *)
+val add : hole -> hole_id
 
 (** Clears the main hole array. *)
 val clear : unit -> unit
 
 (** Gets the current list of holes. *)
-val list : unit -> hole list
+val list : unit -> (hole_id * hole) list

--- a/src/core/interactive.ml
+++ b/src/core/interactive.ml
@@ -379,10 +379,7 @@ let intro (h : Holes.hole) =
        let exp = crawl (LF.Dec (cD, tdec)) cG t' in
        Comp.MLam (Loc.ghost, nam , exp)
     | t ->
-       Comp.Hole
-         ( Loc.ghost,
-           None
-         )
+       Comp.Hole (Loc.ghost, None)
   in
   crawl cDT cGT tau
 

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -698,7 +698,6 @@ let recSgnDecls decls =
 	      let _ = match loc_opt with
                 | Some loc -> Holes.destroy_holes_within loc
                 | None -> () in
-              let _ = Holes.commit () in
 		(cid, tau', e_r')::(reconRecFun lf) in
 	  (* For checking totality of mutual recursive functions,
 	     we should check all functions together by creating a variable
@@ -730,7 +729,6 @@ let recSgnDecls decls =
 		  let _ = match loc_opt with
 		    | Some loc -> Holes.destroy_holes_within loc
 		    | None -> () in
-		  let _ = Holes.commit () in
 		  let _ = Total.clear () in
 		  let sgn = Int.Sgn.Rec((cid, tau', e_r')::(reconRecFun lf)) in
 		    Store.Modules.addSgnToCurrent sgn;

--- a/t/interactive/46.bel
+++ b/t/interactive/46.bel
@@ -1,0 +1,24 @@
+tm : type.
+true : tm.
+false : tm.
+if_then_else : tm -> tm -> tm.
+
+rec f : [ |- tm] -> [ |- tm] =
+fn m => ?foo;
+
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:split foo m
+ case m of
+| [ |- true] => ?
+| [ |- false] => ?
+| [ |- if_then_else X Z] => ?
+;
+%:numholes
+1;
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:numholes
+1;


### PR DESCRIPTION
Ultimately, #46 has to do with the fact that holes exist in two states: staged and committed.

This is my understanding of how holes used to work:
* During typechecking, (specifically during conversion from approximate syntax to internal syntax,) holes were *staged*, in which they are added to the array of staged holes in `holes.ml`.
* However, at typechecking time, the index of the hole in the final committed array (hereafter called the hole id) is unknown (since the hole was merely staged) so the hole id cannot be stored inside the Hole node.
* A strategy was adopted to associate Hole nodes in the AST to entries in the committed holes array: rather than store the hole id (which is unknown) inside the node, a *function* of type `unit -> hole_id` was stored inside the hole. This function would be called once the holes were committed and their hole ids finalized.
* How did this function work? Some kind of information would need to be used to uniquely identify the hole in the committed hole array. The uniquely identifying piece of information that was chosen was the *hole location*. The `unit -> hole_id` function would scan the array of committed holes until it found one whose location matched the location of the hole presently being typechecked.
* This strategy is a bad idea for the following reason: what do we do when we need to invent a Hole AST node later? For example, when splitting on a variable at a hole, we need to create holes for each branch of the generated case expression. Each of these Hole AST nodes needs a function `unit -> hole_id`.
* The solution that was adopted was to invent bogus hole locations to ensure that the holes were indeed uniquely identified.
* You'll never believe what happened next: the functions were never called. (Small exception: they were called during pretty-printing just so that the hole number could be displayed in a comment after the hole.)

So this left me with two big questions:

1. Why is there a staged holes array in the first place? The only place it really is interacted with is the `commit` function which transfers staged holes to committed holes.
2. Why use hole locations to identify holes uniquely? This creates big problems when the need arises to create Hole nodes.

Now why *exactly* did #46 happen?

* When interactive mode commands would create new holes, they would *stage* them. So `intro` would stage the new hole it would create to replace the old one and `split` would stage the hole it created for each branch of the split expression.
* These newly staged holes were never committed by the interactive mode commands.
* The load command would clear the committed holes array but not the staged holes array.
* When another file was loaded, those staged holes would be committed during typechecking.
* Since those holes had bogus locations but were otherwise correct (they had the right contexts stored inside them) it looked like the newly generated holes had corrupted positions.

And that's issue #46 in a nutshell.

This was my solution:

* Eliminate staged holes. Instead, holes are directly added to the committed holes array. The distinction between staged and committed holes disappears, and we're simply left with "holes". Much simpler.
* Remove the location-based scheme for identifying holes from AST nodes. This system was essentially unused, so it's better to just forget about it for now. We can implement a less brittle system later if it becomes necessary to associate hole AST nodes with holes in the array. I've already made room for this, by making `Holes.add` return a `hole_id` which is an opaque type (internally an `int`). These ids are presently just indices into the holes array, but they could be something else that would allow us to delete holes from the array without disrupting all the other hole ids.