### PR TITLE
Changed subgoal list to FIFO ordering and updated tests

### DIFF
--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -285,7 +285,7 @@ module Tactic = struct
             meta_branch c context (incomplete_proof new_state)
        in
        tctx.remove_current_subgoal ();
-       let bs = List.map f cgs in
+       let bs = List.map f (List.rev cgs) in
        (* Assemble the split branches computed in `bs` into the Harpoon
           Split syntax.
         *)
@@ -718,7 +718,7 @@ module Prover = struct
             "@[<v>[tactic context] add the following subgoal@,%a@]"
             P.fmt_ppr_cmp_proof_state g
         );
-      DynArray.add s.remaining_subgoals g;
+      DynArray.insert s.remaining_subgoals 0 g;
       add_subgoal_hook s g tctx
     and remove_subgoal g =
       dprintf

--- a/t/harpoon/nats_and_bools_tps.input
+++ b/t/harpoon/nats_and_bools_tps.input
@@ -7,25 +7,24 @@ invert y8
 invert y8
 invert y8
 invert y8
+invert [|- X21]
 invert y8
+solve [|- t_true]
 invert y8
+solve [|- t_false]
 invert y8
+by ih (tps [|- Y41] [|- X4]) as ih0
+unbox (ih0) as IH0
+solve [|- t_if IH0 X41 Z41]
 invert y8
+by ih (tps [|- Z43] [|- Z2]) as ih1
+unbox (ih1) as IH1
+solve [|- t_succ IH1]
 invert y8
+by ih (tps [|- X47] [|- Z1]) as ih2
+unbox (ih2) as IH2
+solve [|- t_pred IH2]
 invert y8
-split ([|- X21])
-solve ([|- t_true])
-solve ([|- t_false])
-solve ([|- t_false])
-by ih (tps [|- Z36] [|- X4]) as r0
-by ih (tps [|- X39] [|- Z2]) as r0
-by ih (tps [|- Y43] [|- Z1]) as r0
-by ih (tps [|- Z46] [|- Z]) as r0
-unbox (r0) as R0
-unbox (r0) as R0
-unbox (r0) as R0
-unbox (r0) as R0
-solve ([|- t_if R0 Y37 X37])
-solve [|- t_succ R0]
-solve [|- t_pred R0]
-solve [|- t_iszero R0]
+by ih (tps [|- Y51] [|- Z]) as ih3
+unbox (ih3) as IH3
+solve [|- t_iszero IH3]

--- a/t/harpoon/type_preservation2.input
+++ b/t/harpoon/type_preservation2.input
@@ -11,3 +11,4 @@ by ih (tpr [|- D] [|- E]) as ih0
 split ih0
 by ih (tpr [|- D5 [_,D1]] [|- E1]) as ih1
 solve ih1
+


### PR DESCRIPTION
Since subgoals are always read from the front of the array, adding new ones to the front instead of the back keeps the user in the same branch of the proof if it is not yet completed. This corresponds to a "depth-first" experience rather than a "breadth-first" one.