### PR TITLE
New interactive test cases

### DIFF
--- a/t/interactive/3.1.bel
+++ b/t/interactive/3.1.bel
@@ -1,0 +1,80 @@
+LF term : type =
+| true : term
+| false : term
+| if_then_else : term -> term -> term -> term
+| z : term
+| succ : term -> term
+| pred : term -> term
+| iszero : term -> term
+;
+
+
+LF value : term -> type =
+| v_zero : value z
+| v_succ : value V -> value (succ V)
+| v_true : value true
+| v_false : value false
+;
+
+LF step: term -> term -> type = 
+| e_if_true   : step (if_then_else true M2 M3) M2
+| e_if_false  : step (if_then_else false M2 M3) M3
+| e_pred_zero : step (pred z) z
+| e_pred_succ : value V -> step (pred (succ V)) V
+| e_iszero_zero	: step (iszero z) true
+| e_iszero_succ	: value V -> step (iszero (succ V)) false
+| e_if_then_else  : step M1 M1' -> step (if_then_else M1 M2 M3) (if_then_else M1' M2 M3)
+| e_succ	  : step M N -> step (succ M) (succ N)
+| e_pred	  : step M N -> step (pred M) (pred N)
+| e_iszero 	  : step M N -> step (iszero M) (iszero N)
+;
+ 
+let e1 : [ |- step (pred (succ ( pred z))) (pred (succ z))] =
+       	     [ |- e_pred (e_succ e_pred_zero)]
+;
+
+LF tp: type =
+   | bool: tp
+   | nat: tp
+;
+
+LF hastype : term -> tp -> type =
+   | t_true : hastype true bool
+   | t_false: hastype false bool
+   | t_zero : hastype z nat
+   | t_if_then_else : hastype M1 bool -> hastype M2 T -> hastype M3 T
+	   -> hastype (if_then_else M1 M2 M3) T
+   | t_succ: hastype M nat -> hastype (succ M) nat
+   | t_pred : hastype M nat -> hastype (pred M) nat
+   | t_iszero : hastype M nat -> hastype (iszero M) bool 
+;
+
+rec tps: [ |- hastype M T] -> [ |- step M N] -> [ |- hastype N T] =
+/ total s (tps m t n d s) /
+  fn d => fn s => ?;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:lochole 0
+("input.bel" 54 1517 1535 54 1517 1536);
+%:numlfholes
+0;
+%:split 0 s
+
+case s of
+| [ |- e_if_true ] => ?
+| [ |- e_if_false ] => ?
+| [ |- e_pred_zero] => ?
+
+| [ |- e_pred_succ Y6] => ?
+| [ |- e_iszero_zero] => ?
+| [ |- e_iszero_succ X5] => ?
+
+| [ |- e_if_then_else Z4] => ?
+| [ |- e_succ Y3] => ?
+| [ |- e_pred Y2] => ?
+
+| [ |- e_iszero Y1] => ?
+;

--- a/t/interactive/test_constructors.bel
+++ b/t/interactive/test_constructors.bel
@@ -1,0 +1,141 @@
+% LFHoles/tps.bel
+
+% Value soundness
+% Author: Brigitte Pientka
+%
+
+tp   : type.   --name tp T.
+nat  : tp.
+arrow  : tp -> tp -> tp.
+
+exp  : type.   --name exp E x.
+z    : exp.
+suc  : exp -> exp.
+match: exp -> exp -> (exp -> exp) -> exp.
+letv : exp -> (exp -> exp) -> exp.  % let x = e1 in e2
+lam  : tp -> (exp -> exp) -> exp.
+app  : exp -> exp -> exp.
+
+
+
+% Evaluation
+eval : exp -> exp -> type.  --name eval F.
+ev_z : eval z z.
+
+ev_s : eval E V -> eval (suc E) (suc V).
+
+ev_m_z: eval (match E E1 (\x. E2 x)) V
+	<- eval E z
+	<- eval E1 V.
+
+ev_m_s: eval (match E E1 (\x. E2 x)) V
+	<- eval E (suc V2)
+	<- eval (E2 V2) V.
+
+ev_l : eval (E2 V1) V  -> eval E1 V1 -> eval (letv E1 (\x. E2 x)) V.
+
+ev_lam: eval (lam T (\x. E x)) (lam T (\x. E x)).
+
+ev_app: eval E1 (lam T (\x. E x)) -> eval E2 V2 -> eval (E V2) V
+     -> eval (app E1 E2) V.
+
+
+% Typing
+
+oft : exp -> tp -> type.  --name oft D u.
+
+tp_z     : oft z nat.
+tp_s     : oft E nat ->
+	   oft (suc E) nat.
+
+tp_match : oft (match E E1 (\x. E2 x)) T
+	 <- oft E nat
+	 <- oft E1 T
+	 <- ({x:exp}oft x nat -> oft (E2 x) T).
+
+tp_lam :   ({x:exp} oft x T1 -> oft (E x) T2)
+        -> oft (lam T1 (\x . E x)) (arrow T1 T2).
+
+tp_app : oft E2 T2 ->
+         oft E1 (arrow T2 T1)
+	 -> oft (app E1 E2) T1.
+
+tp_letv : ({x:exp} oft x T1 -> oft (E2 x) T2) ->
+	   oft E1 T1
+        -> oft (letv E1 (\ x . E2 x)) T2.
+
+% Gives type-checking error, 'Substitution not well-typed'
+
+--query 1 *  D : oft (suc (suc z)) T.
+--query 1 * D : oft (lam T (\x.x)) S.
+--query 1 *  D : oft (letv (suc (suc z)) (\x. app (lam nat (\y.y)) x) ) T.
+--query 1 * D : oft (lam T (\x.x)) S.
+
+--query * 5 P : oft X nat -> oft (suc X) nat.
+
+% Type preservation proof
+rec tps :  [ |- eval E V] -> [ |- oft E T]
+         -> [ |- oft V T]  =
+fn f => fn d => case f of
+| [ |- ev_z] => d
+
+| [ |- ev_s F1]  =>
+  let [ |- tp_s D1] = d in
+  let [ |- C1]      = tps [ |- F1] [ |- D1] in
+  [ |- tp_s C1]
+
+| [ |- ev_m_z F1 F] =>
+  let [ |- tp_match (\x.\u. D2) D1 D] = d   in
+  tps [ |- F1] [ |- D1]
+
+| [ |- ev_m_s F2 F] =>
+  let [ |- tp_match (\x.\u. D2) D1 D] = d   in
+  let [ |- tp_s C]    =   tps [ |- F] [ |- D] in
+  tps [ |- F2] [ |- (D2[_,C])]
+
+| [ |- ev_lam] =>  d
+  %    let [ ] tp_lam (\x. \u. (D x u)) = d in d
+
+
+| [ |- ev_app F1 F2 F3] =>
+  let [ |- tp_app D2 D1]            = d in
+  let [ |- tp_lam \x. \u. D]    = tps [ |- F1] [ |- D1]  in
+  let [ |- C2]                      = tps [ |- F2] [ |- D2]  in
+  tps [ |- F3] [ |- (D[_,C2])]
+
+| [ |- ev_l F2 F1] =>
+  let [ |- tp_letv (\x.\u. D2) D1]     = d in
+  let [ |- C1]                = tps [ |- F1] [ |- D1] in
+    tps [ |- ?] [ |- D2[_,C1]]
+;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+0;
+%:constructors oft
+tp_z : [0] oft z nat
+tp_s : [1] {E : exp}  oft E nat -> oft (suc E) nat
+tp_match : [4] 
+{E2 : {x5 : exp}  exp} 
+ {T : tp} 
+  {E1 : exp} 
+   {E : exp} 
+    ({x : exp}  oft x nat -> oft (E2 x) T) -> oft E1 T -> oft E nat -> oft (match E E1 (\x. E2 x)) T
+tp_lam : [3] 
+{T1 : tp} 
+ {E : {x6 : exp}  exp} 
+  {T2 : tp} 
+   ({x : exp}  oft x T1 -> oft (E x) T2) -> oft (lam T1 (\x. E x)) (arrow T1 T2)
+tp_app : [4] 
+{E2 : exp} 
+ {T2 : tp} 
+  {E1 : exp} 
+   {T1 : tp}  oft E2 T2 -> oft E1 (arrow T2 T1) -> oft (app E1 E2) T1
+tp_letv : [4] 
+{T1 : tp} 
+ {E2 : {x7 : exp}  exp} 
+  {T2 : tp} 
+   {E1 : exp} 
+    ({x : exp}  oft x T1 -> oft (E2 x) T2) -> oft E1 T1 -> oft (letv E1 (\x. E2 x)) T2
+;

