### PR TITLE
Fix #68

### DIFF
--- a/src/core/index.ml
+++ b/src/core/index.ml
@@ -173,13 +173,13 @@ and index_typ cvars bvars fvars = function
   | Ext.LF.AtomTerm(loc, n) ->
       begin match n with
         | Ext.LF.TList(loc2,nl) ->
-	    (match  shunting_yard nl with
-	       | Ext.LF.Root(_, Ext.LF.Name(_, a), tS') -> 
-		   index_typ cvars bvars fvars (Ext.LF.Atom (loc, a, tS'))
-	       | Ext.LF.Root(_, _h , _tS)  -> 
-		   raise (Error (loc, IllFormedCompTyp))
-	    )
-
+           begin
+	           match shunting_yard nl with
+	           | Ext.LF.Root(_, Ext.LF.Name(_, a), tS') ->
+		            index_typ cvars bvars fvars (Ext.LF.Atom (loc, a, tS'))
+	           | _ ->
+		            raise (Error (loc, IllFormedCompTyp))
+           end
         | Ext.LF.Root(loc2, Ext.LF.Name(_,name), tS) ->
             index_typ cvars bvars fvars (Ext.LF.Atom(loc2, name, tS))
       end


### PR DESCRIPTION
When indexing types, (translating external syntax into approximate
syntax,) we presently forbid holes from appearing in types.

Generally, types must be written by the user (for `rec` declarations),
in which case putting a hole in the type doesn't make sense. (The body
of a `rec` declaration is a _checkable_ expression, not a
_synthesizable_ expression.)
However, for `let` declarations, the body must have a synthesizable
type, so it intuitively should be possible to use a hole for the type
in order to get Beluga to tell the user what the type is.