### PR TITLE
Make induction order for harpoon optional

### DIFF
--- a/src/core/harpoon.ml
+++ b/src/core/harpoon.ml
@@ -520,12 +520,12 @@ module Prover = struct
     ; remaining_subgoals : unit Comp.proof_state DynArray.t
     ; automation_state : Automation.automation_state
     ; theorem_name : Id.name
-    ; order : Comp.order
+    ; order : Comp.order option
     }
 
   let make_prover_state
         (name : Id.name)
-        (order : Comp.order)
+        (order : Comp.order option)
         (s : unit Comp.proof_state)
       : interpreter_state =
     { initial_state = s
@@ -615,7 +615,7 @@ module Prover = struct
       [ Total.make_total_dec
           s.theorem_name
           (Whnf.cnormCTyp s.initial_state.goal |> Total.strip)
-          (Some s.order)
+          s.order
       ]
     in
     (** Checks that the given term corresponds to the given kind of invocation.
@@ -805,7 +805,7 @@ module Prover = struct
         (ppf : Format.formatter) (* The formatter used to display messages *)
         (name : Id.name) (* The name of the theorem to prove *)
         (stmt : Comp.tclo) (* The statement of the theorem *)
-        (order : Comp.order) (* The induction order of the theorem *)
+        (order : Comp.order option) (* The induction order of the theorem *)
       : unit =
     let g = Comp.make_proof_state stmt in
     let s = make_prover_state name order g in

--- a/src/core/harpoon.mli
+++ b/src/core/harpoon.mli
@@ -52,5 +52,5 @@ end;
 module Comp = Syntax.Int.Comp
 
 module Prover : sig
-  val start_toplevel : Format.formatter -> Id.name -> Comp.tclo -> Comp.order -> unit
+  val start_toplevel : Format.formatter -> Id.name -> Comp.tclo -> Comp.order option -> unit
 end

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2377,7 +2377,7 @@ let total_decl (arg : Comp.order t) : Comp.total_dec t =
   alt trust total
   |> labelled "totality declaration"
 
-let numeric_total_order = total_order numeric_total_arg
+let optional_numeric_total_order = maybe (total_order numeric_total_arg)
 
 (** Mutual block of computation type declarations. *)
 let sgn_cmp_typ_decl =

--- a/src/core/parser.mli
+++ b/src/core/parser.mli
@@ -49,7 +49,7 @@ val sgn : Syntax.Ext.Sgn.decl list t
 (** Parser for a Harpoon command. *)
 val harpoon_command : Syntax.Ext.Harpoon.command t
 
-val numeric_total_order : Syntax.Ext.Comp.numeric_order t
+val optional_numeric_total_order : Syntax.Ext.Comp.numeric_order option t
 
 (** Parser for computation type. *)
 val cmp_typ : Comp.typ t

--- a/t/harpoon/reduce_halts.input
+++ b/t/harpoon/reduce_halts.input
@@ -1,5 +1,5 @@
 %: load t/harpoon/reduce_halts.bel
 %: prove rh
 {T: [|- tp]} {M: [|- tm T]} Reduce [|- T] [|- M] -> [|- halts M]
-2
+
 split z6


### PR DESCRIPTION
For some proofs, including the one in `t/harpoon/reduce_halts.input`, the induction order is not required. Moreover, for some proofs like a proof of `[⊢ true (forall (\x. eq (plus zero x) x))]`, it is impossible to give an induction order since the type is not a function type.

In this PR, I make the induction order input optional. However, I don't change the prompt itself in order to handle the above two cases consistently.