--- a/t/interactive/test_fsig.bel
+++ b/t/interactive/test_fsig.bel
@@ -1,0 +1,55 @@
+% caseonpairs-leftovercnstrs.bel
+
+LF tp : type =
+| nat : tp
+| prod : tp -> tp -> tp
+;
+
+LF exp : type =
+| pair : exp -> exp -> exp
+;
+
+LF oft : exp -> tp -> type =
+| oft_pair : oft M1 A -> oft M2 B -> oft (pair M1 M2) (prod A B)
+;
+
+
+LF check : exp -> tp -> type =
+| chk_pair : check M1 A -> check M2 B -> check (pair M1 M2) (prod A B)
+;
+
+schema ctx = some [t:tp] block x:exp, v:oft x t;
+
+LF biDer : exp -> tp -> type =
+| chk : check M T -> biDer M T
+;
+
+--name tp T.
+--name exp M.
+--name oft D.
+--name check C.
+--name biDer B.
+
+rec completenessGood : (g:ctx) [g |- oft M T] -> [g |- biDer M T] =
+fn e => case e of
+| [g |- oft_pair D1 D2] =>
+  (case completenessGood [g |- D1] of
+   | [g |- chk C'] =>
+     (case completenessGood [g |- D2] of
+      | [g |- chk C''] => [g |- chk (chk_pair C' C'')]
+     )
+  )
+;
+
+rec completenessFaulty : (g:ctx) [g |- oft M T] -> [g |- biDer M T] =
+fn e => case e of
+| [g |- oft_pair D1 D2] =>
+  (case (completenessFaulty [g |- D1], completenessFaulty [g |- D2]) of  % [g |- biDer (M[..]) T] * [g |- biDer (N[..]) S]
+   | ([g |- chk C'], [g |- chk C'']) => [g |- chk (chk_pair C' C'')]
+  )
+;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:fsig completenessGood
+completenessGood:    [g |- oft M T] -> [g |- biDer M T];

--- a/t/interactive/test_printhole-lf.bel
+++ b/t/interactive/test_printhole-lf.bel
@@ -1,0 +1,115 @@
+% LFHoles/jpath.bel
+% An example with a 3rd order signature. Proving it's equivalent to a 2nd order
+% definition.
+% Authors: Andrew Cave, Brigitte Pientka
+
+tm: type. --name tm T.
+lam: (tm -> tm) -> tm.
+app: tm -> tm -> tm.
+rdx : (tm -> tm) -> tm -> tm.
+
+path: type. --name path P.
+bind: (path -> path) -> path.
+left: path -> path.
+right: path -> path.
+done: path.
+
+is_path: path -> tm -> type. --name is_path I.
+
+p_lam: is_path (bind P) (lam E)
+       <- ({x:tm}{q:path}is_path q x -> is_path (P q) (E x)).
+
+p_left: is_path (left P) (app M N)
+       <- is_path P M.
+
+p_right: is_path (right P) (app M N)
+       <- is_path P N.
+
+p_done: is_path done M.
+
+p_rdx : ({x:tm} ({q:path} is_path q M -> is_path q x) -> is_path P (F x)) -> is_path P (rdx F M).
+
+jpath : path -> tm -> type.
+jump : tm -> tm -> type.
+
+j_lam: jpath (bind P) (lam E)
+       <- ({x:tm}{q:path} jpath q x -> jpath (P q) (E x)).
+
+j_left: jpath (left P) (app M N)
+       <- jpath P M.
+
+j_right: jpath (right P) (app M N)
+       <- jpath P N.
+
+j_done: jpath done M.
+
+j_rdx : ({x:tm} jump M x -> jpath P (F x)) -> jpath P (rdx F M).
+j_jump : jump N X -> jpath P N -> jpath P X.
+
+schema jctx = block x:tm, p:path, _t:is_path p x, _u:jpath p x
+ + some [n:tm] block x:tm, _t: ({q:path} is_path q n -> is_path q x), _u:jump n x;
+
+rec fwd : (g:jctx) [g |- is_path (P[..]) (M[..])] -> [g |- jpath (P[..]) (M[..])] =
+fn p => case p of
+| [g |- p_lam (\x.\q.\d. P)] =>
+  let [g,b:block x:tm, p:path, _t:is_path p x, _u:jpath p x |-  P'[..,b.1,b.2,b.4]]
+     = fwd [g,b:block x:tm, p:path, _t:is_path p x, _u:jpath p x |-  P[..,b.1,b.2,b.3]] in
+  [g |- j_lam (\x.\q.\d. P')]
+| [g |- p_left (P[..])] => let [g |- P'[..]] = fwd [g |- P[..]] in [g |- j_left (P'[..])]
+| [g |- p_right (P[..])] => let [g |- P'[..]] = fwd [g |- P[..]] in [g |- j_right (P'[..])]
+| [g |- p_done] => [g |- j_done]
+| [g |- p_rdx (\x. \f. P)] : [g |- is_path (Q[..]) (rdx (\x. F) (M[..]))] =>
+  let [g,b:block x:tm, _t: ({q:path} is_path q (N[..]) -> is_path q x), _u:jump (N[..]) x |-  E[..,b.1,b.3]]
+      = fwd [g,b:block x:tm, _t: ({q:path} is_path q (M[..]) -> is_path q x), _u:jump (M[..]) x |-  P[..,b.1,b.2]]
+  in
+    [g |- j_rdx (\x. \j. E)]
+| [g |- #p.3[..]] => [g |- #p.4[..]]
+| {#q : [g |- block x:tm, _t: ({q:path} is_path q (N[..]) -> is_path q x), _u:jump (N[..]) x]}
+  [g |- (#q.2[..]) (P[..]) (D[..])] => 
+  let [g |- J[..]] = fwd [g |- D] in  
+   [g |- j_jump (#q.3[..]) (J[..])]
+;
+
+rec bwd : (g:jctx) [g |- jpath (P[..]) (M[..])] -> [g |- is_path (P[..]) (M[..])] =
+fn p => case p of
+| [g |- j_lam (\x.\q.\d. P)] =>
+  let [g,b:block x:tm, p:path, _t:is_path p x, _u:jpath p x |-  P'[..,b.1,b.2,b.3]]
+     = bwd [g,b:block x:tm, p:path, _t:is_path p x, _u:jpath p x |-  P[..,b.1,b.2,b.4]] in
+  [g |- p_lam (\x.\q.\d. P')]
+| [g |- j_left (P[..])] => let [g |- P'[..]] = bwd [g |- P[..]] in [g |- p_left (P'[..])]
+| [g |- j_right (P[..])] => let [g |- P'[..]] = bwd [g |- P[..]] in [g |- p_right (P'[..])]
+| [g |- j_done] => [g |- p_done]
+| [g |- j_rdx (\x. \f. E)] : [g |- jpath (Q[..]) (rdx (\x. F) (N[..]))] =>
+   let [g, b:block (x:tm, _t: ({q:path} is_path q (N1[..]) -> is_path q x), _u:jump (N1[..]) x) |-  F1[..,b.1,b.2]]
+       = bwd [g, b:block x:tm, _t: ({q:path} is_path q (N[..]) -> is_path q x), _u:jump (N[..]) x |-  E[..,b.1,b.3]] in
+   [g |- p_rdx (\x. \f. F1)]
+| [g |- #p.4[..]] => [g |- #p.3[..]]
+| {#q : [g |- block x:tm, _t: ({q:path} is_path q (N[..]) -> is_path q x), _u:jump (N[..]) x]}
+  {J : [g |- jpath (P1[..]) (N[..])]}
+  [g |- j_jump (#q.3[..]) (J[..])] =>
+   let [g |- H[..]] = bwd [g |- J[..]] in
+   [g |- (#q.2[..]) _ ?]
+;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:countholes
+Computation Level Holes: 0
+LF Level Holes: 1;
+%:printhole-lf 0
+
+File "input.bel", line 91, characters 22-23
+  - Meta-Context: 
+	{g : jctx}
+	{z3 : [g |- path]}
+	{y4 : [g |- tm]}
+	{q : #[g |- block (x:tm, _t:{q : path}  is_path q (y4[ ..]) -> is_path q x, _u:jump (y4[ ..]) x)]}
+	{J : [g |- jpath z3 y4]}
+	{H : [g |- is_path z3 y4]}
+____________________________________________________________________________
+  - LF Context: g
+
+============================================================================
+  - Goal Type: is_path z3 y4
+  - Variable of this type: H
+;

--- a/t/interactive/test_split/deptypes.bel
+++ b/t/interactive/test_split/deptypes.bel
@@ -1,0 +1,19 @@
+nat:type.
+vec: nat -> type.
+z:nat.
+s: nat -> nat.
+nil: vec z.
+cons: nat -> vec N -> vec (s N).
+
+rec head: [ |- vec (s N)] -> [ |- nat] = 
+/ total x (head n x) /
+fn x => case x of [|- cons H T] => ? ;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:split 0 x
+ case x of
+| [ |- cons Y2 X2] => ?
+;

--- a/t/interactive/test_split/meta_3.1.bel
+++ b/t/interactive/test_split/meta_3.1.bel
@@ -1,0 +1,81 @@
+LF term : type =
+| true : term
+| false : term
+| if_then_else : term -> term -> term -> term
+| z : term
+| succ : term -> term
+| pred : term -> term
+| iszero : term -> term
+;
+
+
+LF value : term -> type =
+| v_zero : value z
+| v_succ : value V -> value (succ V)
+| v_true : value true
+| v_false : value false
+;
+
+LF step: term -> term -> type = 
+| e_if_true   : step (if_then_else true M2 M3) M2
+| e_if_false  : step (if_then_else false M2 M3) M3
+| e_pred_zero : step (pred z) z
+| e_pred_succ : value V -> step (pred (succ V)) V
+| e_iszero_zero	: step (iszero z) true
+| e_iszero_succ	: value V -> step (iszero (succ V)) false
+| e_if_then_else  : step M1 M1' -> step (if_then_else M1 M2 M3) (if_then_else M1' M2 M3)
+| e_succ	  : step M N -> step (succ M) (succ N)
+| e_pred	  : step M N -> step (pred M) (pred N)
+| e_iszero 	  : step M N -> step (iszero M) (iszero N)
+;
+ 
+let e1 : [ |- step (pred (succ ( pred z))) (pred (succ z))] =
+       	     [ |- e_pred (e_succ e_pred_zero)]
+;
+
+LF tp: type =
+   | bool: tp
+   | nat: tp
+;
+
+LF hastype : term -> tp -> type =
+   | t_true : hastype true bool
+   | t_false: hastype false bool
+   | t_zero : hastype z nat
+   | t_if_then_else : hastype M1 bool -> hastype M2 T -> hastype M3 T
+	   -> hastype (if_then_else M1 M2 M3) T
+   | t_succ: hastype M nat -> hastype (succ M) nat
+   | t_pred : hastype M nat -> hastype (pred M) nat
+   | t_iszero : hastype M nat -> hastype (iszero M) bool 
+;
+
+rec tps: [ |- hastype M T] -> [ |- step M N] -> [ |- hastype N T] = 
+/ total s (tps m t n d s) /
+  fn d => fn s => ?
+;
+
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:countholes
+Computation Level Holes: 1
+LF Level Holes: 0;
+%:split 0 s
+
+case s of
+| [ |- e_if_true ] => ?
+| [ |- e_if_false ] => ?
+| [ |- e_pred_zero] => ?
+
+| [ |- e_pred_succ Y6] => ?
+| [ |- e_iszero_zero] => ?
+| [ |- e_iszero_succ X5] => ?
+
+| [ |- e_if_then_else Z4] => ?
+| [ |- e_succ Y3] => ?
+| [ |- e_pred Y2] => ?
+
+| [ |- e_iszero Y1] => ?
+;

--- a/t/interactive/test_split/natind.bel
+++ b/t/interactive/test_split/natind.bel
@@ -1,0 +1,23 @@
+inductive Nat : ctype = 
+| Z : Nat
+| S : Nat -> Nat ;
+
+rec test : Nat -> Nat = fn y =>
+ (case y of 
+ | Z   =>   ? 
+ 
+ | S v1   =>   ? 
+ 
+)  ;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+2;
+%:split 1 v1
+ case v1 of
+ | Z  => ?
+ 
+ | S v1  => ?
+ 
+;

--- a/t/interactive/test_split/reconren.bel
+++ b/t/interactive/test_split/reconren.bel
@@ -1,0 +1,24 @@
+tm : type.
+c : tm.
+
+schema ctx = tm;
+
+inductive Foo : (g:ctx) {#W:[g |- # g]}  ctype =
+;
+
+inductive Bar : (g:ctx) {#p:[g |- tm]} ctype =
+;
+
+rec f : Foo [g |- #W[..]] -> Bar [g |- #p[..]] -> Bar [g |- #p[#W[..]]] =
+?
+;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+1;
+%:split 0 g
+ case [g] of
+| [g, x1 : tm] => ?
+| [] => ?
+;

--- a/t/interactive/test_split/sn-full.bel
+++ b/t/interactive/test_split/sn-full.bel
@@ -1,0 +1,239 @@
+% Strong normalization for simply-typed lambda-calculus in Beluga
+
+LF ty : type =
+  | base : ty
+  | arr  : ty -> ty -> ty
+  ;
+--name ty A.
+
+LF tm : ty -> type =
+  | abs : (tm A -> tm B) -> tm (arr A B)
+  | app : tm (arr A B) -> tm A -> tm B
+  ;
+--name tm M.
+
+schema cxt = tm A; % some [a : ty] block tm a;
+
+LF step : tm A -> tm A -> type =
+  | rbeta : step (app (abs M) N) (M N)
+  | rabs  : ({x : tm A} step (M x) (M' x)) -> step (abs M) (abs M')
+  | rappl : step M M' -> step (app M N) (app M' N)
+  | rappr : step N N' -> step (app M N) (app M N')
+  ;
+
+% Lemma: If [ρ]M ⇒ M' then M ⇒ N and M' = [ρ]N.
+
+inductive ExStep : (g1 : cxt) (g2 : cxt)
+  {M : [g1 |- tm A[]]} {#R : [g2 |-# g1]} {M' : [g2 |- tm A[]]} ctype =
+  | Ex : [g1 |- step M N] -> ExStep [g1 |- M] [g2 |- #R] [g2 |- N[#R]]
+  ;
+
+rec invRenStep : {g1 : cxt} {M : [g1 |- tm A[]]} {#R : [g2 |-# g1]}
+    [g2 |- step M[#R] M'] -> ExStep [g1 |- M] [g2 |- #R] [g2 |- M'] =
+
+  % / total m (invRenStep g1 g2 a m) /  %% Totality checker does not see termination
+
+  mlam g1, M, #R => fn s => 
+
+  %% We would like to split on s, but limitations of Beluga force us
+  %% to go the longer route and split on M, such that the renaming
+  %% is pushed inside.
+  case [ g1 |- M ] of
+
+    %% Case application
+    | [g1 |- app M1 M2] =>
+
+      % Cannot reconstruct type:
+      % let ih : {#R : [g2 |-# g1]}  [g2 |- step (M1[#R]) M'] ->
+      %          ExStep [g1 |- M] [g2 |- #R] [g2 |- M']
+      %        = invRenStep [g1] [g1 |- M1] in
+
+      %% We case on the function part.
+      (case [g1 |- M1] of
+
+      %% Case beta-redex
+      | [g1 |- abs \ x. M1'] => (case s of
+        %% We either contract the beta-redex...
+        | [g2 |- rbeta] => Ex [g1 |- rbeta]
+        %% ... or reduce in the left or right subterm
+        | [g2 |- rappl S] => 
+            %% Totality checker complains here:
+            let Ex [g1 |- S'] = % ih [g2 |- #R] [g2 |- S]
+              invRenStep [g1] [g1 |- M1] [g2 |- #R] [g2 |- S]
+            in  Ex [g1 |- rappl S' ]
+        | [g2 |- rappr S] => 
+            %% Totality checker complains here:
+            let Ex [g1 |- S'] = invRenStep [g1] [g1 |- M2]  [g2 |- #R] [g2 |- S]
+            in  Ex [g1 |- rappr S' ]
+        )
+
+      %% Case not beta-redex
+      | [g1 |- M1] => (case s of
+        %% We either reduce in the left subterm ...
+        | [g2 |- rappl S] =>
+            let Ex [g1 |- S'] = invRenStep [g1] [g1 |- M1] [g2 |- #R] [g2 |- S]
+            in  Ex [g1 |- rappl S' ]
+        %% ... or in the right subterm.
+        | [g2 |- rappr S] =>
+            let Ex [g1 |- S'] = invRenStep [g1] [g1 |- M2] [g2 |- #R] [g2 |- S]
+            in  Ex [g1 |- rappr S' ]
+        )
+      )
+
+    %% Case abstraction: reduction is in function body.
+    | [g1 |- abs \x. M1] => let [g2 |- rabs \y. S] = s in
+          let Ex [g1, x : tm A[] |- S'] =
+            invRenStep [g1, x : tm _]
+              [g1, x : tm _ |- M1] [g2, x : tm _ |- #R[..], x] [g2, y : tm _ |- S ] in
+          Ex [g1 |- rabs \x. S']
+
+    % Case variable: does not reduce
+    | [g1 |- #p ] => impossible s
+  ;
+
+inductive SN : (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | Acc : ({M' : [ g |- tm A[] ]} [ g |- step M M' ] -> SN [ g |- M' ])
+        -> SN [ g |- M ]
+  ;
+
+% Lemma: closure of SN under renaming.
+%
+% Let Γ₂ ⊢ ρ : Γ₁.
+% If Γ₁ ⊢ M ∈ SN then Γ₂ ⊢ [ρ]M ∈ SN.
+% By induction on M ∈ SN.
+% We show [ρ]M ∈ SN by assuming [ρ]M ⇒ M' and proving M' ∈ SN.
+% Assume [ρ]M ⇒ M'.
+% Then M ⇒ N with M' = [ρ]N.
+% By IH on N ∈ SN, [ρ]N ∈ SN, thus, M' ∈ SN.
+% QED.
+
+rec renSN : {g2 : cxt} {#R : [g2 |-# g1]} {M : [g1 |- tm A[]]}
+       SN [g1 |- M]
+    -> SN [g2 |- M[#R]] =
+  % / total s (renSN g1 g2 a r m s) /  %% Totality checker not prepared for wf-induction.
+  mlam g2, #R, M => fn s => let s : SN [g1 |- M] = s in
+    case s of
+    | Acc f => Acc (mlam M' => fn r =>
+        let Ex [g1 |- S] = invRenStep [g1] [g1 |- M] [g2 |- #R] r
+        in  renSN [g2] [g2 |- #R] [g1 |- _] (f [g1 |- _] [g1 |- S])
+      )
+  ;
+
+stratified Red : {A : [ |- ty ]} (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | RBase : SN [g |- M] -> Red [ |- base ] [g |- M]
+  | RArr  : ({g' : cxt} {#S : [g' |-# g]} {N : [g' |- tm A[]]}
+               Red [|- A] [g' |- N]
+            -> Red [|- B] [g' |- app M[#S] N])
+         -> Red [ |- arr A B ] [g |- M]
+  ;
+
+% Corollary: closure under weak head expansion
+
+rec whExp : Red [|- A] [g |- M [.., N] ]
+         -> Red [|- A] [g |- (app (abs \ x. M) N)] =
+  ?
+  ;
+
+inductive RedS : {g : cxt} (g' : cxt) {#S : [g' |- g]} ctype =
+  | RNil  : RedS [] [ g' |- ^ ]
+  | RCons : Red [|- A] [g' |- M]
+         -> RedS [g] [g' |- #S]
+         -> RedS [g, x : tm A[]] [g' |- #S, M]
+  ;
+
+%% Closure of Red under renaming
+%% (uses closure of SN under renaming and Kripke definition)
+
+rec renRed : {g2 : cxt} {#R : [g2 |-# g1]}
+       Red [|- A[]] [g1 |- M]
+    -> Red [|- A[]] [g2 |- M[#R]] =
+  mlam g2, #R => fn r =>
+  let r : Red [|- A[]] [g1 |- M] = r in
+  case r of
+    | RBase s => RBase (renSN [g2] [g2 |- #R] [g1 |- M] s)
+    | RArr  f => RArr (mlam g', #R', N => fn r => f [g'] [g' |- #R[#R']] [g' |- N] r)
+  ;
+
+%% Closure of RedS under renaming (pointwise from Red)
+
+rec renRedS : {g2 : cxt} {#R : [g2 |-# g1]}
+       RedS [g] [g1 |- #S    ]
+    -> RedS [g] [g2 |- #S[#R]] =
+  mlam g2, #R => fn s => case s of
+    | RNil       => RNil
+    | RCons r s' => RCons (renRed  [g2] [g2 |- #R] r)
+                          (renRedS [g2] [g2 |- #R] s')
+  ;
+
+%% Lemmata for fundamental theorem
+
+%% Variable case
+
+rec fundVar : {g : cxt} {#p : [g |- tm A[]]}
+          RedS [g] [g' |- #S]
+       -> Red [|- A] [g' |- #p[#S]] =
+  / total g (fundVar g) /
+  mlam g, #p => fn s => case [g] of
+    | [] => impossible [ |- #p ]
+    | [g, x : tm A[]] => case [g, x : tm _ |- #p] of
+      | [g, x : tm A[] |- x     ] => let RCons r s' = s in r
+      | [g, x : tm A[] |- #q[..]] => let RCons r s' = s in fundVar [g] [g |- #q] s'
+  ;
+
+%% Application
+
+rec fundApp : %% {g : cxt} {M : [g |- tm (arr A[] B[])]} {N : [g |- tm A}
+          Red [|- arr A B ] [g |- M ]
+       -> Red [|- A]        [g |- N ]
+       -> Red [|- B]        [g |- app M N ] =
+  fn r, s => let s : Red [|- B] [g |- N] = s in   %% fake match to bind g and N
+    let RArr f = r in
+    f [g] [ g |- .. ] [g |- N] s
+  ;
+
+%% Abstraction
+
+%% rec fundAbs : Red
+
+%% Fundamental theorem
+
+rec thm : {g : cxt} {M : [g |- tm A[]]}
+          RedS [g] [g' |- #S0]
+       -> Red [|- A] [g' |- M[#S0]] =
+  mlam g, M => fn s =>
+  case [g |- M ] of
+  | [g |- #p ]         =>  fundVar [g] [g |- #p] s
+  | {M : [g, x : tm A[] |- tm B[]]} [g |- abs \ x. M ] =>
+      RArr (mlam g', #S, N => fn r => ?)
+%        whExp ?) % (thm [g, x : tm A[]] [g, x : tm A[] |- M] (RCons r (renRedS [g'] [g' |- #S] s))))
+  | [g |- app M N    ] =>  fundApp (thm [g] [g |- M] s) (thm [g] [g |- N] s)
+  ;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:countholes
+Computation Level Holes: 2
+LF Level Holes: 0;
+%:numholes
+2;
+%:split 0 g
+ case [g] of
+| [g, x1 : tm A] => ?
+| [] => ?
+;
+%:split 0 M
+
+case [g, y59 |- M] of
+| [g, x59 |- #p2[ ..]] => ?
+| [g, z59 |- z59] => ?
+
+| [g, y60 |- abs (\x1. M8)] => ?
+| [g, x60 |- app M6 M7] => ?
+;
+%:split 0 N
+
+case [g |- N] of
+| [g |- #p3] => ?
+| [g |- abs (\x1. M11)] => ?
+| [g |- app M9 M10] => ?
+;

--- a/t/interactive/test_split/sn.bel
+++ b/t/interactive/test_split/sn.bel
@@ -1,0 +1,116 @@
+% 2017-05-02
+% Strong normalization for simply-typed lambda-calculus in Beluga
+
+LF ty : type =
+  | base : ty
+  | arr  : ty -> ty -> ty
+  ;
+--name ty A.
+
+LF tm : ty -> type =
+  | abs : (tm A -> tm B) -> tm (arr A B)
+  | app : tm (arr A B) -> tm A -> tm B
+  ;
+--name tm M.
+
+% ==> : tm A -> tm A -> type.
+% --infix ==> 1 none.
+
+% rbeta : (app (abs M) N) ==> (M N).
+%   % | rabs  : ({x : tm A} (M x) ==> (M' x)) -> (abs M) ==> (abs M')
+
+LF step : tm A -> tm A -> type =
+  | rbeta : step (app (abs M) N) (M N)
+  | rabs  : ({x : tm A} step (M x) (M' x)) -> step (abs M) (abs M')
+  | rappl : step M M' -> step (app M N) (app M' N)
+  | rappr : step N N' -> step (app M N) (app M N')
+  ;
+
+schema cxt = tm A; % some [a : ty] block tm a;
+
+inductive SN : (g : cxt) {M : [ g |- tm A ]} ctype =
+  | Acc : ({M' : [ g |- tm A ]} [ g |- step M M' ] -> SN [ g |- M' ])
+        -> SN [ g |- M ]
+  ;
+
+stratified Red : {A : [ |- ty ]} (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | RBase : SN [g |- M] -> Red [ |- base ] [g |- M]
+  | RArr  : ({g' : cxt} {#S : [g' |-# g]} {N : [g' |- tm A[]]}
+               Red [|- A] [g' |- N]
+            -> Red [|- B] [g' |- app M[#S] N])
+         -> Red [ |- arr A B ] [g |- M]
+  ;
+
+inductive RedS : {g : cxt} (g' : cxt) {#S : [g' |- g]} ctype =
+  | RNil  : RedS [] [ g' |- ^ ]
+  | RCons : Red [|- A] [g' |- M]
+         -> RedS [g] [g' |- #S]
+         -> RedS [g, x : tm A[]] [g' |- #S, M]
+  ;
+
+%% Lemmata for fundamental theorem
+
+rec fundVar : {g : cxt} {M : [g |- tm A[]]}
+          RedS [g] [g' |- #S]
+       -> Red [|- A] [g' |- M[#S]] =
+/ total r (fundVar g g' a s m r) /
+ mlam g, M => fn r => 
+ (case r of 
+ | RNil   =>   ? 
+
+)
+
+;
+%{
+rec fundVar : {g : cxt} {#p : [g |- tm A[]]}
+          RedS [g] [g' |- #S]
+       -> Red [|- A] [g' |- #p[#S]] =
+% / total s (fundVar g g' A s 
+ mlam g, #p => fn s => ?
+ 
+
+
+%{case s of
+    | RNil       => impossible [ |- # p ]
+    | RCons r s' => ?
+}%
+  ;
+}%
+%% Fundamental theorem
+
+
+rec thm : {g : cxt} {M : [g |- tm A[]]}
+% g, g', A, #S, M
+          RedS [g] [g' |- #S]
+       -> Red [|- A] [g' |- M[#S]] =
+    mlam g, M => fn s => (case [g |- M] of 
+
+|  [g |- #p1] =>  ?  
+
+|  [g |- abs (\x1. M3)] =>  ?  
+
+|  [g |- app M1 M2] =>  ?  
+)   
+%{ (case [g |- M ] of
+ | [g |- #p1 ] =>  ?
+ | [g |- abs \ x. M1 ] =>  ?
+ | [g |- app M2 M3 ] =>  ?
+)
+}%
+  ;
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:countholes
+Computation Level Holes: 4
+LF Level Holes: 0;
+%:split 1 g
+ case [g] of
+| [g, x1 : tm A] => ?
+| [] => ?
+;
+%:split 2 g
+ case [g] of
+| [g, x2 : tm A] => ?
+| [] => ?
+;

--- a/t/interactive/test_split/sn2.bel
+++ b/t/interactive/test_split/sn2.bel
@@ -1,0 +1,114 @@
+
+LF ty : type =
+  | base : ty
+  | arr  : ty -> ty -> ty
+  ;
+--name ty A.
+
+LF tm : ty -> type =
+  | abs : (tm A -> tm B) -> tm (arr A B)
+  | app : tm (arr A B) -> tm A -> tm B
+  ;
+--name tm M.
+
+schema cxt = tm A; % some [a : ty] block tm a;
+
+LF step : tm A -> tm A -> type =
+  | rbeta : step (app (abs M) N) (M N)
+  | rabs  : ({x : tm A} step (M x) (M' x)) -> step (abs M) (abs M')
+  | rappl : step M M' -> step (app M N) (app M' N)
+  | rappr : step N N' -> step (app M N) (app M N')
+  ;
+
+% Lemma: If [ρ]M ⇒ M' then M ⇒ N and M' = [ρ]N.
+
+inductive ExStep : (g1 : cxt) (g2 : cxt)
+  {M : [g1 |- tm A[]]} {#R : [g2 |-# g1]} {M' : [g2 |- tm A[]]} ctype =
+  | Ex : [g1 |- step M N] -> ExStep [g1 |- M] [g2 |- #R] [g2 |- N[#R]]
+  ;
+
+inductive SN : (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | Acc : ({M' : [ g |- tm A[] ]} [ g |- step M M' ] -> SN [ g |- M' ])
+        -> SN [ g |- M ]
+  ;
+
+stratified Red : {A : [ |- ty ]} (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | RBase : SN [g |- M] -> Red [ |- base ] [g |- M]
+  | RArr  : ({g' : cxt} {#S : [g' |-# g]} {N : [g' |- tm A[]]}
+               Red [|- A] [g' |- N]
+            -> Red [|- B] [g' |- app M[#S] N])
+         -> Red [ |- arr A B ] [g |- M]
+  ;
+
+
+inductive RedS : {g : cxt} (g' : cxt) {#S : [g' |- g]} ctype =
+  | RNil  : RedS [] [ g' |- ^ ]
+  | RCons : Red [|- A] [g' |- M]
+         -> RedS [g] [g' |- #S]
+         -> RedS [g, x : tm A[]] [g' |- #S, M]
+  ;
+%
+%% Abstraction
+
+%% rec fundAbs : Red
+
+rec whExp : Red [|- A] [g |- M [.., N] ] 
+         -> Red [|- A] [g |- (app (abs \ x. M) N)] =
+  ?
+  ;
+
+%% Fundamental theorem
+
+rec thm : {g : cxt} {M : [g |- tm A[]]}
+          RedS [g] [g' |- #S0]
+       -> Red [|- A] [g' |- M[#S0]] =
+  mlam g, M => fn s =>
+  case [g |- M ] of
+%%  | [g |- #p ]         =>  fundVar [g] [g |- #p] s
+  | {M : [g, x : tm A[] |- tm B[]]} [g |- abs \ x. M ] =>
+      RArr (mlam g', #S, N => fn r => ?)
+%%        whExp ?) % (thm [g, x : tm A[]] [g, x : tm A[] |- M] (RCons r (renRedS [g'] [g' |- #S] s))))
+%%  | [g |- app M N    ] =>  fundApp (thm [g] [g |- M] s) (thm [g] [g |- N] s)
+  ;
+
+%{
+Entry S displays B, but should display g as source context for the renaming.
+
+Hole Number 1
+File "/home/abel/play/beluga/sn.bel", line 208, characters 38-39
+________________________________________________________________________________
+    - Meta-Context: 
+	{g : cxt}
+	{A : [ |- ty]}
+	{B : [ |- ty]}
+	{M : [g, x : tm A |- tm B]}
+	{g' : cxt}
+	{S : [g' |- #  B]}
+	{N : [g' |- tm A]}
+_______________________________________
+}%
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:countholes
+Computation Level Holes: 2
+LF Level Holes: 0;
+%:split 0 N
+
+case [g |- N] of
+| [g |- #p1] => ?
+| [g |- abs (\x1. M4)] => ?
+| [g |- app M2 M3] => ?
+;
+%:split 1 g'
+ case [g'] of
+| [g', x2 : tm A] => ?
+| [] => ?
+;
+%:split 1 N
+
+case [g' |- N] of
+| [g' |- #p3] => ?
+| [g' |- abs (\x1. M7)] => ?
+| [g' |- app M5 M6] => ?
+;

--- a/t/interactive/test_split/sn3.bel
+++ b/t/interactive/test_split/sn3.bel
@@ -1,0 +1,141 @@
+% Strong normalization for simply-typed lambda-calculus in Beluga
+
+LF ty : type =
+  | base : ty
+  | arr  : ty -> ty -> ty
+  ;
+--name ty A.
+
+LF tm : ty -> type =
+  | abs : (tm A -> tm B) -> tm (arr A B)
+  | app : tm (arr A B) -> tm A -> tm B
+  ;
+--name tm M.
+
+LF step : tm A -> tm A -> type =
+  | rbeta : step (app (abs M) N) (M N)
+  | rabs  : ({x : tm A} step (M x) (M' x)) -> step (abs M) (abs M')
+  | rappl : step M M' -> step (app M N) (app M' N)
+  | rappr : step N N' -> step (app M N) (app M N')
+  ;
+
+schema cxt = tm A; % some [a : ty] block tm a;
+
+inductive SN : (g : cxt) {M : [ g |- tm A ]} ctype =
+  | Acc : ({M' : [ g |- tm A ]} [ g |- step M M' ] -> SN [ g |- M' ])
+        -> SN [ g |- M ]
+  ;
+
+stratified Red : {A : [ |- ty ]} (g : cxt) {M : [ g |- tm A[] ]} ctype =
+  | RBase : SN [g |- M] -> Red [ |- base ] [g |- M]
+  | RArr  : ({g' : cxt} {#S : [g' |-# g]} {N : [g' |- tm A[]]}
+               Red [|- A] [g' |- N]
+            -> Red [|- B] [g' |- app M[#S] N])
+         -> Red [ |- arr A B ] [g |- M]
+  ;
+
+% Corollary: closure under weak head expansion
+
+rec whExp : Red [|- A] [g |- M [.., N] ] 
+         -> Red [|- A] [g |- (app (abs \ x. M) N)] =
+  ?
+  ;
+
+inductive RedS : {g : cxt} (g' : cxt) {#S : [g' |- g]} ctype =
+  | RNil  : RedS [] [ g' |- ^ ]
+  | RCons : Red [|- A] [g' |- M]
+         -> RedS [g] [g' |- #S]
+         -> RedS [g, x : tm A[]] [g' |- #S, M]
+  ;
+
+%% Lemmata for fundamental theorem
+
+%% Variable case
+
+rec fundVar : {g : cxt} {#p : [g |- tm A[]]}
+          RedS [g] [g' |- #S]
+       -> Red [|- A] [g' |- #p[#S]] =
+  / total g (fundVar g) /
+  mlam g, #p => fn s => case [g] of
+    | [] => impossible [ |- #p ]
+    | [g, x : tm A[]] => case [g, x : tm _ |- #p] of
+      | [g, x : tm A[] |- x     ] => let RCons r s' = s in r
+      | [g, x : tm A[] |- #q[..]] => let RCons r s' = s in fundVar [g] [g |- #q] s'
+  ;
+
+%% Application
+
+rec fundApp : %% {g : cxt} {M : [g |- tm (arr A[] B[])]} {N : [g |- tm A}
+          Red [|- arr A B ] [g |- M ]
+       -> Red [|- A]        [g |- N ]
+       -> Red [|- B]        [g |- app M N ] =
+  fn r, s => let s : Red [|- B] [g |- N] = s in   %% fake match to bind g and N
+    let RArr f = r in 
+    f [g] [ g |- .. ] [g |- N] s
+  ;
+
+%% Abstraction
+
+%% rec fundAbs : Red 
+
+%% Fundamental theorem
+
+rec thm : {g : cxt} {M : [g |- tm A[]]}
+          RedS [g] [g' |- #S0]
+       -> Red [|- A] [g' |- M[#S0]] =
+  mlam g, M => fn s =>
+  case [g |- M ] of
+  | [g |- #p ]         =>  fundVar [g] [g |- #p] s
+  | [g |- abs \ x. M ] =>  RArr (mlam g', #S, N => fn r => whExp (thm [g, x : tm _] [g, x : tm _ |- M] ?))
+  | [g |- app M N    ] =>  fundApp (thm [g] [g |- M] s) (thm [g] [g |- N] s)
+  ;
+
+%{
+Uncaught exception.
+Please report this as a bug.
+
+## Type Reconstruction: /home/abel/play/beluga/sn.bel ##
+Unify.Make(T).GlobalCnstrFailure(_, "abs (\\x. M[ #S0[#S[..]], x]) =/= abs (\\x. M[ #S0[#S[..]], x])")
+
+@andreasabel
+andreasabel commented 7 days ago
+
+Maybe connected to #38?
+@pientka
+
+Attach files by dragging & dropping,
+
+, or pasting from the clipboard.
+Styling with Markdown is supported
+}%
+
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:numholes
+2;
+%:split 0 g
+ case [g] of
+| [g, x1 : tm A] => ?
+| [] => ?
+;
+%:split 0 N
+
+case [g |- N] of
+| [g |- #p2] => ?
+| [g |- abs (\x1. M6)] => ?
+| [g |- app M4 M5] => ?
+;
+%:split 1 M
+
+case [g, x25 |- M] of
+| [g, z25 |- #p3[ ..]] => ?
+| [g, y26 |- y26] => ?
+
+| [g, x26 |- abs (\x1. M9)] => ?
+| [g, z26 |- app M7 M8] => ?
+;
+%:split 1 g
+ case [g] of
+| [g, x4 : tm A] => ?
+| [] => ?
+;


### PR DESCRIPTION
The "\t\interactive" folder contains 
- a folder called "test_split" folder contains test cases where the split command was used, and
-  files named "test_"+command_name to test the corresponding interactive command. 

All these tests passed the TEST. 

There is branch here where I store files that would test the other interactive commands but using the current TEST file they fail on it. https://github.com/szilviagyapay/Beluga/tree/Failing_interactive_test_cases/failed_interactive_test_cases
