### PR TITLE
Fix bugs of auto_solve_trivial

### DIFF
--- a/src/beluga/main.ml
+++ b/src/beluga/main.ml
@@ -161,19 +161,20 @@ let per_file file_name =
       begin
         let open Format in
         fprintf std_formatter
-          "\n## Holes: %s  ##\n@[<v>%a@]@."
+          "@[<v>## Holes: %s  ##@,@[<v>%a@]@]@."
           file_name
           (pp_print_list Holes.print) (Holes.list ());
       end;
     begin match leftoverVars with
     | None -> ()
     | Some vars ->
-       if !Debug.chatter != 0 then begin
-           printf "\n## Left over variables ##" ;
-           Recsgn.print_leftoverVars vars
-         end ;
-       raise (Abstract.Error (Syntax.Loc.ghost, Abstract.LeftoverVars))
-    end ;
+      let open Format in
+      if !Debug.chatter <> 0 then
+        fprintf std_formatter "@[<v>## Leftover variables: %s  ##@,  @[%a@]@]@."
+          file_name
+          Recsgn.fmt_ppr_leftover_vars vars;
+      raise (Abstract.Error (Syntax.Loc.ghost, Abstract.LeftoverVars))
+    end;
     if !Typeinfo.generate_annotations then
       Typeinfo.print_annot file_name;
     print_newline();

--- a/src/core/abstract.mli
+++ b/src/core/abstract.mli
@@ -58,3 +58,5 @@ val subpattern : LF.mctx -> LF.dctx -> LF.sub -> LF.dctx ->
 val closedTyp : (LF.dctx * LF.typ) -> bool
 
 val printFreeMVars : LF.psi_hat -> LF.normal -> unit
+
+val fmt_ppr_collection : Format.formatter -> free_var LF.ctx -> unit

