### PR TITLE
Improved LF solver

### DIFF
--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -1,8 +1,27 @@
 open Syntax.Int
 
+type goal
+type query
+
 module Options :
 sig
   val enableLogic : bool ref
+end
+
+module Convert :
+sig
+  val typToQuery : LF.dctx -> LF.mctx -> (LF.typ * Id.offset) ->
+                   query * LF.typ * LF.sub * (Id.name * LF.normal) list
+end
+
+module Frontend :
+sig
+  exception Done
+end
+
+module Solver :
+sig
+  val solve : LF.mctx -> LF.dctx -> query -> (LF.dctx * LF.normal -> unit) -> unit
 end
 
 type bound = int option
@@ -10,3 +29,7 @@ type bound = int option
 val storeQuery : Id.name option -> LF.typ * Id.offset -> bound -> bound -> unit
 val runLogic : unit -> unit
 val runLogicOn : Id.name option -> LF.typ * Id.offset -> bound -> bound -> unit
+(** Clears the local storage of the logic programming engine,
+ * and loads the LF signature.
+ *)
+val prepare : unit -> unit

--- a/src/core/unify.ml
+++ b/src/core/unify.ml
@@ -374,15 +374,25 @@ let isVar h = match h with
     let _ = mark  () in
       try f () with
         | NotInvertible ->
-            (dprint (fun () -> "Unwind trail - exception     notInvertible") ;
-             unwind (); raise NotInvertible)
-        | Failure msg -> (dprint (fun () -> "Unwind trail - exception Failure " ^
-     msg);unwind (); raise (Failure msg))
-        | Error msg -> (dprint (fun () -> "Unwind trail - exception Error " ^
-     msg);unwind (); raise (Error msg))
-        | GlobalCnstrFailure (loc , msg) -> (dprint (fun () -> "Unwind trail - exception GlobalCnstrFailure " ^
-     msg);unwind (); raise (GlobalCnstrFailure (loc, msg)))
-        | e -> (dprint (fun () -> "?? " ) ; unwind (); raise e )
+           dprint (fun () -> "Unwind trail - exception     notInvertible");
+           unwind ();
+           raise NotInvertible
+        | Failure msg ->
+           dprint (fun () -> "Unwind trail - exception Failure " ^ msg);
+            unwind ();
+            raise (Failure msg)
+        | Error msg ->
+           dprint (fun () -> "Unwind trail - exception Error " ^ msg);
+           unwind ();
+           raise (Error msg)
+        | GlobalCnstrFailure (loc , msg) ->
+           dprint (fun () -> "Unwind trail - exception GlobalCnstrFailure " ^ msg);
+           unwind ();
+           raise (GlobalCnstrFailure (loc, msg))
+        | e ->
+           dprint (fun () -> "?? " );
+           unwind ();
+           raise e 
 
   (* ---------------------------------------------------------------------- *)
 

--- a/t/interactive/logic-programming/1.bel
+++ b/t/interactive/logic-programming/1.bel
@@ -1,0 +1,20 @@
+tp : type.
+arr : tp → tp → tp.
+--name tp A.
+
+tm : type.
+lam : (tm → tm) → tm.
+--name tm M.
+
+oft : tm → tp → type.
+t_lam : ({x : tm} oft x A → oft (M x) B) → oft (lam M) (arr A B).
+
+rec copy : [ ⊢ oft M A ] → [ ⊢ oft M A ] =
+fn d ⇒ case d of
+    [ ⊢ t_lam \x. \u. D ] ⇒ [ ⊢ ?a ]
+;
+%:load input.bel
+The file input.bel has been successfully loaded;
+%:solve-lf-hole a
+t_lam (\x. \x2. D)
+;


### PR DESCRIPTION
I improve on the solver in `logic.ml` implemented by Costin with the following contributions:
1. I added meta-context search: a meta-context `cD` is propagated through the solver and is searched for variables that could solve the goal. (What is a meta-context? Consider a code fragment such as `let [ |- E ] = e in [ |- ?a ]`. The meta-context at the hole `a` contains the metavariable `E` introduced by the let-box construct.)
2. I added sigma-type projection search: the meta-context can contain parameter variables, for which it is necessary to try all the projections. Parameter variables begin with a `#`, e.g. `let [ |- #p ] = d in [ |- ?a ]`. Perhaps `#p` is a block, i.e. an n-ary (dependent) tuple. The solver now searches through this tuple for solutions.