### PR TITLE
Fix 44

### DIFF
--- a/src/core/interactive.ml
+++ b/src/core/interactive.ml
@@ -461,6 +461,10 @@ let split (e : string) (hi : Holes.hole_id * Holes.hole) : Comp.exp_chk option =
               let bl = branchCovGoals 0 cG0 tau0 cgs in
               Some (matchFromPatterns l (Comp.Var(l, i)) bl)
            | Comp.TypClo (tau, t) -> matchTyp (Whnf.cnormCTyp (tau, t))
+             (* if the type is the type of a variable we're doing
+               induction on, then we can just match the inner type
+              *)
+           | Comp.TypInd tau -> matchTyp tau
            | _ ->
               failwith
                 ( "Found variable in gCtx, cannot split on "

--- a/t/interactive/44.bel
+++ b/t/interactive/44.bel
@@ -1,0 +1,14 @@
+LF tp : type =
+   | nat : tp
+   | bool : tp;
+
+rec f: [⊢ tp] → [⊢ tp] =
+    / total t (f t) /
+    fn t ⇒ ?;
+%:load input.bel
+- The file input.bel has been successfully loaded;
+%:split 0 t
+ case t of
+| [ |- nat] => ?
+| [ |- bool] => ?
+;


### PR DESCRIPTION
#44 is caused by the fact that when a variable is marked as an induction variable, its type is wrapped with the `TypInd` constructor. This case was not handed by the helper function `matchTyp` inside `searchGctx` inside `split` in `interactive.ml` around line 436.

The solution was to simply continue the recursion of `matchTyp` on the smaller type wrapped inside `TypInd`.