### PR TITLE
Add a command to control auto tactics

### DIFF
--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -523,6 +523,10 @@ module Automation = struct
       else auto_nothing
     in
     filter_auto (Hashtbl.find auto_st automation_kind)
+
+  let toggle_automation auto_st automation_kind : unit =
+    let (b, _) = Hashtbl.find auto_st automation_kind in
+    b := not !b
 end
 
 module Prover = struct
@@ -665,6 +669,9 @@ module Prover = struct
        Format.fprintf ppf "There are %d IHs:@,"
          (Context.length g.context.cIH);
        Context.to_list g.context.cIH |> List.iteri f
+
+    | Command.ToggleAutomation automation_kind ->
+       Automation.toggle_automation s.automation_state automation_kind
 
     (* Real tactics: *)
     | Command.Unbox (t, name) ->

--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -517,12 +517,10 @@ module Automation = struct
     hashtbl
 
   let get_automation auto_st automation_kind : t =
-    let filter_auto (cond, auto) : t =
-      if !cond
-      then auto
-      else auto_nothing
-    in
-    filter_auto (Hashtbl.find auto_st automation_kind)
+    let (b, auto) = Hashtbl.find auto_st automation_kind in
+    if !b
+    then auto
+    else auto_nothing
 
   let toggle_automation auto_st automation_kind : unit =
     let (b, _) = Hashtbl.find auto_st automation_kind in

--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -564,13 +564,12 @@ module Prover = struct
       Some (DynArray.get gs (current_subgoal_index gs))
 
   let add_subgoal_hook s g tctx =
-    let open Automation in
     let auto_st = s.automation_state in
     ignore
       (List.exists
          (fun f -> f g tctx)
-         [ get_automation auto_st `auto_solve_trivial
-         ; get_automation auto_st `auto_intros
+         [ Automation.get_automation auto_st `auto_solve_trivial
+         ; Automation.get_automation auto_st `auto_intros
          ]
       )
 

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2743,6 +2743,17 @@ let harpoon_command =
         (keyword "as" &> name)
     $> fun (t, name) -> H.Unbox (t, name)
   in
+  let automation_kind =
+    choice
+      [ keyword "auto-intros" &> pure `auto_intros
+      ; keyword "auto-solve-trivial" &> pure `auto_solve_trivial
+      ]
+  in
+  let toggle_automation =
+    keyword "toggle-automation"
+    &> automation_kind
+    $> fun t -> H.ToggleAutomation t
+  in
   let trivial_command =
     [ "show-proof", H.ShowProof
     ; "show-ihs", H.ShowIHs
@@ -2758,5 +2769,6 @@ let harpoon_command =
       :: solve
       :: by
       :: unbox
+      :: toggle_automation
       :: trivial_command
     )

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -219,6 +219,11 @@ module Harpoon = struct
     | `invert
     ]
 
+  type automation_kind =
+    [ `auto_intros
+    | `auto_solve_trivial
+    ]
+
   type command =
     (* Actual tactics *)
 

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -240,6 +240,8 @@ module Harpoon = struct
     | ShowProof
     | Defer (* Defers the current subgoal to later *)
     | ShowSubgoals (* Lists all open subgoals *)
+
+    | ToggleAutomation of automation_kind
 end
 
 

--- a/t/harpoon/type_preservation2.input
+++ b/t/harpoon/type_preservation2.input
@@ -1,0 +1,13 @@
+%: load t/harpoon/type_preservation.bel
+%: prove tpr
+[|- oft M A] -> [|- eval M M'] -> [|- oft M' A]
+2
+toggle-automation auto-solve-trivial
+split y7
+solve z6
+solve z6
+split z6
+by ih (tpr [|- D] [|- E]) as ih0
+split ih0
+by ih (tpr [|- D5 [_,D1]] [|- E1]) as ih1
+solve ih1


### PR DESCRIPTION
This PR adds a command for controlling auto tactics, i.e., for turning on and off auto tactics.
The command looks like
```
toggle-automation auto-solve-trivial
% or
toggle-automation auto-intros
```
