### PR TITLE
interactive: process global pragmas in `%:load`

### DIFF
--- a/src/beluga/main.ml
+++ b/src/beluga/main.ml
@@ -113,14 +113,7 @@ let main () =
       try
         let sgn = Parser.parse_file ~name:file_name Parser.sgn in
         (* If the file starts with a global pragma then process it now. *)
-        let rec extract_global_pragmas = function
-          | Synext.Sgn.GlobalPragma(_, Synext.Sgn.NoStrengthen) :: t -> begin Lfrecon.strengthen := false; extract_global_pragmas t end
-          | Synext.Sgn.GlobalPragma(_, Synext.Sgn.Coverage(opt))::t -> begin
-            Coverage.enableCoverage := true;
-            begin match opt with | `Warn -> Coverage.warningOnly := true | `Error -> () end;
-            extract_global_pragmas t end
-          | l -> l in
-        let sgn = extract_global_pragmas sgn in
+        let sgn = Recsgn.apply_global_pragmas sgn in
         if !externall then begin
           if !Debug.chatter != 0 then
             printf "\n## Pretty-printing of the external syntax : ##\n";

--- a/src/core/command.ml
+++ b/src/core/command.ml
@@ -134,6 +134,7 @@ let load =
         (fun ppf arglist ->
 	        let per_file f =
             let sgn = Parser.parse_file ~name:f Parser.sgn in
+            let sgn = Recsgn.apply_global_pragmas sgn in
             let sgn' =
               begin match Recsgn.recSgnDecls sgn with
 	            | sgn', None -> sgn'

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -130,6 +130,21 @@ let sgnDeclToHtml = function
     let _ = Format.pp_set_margin (Format.str_formatter) margin in
     Html.printingHtml := false
 
+let rec apply_global_pragmas =
+  function
+  | Synext.Sgn.GlobalPragma(_, Synext.Sgn.NoStrengthen) :: t ->
+     Lfrecon.strengthen := false;
+     apply_global_pragmas t
+  | Synext.Sgn.GlobalPragma(_, Synext.Sgn.Coverage(opt))::t ->
+     Coverage.enableCoverage := true;
+     begin
+       match opt with
+       | `Warn -> Coverage.warningOnly := true
+       | `Error -> ()
+     end;
+     apply_global_pragmas t
+  | l -> l
+
 let recSgnDecls decls =
   let leftoverVars : leftoverVars ref = ref [] in
   let is_empty = function

--- a/src/core/recsgn.mli
+++ b/src/core/recsgn.mli
@@ -2,6 +2,10 @@ open Syntax
 
 type leftoverVars = (Abstract.free_var Int.LF.ctx * Loc.t) list
 
+(** Processes global pragmas, which must appear at the beginning of
+    the list, and returns the remaining declarations. *)
+val apply_global_pragmas : Syntax.Ext.Sgn.decl list -> Syntax.Ext.Sgn.decl list
+
 val recSgnDecls : Syntax.Ext.Sgn.decl list -> Syntax.Int.Sgn.decl list * leftoverVars option
 
 val print_leftoverVars : leftoverVars -> unit

--- a/t/interactive/96.bel
+++ b/t/interactive/96.bel
@@ -1,0 +1,8 @@
+--nostrengthen
+
+LF tm : type =
+    | u : tm
+;
+
+%:load input.bel
+The file input.bel has been successfully loaded;


### PR DESCRIPTION
* We move the global pragma processing function into `recsgn.ml` and
  rename it to `apply_global_pragmas`.
* The existing code in `main.ml` is refactored to call this function.
* The code in `command.ml` that implements the `%:load` command is
  adjusted to call this function before processing the declaractions
  in the body.

Fixes #96.