--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -133,6 +133,9 @@ let rec fold (empty : 'b) (f : 'b -> 'a -> 'b) (ctx : 'a LF.ctx) =
   | LF.Empty -> empty
   | LF.Dec (ctx', d) -> f (fold empty f ctx') d
 
+let map f ctx =
+  fold LF.Empty (fun ctx' x -> LF.Dec (ctx', f x)) ctx
+
 (** Transforms a context into a list by applying the given function.
     The list order will be the reverse of the context,
     i.e. the rightmost entry of the context (which is the first entry)

--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -184,13 +184,6 @@ let rec of_list_map (l : 'a list) (f : 'a -> 'b) : 'b LF.ctx =
 let of_list (l : 'a list) : 'a LF.ctx =
   of_list_map l Misc.id
 
-(** Converts a collection of hypotheses into local hypotheses. *)
-let to_local_context (h : Comp.hypotheses) : Comp.local_hypotheses =
-  let open Comp in
-  { cDl = to_list h.cD
-  ; cGl = to_list h.cG
-  }
-
 (** Iterate over a context from left to right (oldest variable first).
     The callback `f` gets both the subcontext of the variable _and_ the variable as input.
     Not tail-recursive, since contexts are snoc-lists.

--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -210,7 +210,7 @@ let rec iter_rev (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a -> unit) : unit =
 let iter_rev' (ctx : 'a LF.ctx) (f : 'a -> unit) : unit =
   iter_rev ctx (fun _ -> f)
 
-let find_with_index (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a -> bool) : ('a * int) option =
+let find_with_index (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a * int -> bool) : ('a * int) option =
   let rec go (ctx : 'a LF.ctx) (idx : int) =
     match ctx with
     | Empty -> None
@@ -218,15 +218,15 @@ let find_with_index (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a -> bool) : ('a * int)
        let open Maybe in
        Lazy.force
          ( lazy (go ctx' (idx + 1))
-           <|> lazy (of_bool (f ctx' x) &> Some (x, idx))
+           <|> lazy (of_bool (f ctx' (x, idx)) &> Some (x, idx))
          )
   in
   go ctx 1
 
-let find_with_index' (ctx : 'a LF.ctx) (f : 'a -> bool) : ('a * int) option =
+let find_with_index' (ctx : 'a LF.ctx) (f : 'a * int -> bool) : ('a * int) option =
   find_with_index ctx (Misc.const f)
 
-let find_with_index_rev (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a -> bool) : ('a * int) option =
+let find_with_index_rev (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a * int -> bool) : ('a * int) option =
   let rec go (ctx : 'a LF.ctx) (idx : int) =
     match ctx with
     | Empty -> None
@@ -234,13 +234,13 @@ let find_with_index_rev (ctx : 'a LF.ctx) (f : 'a LF.ctx -> 'a -> bool) : ('a * 
        (** The following does not use Maybe.(<|>) to be optimized by
            TCO (Tail Call Optimzations)
         *)
-       if f ctx' x
+       if f ctx' (x, idx)
        then Some (x, idx)
        else go ctx' (idx + 1)
   in
   go ctx 1
 
-let find_with_index_rev' (ctx : 'a LF.ctx) (f : 'a -> bool) : ('a * int) option =
+let find_with_index_rev' (ctx : 'a LF.ctx) (f : 'a * int -> bool) : ('a * int) option =
   find_with_index_rev ctx (Misc.const f)
 
 (** Find an item satisfying a condition in a context from left to right

--- a/src/core/context.mli
+++ b/src/core/context.mli
@@ -45,10 +45,10 @@ val find        : 'a ctx -> ('a ctx -> 'a -> bool) -> 'a option
 val find'       : 'a ctx -> ('a -> bool) -> 'a option
 val find_rev    : 'a ctx -> ('a ctx -> 'a -> bool) -> 'a option
 val find_rev'   : 'a ctx -> ('a -> bool) -> 'a option
-val find_with_index     : 'a ctx -> ('a ctx -> 'a -> bool) -> ('a * int) option
-val find_with_index'    : 'a ctx -> ('a -> bool) -> ('a * int) option
-val find_with_index_rev : 'a ctx -> ('a ctx -> 'a -> bool) -> ('a * int) option
-val find_with_index_rev': 'a ctx -> ('a -> bool) -> ('a * int) option
+val find_with_index     : 'a ctx -> ('a ctx -> 'a * int -> bool) -> ('a * int) option
+val find_with_index'    : 'a ctx -> ('a * int -> bool) -> ('a * int) option
+val find_with_index_rev : 'a ctx -> ('a ctx -> 'a * int -> bool) -> ('a * int) option
+val find_with_index_rev': 'a ctx -> ('a * int -> bool) -> ('a * int) option
 
 val getNameDCtx : dctx -> int -> Id.name
 val getNameMCtx : mctx -> int -> Id.name

--- a/src/core/context.mli
+++ b/src/core/context.mli
@@ -24,6 +24,9 @@ val append_hypotheses : Comp.hypotheses -> Comp.hypotheses -> Comp.hypotheses
 (** General eliminator for contexts. *)
 val fold            : 'b -> ('b -> 'a -> 'b) -> 'a ctx -> 'b
 
+(** Lift a function into contexts. *)
+val map             : ('a -> 'b) -> 'a ctx -> 'b ctx
+
 val to_list_map_rev : 'a ctx -> ('a ctx -> 'a -> 'b) -> 'b list
 val to_list_map     : 'a ctx -> ('a ctx -> 'a -> 'b) -> 'b list
 val to_list_rev     : 'a ctx -> 'a list

--- a/src/core/context.mli
+++ b/src/core/context.mli
@@ -32,7 +32,6 @@ val to_sublist      : 'a ctx -> ('a ctx * 'a) list
 val to_sublist_rev  : 'a ctx -> ('a ctx * 'a) list
 val of_list_map     : 'a list -> ('a -> 'b) -> 'b ctx
 val of_list         : 'a list -> 'a ctx
-val to_local_context : Comp.hypotheses -> Comp.local_hypotheses
 val iter        : 'a ctx -> ('a ctx -> 'a -> unit) -> unit
 val iter'       : 'a ctx -> ('a -> unit) -> unit
 val iter_rev    : 'a ctx -> ('a ctx -> 'a -> unit) -> unit

--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -380,7 +380,7 @@ module Automation = struct
   let auto_solve_trivial : t =
     fun g tctx ->
     let { cD; cG; _ } = g.context in
-    let m_is_witness (m : LF.ctyp_decl) =
+    let m_is_witness ((m, idx) : LF.ctyp_decl * int) =
       dprintf
         (fun p ->
           p.fmt
@@ -389,7 +389,7 @@ module Automation = struct
         );
       match m with
       | LF.Decl (_, mtyp, _) ->
-         Whnf.convCTyp g.goal (Comp.TypBox (Loc.ghost, mtyp), Whnf.m_id)
+         Whnf.convCTyp g.goal (Comp.TypBox (Loc.ghost, mtyp), LF.MShift idx)
       | LF.DeclOpt _ ->
          raise (Error.Violation "[auto_solve_trivial] Unexpected DeclOpt")
     in
@@ -408,7 +408,7 @@ module Automation = struct
       | _ ->
          raise (Error.Violation "[auto_solve_trivial] Impossible case")
     in
-    let c_is_witness (c : Comp.ctyp_decl) =
+    let c_is_witness ((c, _) : Comp.ctyp_decl * int) =
       dprintf
         (fun p ->
           p.fmt
@@ -417,7 +417,7 @@ module Automation = struct
         );
       match c with
       | Comp.CTypDecl (_, typ, _) ->
-         Whnf.convCTyp g.goal (typ, LF.MShift 0)
+         Whnf.convCTyp g.goal (typ, Whnf.m_id)
       | Comp.CTypDeclOpt _ ->
          raise (Error.Violation "[auto_solve_trivial] Unexpected CTypDeclOpt")
       | Comp.WfRec _ ->

--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -626,6 +626,19 @@ module Prover = struct
        Format.fprintf ppf "There are %d IHs:@,"
          (Context.length g.context.cIH);
        Context.to_list g.context.cIH |> List.iteri f
+    | Command.ShowSubgoals ->
+       let open Format in
+       let f ppf i g =
+         let open Comp in
+         fprintf ppf "%2d. @[%a@]@,"
+           (i + 1)
+           (P.fmt_ppr_cmp_typ g.context.cD P.l0) (Whnf.cnormCTyp g.goal)
+       in
+       let print_subgoals ppf gs =
+         List.iteri (f ppf) gs
+       in
+       fprintf ppf "@[<v>%a@]"
+         print_subgoals (DynArray.to_list s.remaining_subgoals)
 
     | Command.ToggleAutomation automation_kind ->
        Automation.toggle_automation s.automation_state automation_kind

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -41,10 +41,11 @@ possibly extend parsing functions later with metadata.
 **** OCaml shortcomings
 
 OCaml is a strict language, so one cannot define recursive values that
-are _not functions_.
-In particular, one cannot write `let rec x = x`; we get the error
-"this kind of expression is not allowed on the right-hand side of `let
-rec'."
+are _not functions_ in which the recursion is not guarded by a
+constructor.
+For instance, one can write `let rec zeroes = 0 :: zeroes`, but not
+`let rec x = x`. We get the error "this kind of expression is not
+allowed on the right-hand side of `let rec'."
 
 So suppose we are parsing arithmetic expressions with addition and
 multiplication. We would like to write:

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -802,6 +802,12 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
     | LF.No -> false
     | LF.Maybe -> true
     | LF.Inductive -> false
+
+  let fmt_ppr_lf_typ_typing ppf (cD, cPsi, tA) =
+    fprintf ppf "@[<2>@[%a@] ; @[%a@] |-@ @[%a@]@ : type@]"
+      (fmt_ppr_lf_mctx l0) cD
+      (fmt_ppr_lf_dctx cD l0) cPsi
+      (fmt_ppr_lf_typ cD cPsi l0) tA
                     
   let fmt_ppr_lf_msub_typing ppf (cD', t, cD) =
     fprintf ppf "@[%a@] |-@ @[%a@]@ : @[%a@]"
@@ -1466,12 +1472,10 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
       (fmt_ppr_lf_mctx l0) cD
       (fmt_ppr_cmp_gctx cD l0) cG
     
-  let fmt_ppr_cmp_typ_typing ppf (cD, tau) = assert false
-  (*
+  let fmt_ppr_cmp_typ_typing ppf (cD, tau) =
     fprintf ppf "@[%a@] |-@ @[%a@]"
     (fmt_ppr_lf_mctx l0) cD
     (fmt_ppr_cmp_typ cD l0) tau
-   *)
                                            
   let fmt_ppr_rec lvl ppf prefix (f, tau, e) =
     fprintf ppf "@\n%s %s : %a =@ @[<2>%a ;@]@\n"

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -1382,25 +1382,23 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
   and fmt_ppr_cmp_hypothetical cD cG ppf =
     let open Comp in
     function
-    | Hypothetical (h, h', proof) ->
+    | Hypothetical (h, proof) ->
        fprintf ppf "@[<v>{ %a @[<v>%a@]@,}@]"
-         (fmt_ppr_cmp_local_hypotheses h.cD h.cG) h'
+         fmt_ppr_cmp_hypotheses h
          (fmt_ppr_cmp_proof h.cD h.cG) proof;
        
-  and fmt_ppr_cmp_local_hypotheses cD cG ppf =
+  and fmt_ppr_cmp_hypotheses ppf =
     let open Comp in
-    fun { cDl; cGl } ->
-    let comma ppf () = fprintf ppf ",@ " in
-    
+    fun { cD; cG; _ } ->
     fprintf ppf "@[<hv>%a@]@,| @[<hv>%a@]@,;"
       (pp_print_list
-         ~pp_sep: comma
+         ~pp_sep: Fmt.comma
          (fmt_ppr_lf_ctyp_decl cD l0))
-      cDl
+      (Context.to_list_rev cD)
       (pp_print_list
-         ~pp_sep: comma
+         ~pp_sep: Fmt.comma
          (fmt_ppr_cmp_ctyp_decl cD l0))
-      cGl;
+      (Context.to_list_rev cG);
     
   and fmt_ppr_refinement cD cD0 lvl ppf t = begin match (t, cD0) with
                                             | (LF.MShift k, _ ) ->

--- a/src/core/printer.ml
+++ b/src/core/printer.ml
@@ -61,6 +61,9 @@ module Int = struct
     (** Prints a typing judgment for an msub: cD' |- theta : cD *)
     val fmt_ppr_lf_msub_typing : formatter -> LF.mctx * LF.msub * LF.mctx -> unit
 
+    (** Prints a typing judgment for an LF type: cD ; cPsi |- tA : type *)
+    val fmt_ppr_lf_typ_typing : formatter -> LF.mctx * LF.dctx * LF.typ -> unit
+
     (* computational printers *)
     val fmt_ppr_cmp_kind      : LF.mctx -> lvl -> formatter -> Comp.kind -> unit
     val fmt_ppr_cmp_typ       : LF.mctx -> lvl -> formatter -> Comp.typ -> unit

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -1317,8 +1317,10 @@ and inferCtxSchema loc (cD,cPsi) (cD', cPsi') = match (cPsi , cPsi') with
              (P.fmt_ppr_lf_mctx P.l0) cD'
              (P.fmt_ppr_lf_dctx cD P.l0) cPsi
            end;
-          let (_ , s_cid) = Whnf.mctxCDec cD psi1_var in
-          elDCtxAgainstSchema loc Lfrecon.Pibox cD' cPsi' s_cid
+         (* lookup the schema of the context variable on the RHS *)
+         let (_ , s_cid) = Whnf.mctxCDec cD psi1_var in
+         (* and then elaborate the given context against that schema *)
+         elDCtxAgainstSchema loc Lfrecon.Pibox cD' cPsi' s_cid
 
       | (Int.LF.DDec (cPsi1, Int.LF.TypDecl(_ , _tA1)) , Apx.LF.DDec (cPsi2, Apx.LF.TypDecl(x , tA2))) ->
         let cPsi'' = inferCtxSchema loc (cD, cPsi1) (cD',cPsi2) in
@@ -1577,7 +1579,7 @@ and recPatObj' cD pat (cD_s, tau_s) = match pat with
          dprintf
            begin fun p ->
            p.fmt "[recPattern] @[<v>Reconstruction of pattern of empty type@,@[%a@]@]"
-             (P.fmt_ppr_lf_typ cD cPsi P.l0) tP
+             P.fmt_ppr_lf_typ_typing (cD, cPsi, tP)
            end;
          let ttau'  = (Int.Comp.TypBox (loc, Int.LF.ClTyp (Int.LF.MTyp tP, cPsi)), Whnf.m_id) in
          (Int.LF.Empty, Int.Comp.PatEmpty (loc, cPsi), ttau')

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -14,7 +14,7 @@ module R = Store.Cid.DefaultRenderer
 let (dprintf, dprint, _) = Debug.makeFunctions' (Debug.toFlags [11])
 open Debug.Fmt
 
-type leftoverVars = (Abstract.free_var Int.LF.ctx * Syntax.Loc.t) list
+type leftover_vars = (Abstract.free_var Int.LF.ctx * Syntax.Loc.t) list
 
 type error =
   | UnexpectedSucess
@@ -94,11 +94,17 @@ let _ =
       )
   )
 
-let print_leftoverVars = function
-  | [] -> ()
-  | (_cQ, loc):: rest ->
-    Format.fprintf Format.std_formatter "\n%a@." Syntax.Loc.print loc;
-    ()
+let fmt_ppr_leftover_vars ppf : leftover_vars -> unit =
+  let open Format in
+  fprintf ppf "@[<v>%a@]"
+    (pp_print_list ~pp_sep: pp_print_cut
+       begin fun ppf (cQ, loc) ->
+       fprintf ppf "@[<2>@[%a@] |-@ @[%a@]@]"
+         Abstract.fmt_ppr_collection cQ
+         Syntax.Loc.print loc
+       end)
+
+let ppr_leftover_vars = fmt_ppr_leftover_vars Format.std_formatter
 
 let rec stripInd tau = match tau with
   | Int.Comp.TypArr (tau1, tau2) ->
@@ -166,7 +172,7 @@ let rec apply_global_pragmas =
   | l -> l
 
 let recSgnDecls decls =
-  let leftoverVars : leftoverVars ref = ref [] in
+  let leftoverVars : leftover_vars ref = ref [] in
   let is_empty = function
     | Int.LF.Empty -> true
     | _ -> false

--- a/src/core/recsgn.mli
+++ b/src/core/recsgn.mli
@@ -1,11 +1,12 @@
 open Syntax
 
-type leftoverVars = (Abstract.free_var Int.LF.ctx * Loc.t) list
+type leftover_vars = (Abstract.free_var Int.LF.ctx * Loc.t) list
 
 (** Processes global pragmas, which must appear at the beginning of
     the list, and returns the remaining declarations. *)
 val apply_global_pragmas : Syntax.Ext.Sgn.decl list -> Syntax.Ext.Sgn.decl list
 
-val recSgnDecls : Syntax.Ext.Sgn.decl list -> Syntax.Int.Sgn.decl list * leftoverVars option
+val recSgnDecls : Syntax.Ext.Sgn.decl list -> Syntax.Int.Sgn.decl list * leftover_vars option
 
-val print_leftoverVars : leftoverVars -> unit
+val fmt_ppr_leftover_vars : Format.formatter -> leftover_vars -> unit
+val ppr_leftover_vars : leftover_vars -> unit

--- a/t/harpoon/nats_and_bools_tps.input
+++ b/t/harpoon/nats_and_bools_tps.input
@@ -1,6 +1,6 @@
 %: load t/harpoon/nats_and_bools_tps.bel
 %: prove tps
-[|- hastype M T] -> [|- step M N] -> [|- hastype N T]
+[|- hastype M A] -> [|- step M N] -> [|- hastype N A]
 2
 split x8
 invert y8
@@ -12,15 +12,22 @@ invert y8
 invert y8
 invert y8
 invert y8
-by lemma ([|- Y11]) as l1
-by lemma ([|- Y17]) as l2
-by lemma ([|- t_false]) as l3
-by ih (tps [|- Y35] [|- Z2]) as r1
-by ih (tps [|- Z38] [|- Z1]) as r2
-by ih (tps [|- X42] [|- Z]) as r3
-solve l1
-solve l2
-solve l3
-unbox (r1) as R1
-unbox (r3) as R3
-by lemma ([|- t_iszero R3]) as l4
+invert y8
+solve [|- Y11]
+solve [|- Z15]
+invert [|- X21]
+solve [|- t_true]
+solve [|- t_false]
+by ih (tps [|- Z36] [|- X4]) as r
+by ih (tps [|- X39] [|- Z2]) as r
+by ih (tps [|- Y43] [|- Z1]) as r
+by ih (tps [|- Z46] [|- Z]) as r
+solve [|- X52]
+unbox (r) as R
+unbox (r) as R
+unbox (r) as R
+unbox (r) as R
+solve [|- t_if R Y37 X37]
+solve [|- t_succ R]
+solve [|- t_pred R]
+solve [|- t_iszero R]

--- a/t/harpoon/nats_and_bools_tps.input
+++ b/t/harpoon/nats_and_bools_tps.input
@@ -13,21 +13,19 @@ invert y8
 invert y8
 invert y8
 invert y8
-solve [|- Y11]
-solve [|- Z15]
-invert [|- X21]
-solve [|- t_true]
-solve [|- t_false]
-by ih (tps [|- Z36] [|- X4]) as r
-by ih (tps [|- X39] [|- Z2]) as r
-by ih (tps [|- Y43] [|- Z1]) as r
-by ih (tps [|- Z46] [|- Z]) as r
-solve [|- X52]
-unbox (r) as R
-unbox (r) as R
-unbox (r) as R
-unbox (r) as R
-solve [|- t_if R Y37 X37]
-solve [|- t_succ R]
-solve [|- t_pred R]
-solve [|- t_iszero R]
+split ([|- X21])
+solve ([|- t_true])
+solve ([|- t_false])
+solve ([|- t_false])
+by ih (tps [|- Z36] [|- X4]) as r0
+by ih (tps [|- X39] [|- Z2]) as r0
+by ih (tps [|- Y43] [|- Z1]) as r0
+by ih (tps [|- Z46] [|- Z]) as r0
+unbox (r0) as R0
+unbox (r0) as R0
+unbox (r0) as R0
+unbox (r0) as R0
+solve ([|- t_if R0 Y37 X37])
+solve [|- t_succ R0]
+solve [|- t_pred R0]
+solve [|- t_iszero R0]


### PR DESCRIPTION
Resolves #122 and one more basic problem of `auto_solve_trivial`.
With this PR,
1. `auto_solve_trivial` removes a correct subgoal (instead of current one).
1. `auto_solve_trivial` solves subgoals whose proofs are in meta-context.
    (Previously this is not the case because of a bug in the type checking process of `auto_solve_trivial`)