### PR TITLE
Dependent pattern matching & frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - OCAML_VERSION=4.09
 os:
   - linux
-  - osx
 notifications:
   email:
     - beluga-dev@cs.mcgill.ca

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: c
-script: bash -ex .travis-ci.sh
+sudo: required
+install: test -e .travis.opam.sh || wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.06.1
-  - OCAML_VERSION=4.05.0
+  - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
+os:
+  - linux
+  - osx
 notifications:
   email:
     - beluga-dev@cs.mcgill.ca
@@ -11,13 +19,6 @@ notifications:
       - "chat.freenode.net#beluga"
     on_success: always
     on_failure: always
-addons:
-  apt:
-    sources:
-      - avsm
-    packages:
-      - ocaml
-      - opam
 cache:
   directories:
     - $HOME/.opam

--- a/beluga.opam
+++ b/beluga.opam
@@ -10,5 +10,5 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "gen" "sedlex" "extlib"
+  "gen" "sedlex" "extlib" "dune-build-info"
 ]

--- a/beluga.opam
+++ b/beluga.opam
@@ -8,6 +8,6 @@ license: "GPLv3"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
-dependencies: [
+depends: [
   "gen" "sedlex" "extlib"
 ]

--- a/beluga.opam
+++ b/beluga.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+synopsis: "implementation of contextual modal logic for reasoning with higher-order abstract syntax"
 maintainer: "jacob.errington@mail.mcgill.ca"
 authors: ["Brigitte Pientka" "Joshua Dunfield" "Andrew Cave" "Jacob Thomas Errington"]
 homepage: "https://github.com/Beluga-lang/Beluga"

--- a/examples/back/tc.bel
+++ b/examples/back/tc.bel
@@ -63,7 +63,7 @@ schema expCtx = exp ;
 rec synth : {g:expCtx} {E : [g |- exp]} [ |- oft-option] =
   mlam g => mlam E =>
      [ |- none]
-and check : {g:expCtx} {E : [g |- exp]} {T : [ |- tp]} [ |- boolean] =
+and rec check : {g:expCtx} {E : [g |- exp]} {T : [ |- tp]} [ |- boolean] =
   mlam g => mlam E => mlam T =>
     [ |- false]
 ;

--- a/examples/freshML/conv-untyped.bel
+++ b/examples/freshML/conv-untyped.bel
@@ -32,7 +32,7 @@ fn e => case e of
     [g |- app' (T1 ) T2]
 | [g |- ret (V )] => convv [g |- V ]
 
-and convv: (g:ctx)[g |- value (T[])] -> [g |- term] =
+and rec convv: (g:ctx)[g |- value (T[])] -> [g |- term] =
 % / total v (convv g v)/
 fn v => case v of
 | [g |- #p.2] => [g |- #p.1]

--- a/examples/freshML/cps-popl-tutorial1.bel
+++ b/examples/freshML/cps-popl-tutorial1.bel
@@ -47,7 +47,7 @@ mlam g => fn v =>  case v of
      [g |- clam \v.\c. E']
 
 
-and cpse : {g:ctx}[g |- exp A] -> [g,k:ccont A |-  contra] =
+and rec cpse : {g:ctx}[g |- exp A] -> [g,k:ccont A |-  contra] =
 / total e (cpse g a e)/
 mlam g => fn e => case e of
 | [g |- ret (V )] =>

--- a/examples/freshML/cps-popl-tutorial2-crec.bel
+++ b/examples/freshML/cps-popl-tutorial2-crec.bel
@@ -39,7 +39,7 @@ fn v => case v of
     [g |- clam \v.\c. E']
 
 
-and cpse : (g:ctx)[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
+and rec cpse : (g:ctx)[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
 / total e (cpse g a e) /
 fn e => case e of
 | [g |- ret (V )] =>

--- a/examples/freshML/cps-popl-tutorial2.bel
+++ b/examples/freshML/cps-popl-tutorial2.bel
@@ -40,7 +40,7 @@ mlam g => fn v => case v of
     [g |- clam \v.\c. E'[..,v,c]]
 
 
-and cpse : {g:ctx}[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
+and rec cpse : {g:ctx}[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
 / total e (cpse g a e) /
 mlam g => fn e => case e of
 | [g |- ret (V )] =>

--- a/examples/freshML/debruijn-1.bel
+++ b/examples/freshML/debruijn-1.bel
@@ -54,7 +54,7 @@ fn v =>  case v of
      [ |- lam' (T[]) F]
 
 
-and hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
+and rec hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
  / total e (hoas2db _ _ e ) /
   fn e =>  case e of
   | [g |- app (E1 ) (E2 )] =>
@@ -80,7 +80,7 @@ rec db2vhoas : (g:ctx) [g |- exp' (T[])] -> [g |- value (T[])] =
       let [g,x:value (T[]) |-  F] = db2hoas  [h, x:value (T[]) |- E[..]] in
         [g |- lam (T[]) (\x. F)]
 
-and db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
+and rec db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
 % / total e (db2hoas _ _ e)/
   fn e => case e of
   | [g |- app' E1 E2] =>

--- a/examples/freshML/debruijn-1a.bel
+++ b/examples/freshML/debruijn-1a.bel
@@ -66,7 +66,7 @@ mlam g => fn v =>  case v of
      [g |- tlam' \a. F]
 
 
-and hoas2db : {g:ctx} [g |- exp T] ->  [g |- exp' T ] =
+and rec hoas2db : {g:ctx} [g |- exp T] ->  [g |- exp' T ] =
 % / total e (hoas2db _ _ e ) /
 mlam g => fn e =>  case e of
  | [g |- app (E1 ) (E2 )] =>

--- a/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
+++ b/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
@@ -106,7 +106,7 @@ case [ |- A] of
 | [ |- arr T S ] =>
  Arr [g] (mlam h => mlam $W => fn e => reflect (app' [h |- R[$W]] (reify e)))
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => case e of
 | Base [g |- R] => [g |- R]
 | Arr [g] f =>

--- a/examples/logrel/algeq-simplified.bel
+++ b/examples/logrel/algeq-simplified.bel
@@ -70,7 +70,7 @@ mlam A => fn r => case [ |- A] of
     let [h |- S] = reify [|- A] rn in
     reflect [ |- B] [h |- alg_app R[$W] S]
    )
-and reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeq M1 M2 A[]] =
+and rec reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeq M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -142,7 +142,7 @@ fn a => case a of
   let [g |- R'] = algeqNeuSym [g |- R] in
   let [g |- N'] = algeqSym [g |- N] in
   [g |- alg_app (R') (N')]
-and algeqSym : (g:tctx)
+and rec algeqSym : (g:tctx)
   [g |- algeq N1 N2 T]
 -> [g |- algeq N2 N1 T] =
 / total a (algeqSym g n1 n2 t a) /
@@ -270,7 +270,7 @@ fn a1 => fn a2 => case a1 of
   let [g |- R1] = algeqNeuTrans [g |- A1'] [g |- A2'] in
   let [g |- R2] = algeqTrans [g |- B1] [g |- B2] in
   [g |- alg_app (R1) (R2)]
-and algeqTrans : (g:tctx)
+and rec algeqTrans : (g:tctx)
   [g |- algeq N1 N2 T]
 -> [g |- algeq N2 N3 T]
 -> [g |- algeq N1 N3 T] =

--- a/examples/logrel/algeq-simplified1.bel
+++ b/examples/logrel/algeq-simplified1.bel
@@ -65,7 +65,7 @@ mlam A => fn r => case [ |- A] of
     let [h |- S] = reify [|- A] rn in
     reflect [ |- B] [h |- algapp R[$W] S]
    )
-and reify : {A:[|- tp]}LogEq [g |- M1] [g |- M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]}LogEq [g |- M1] [g |- M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -135,7 +135,7 @@ fn a => case a of
   let [g |- R'] = algEqRSym [g |- R] in
   let [g |- N'] = algEqNSym [g |- N] in
   [g |- algapp (R') (N')]
-and algEqNSym : (g:tctx)
+and rec algEqNSym : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N1 T] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -263,7 +263,7 @@ fn a1 => fn a2 => case a1 of
   let [g |- R1] = algEqRTrans [g |- A1'] [g |- A2'] in
   let [g |- R2] = algEqNTrans [g |- B1] [g |- B2] in
   [g |- algapp R1 R2]
-and algEqNTrans : (g:tctx)
+and rec algEqNTrans : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N3 T]
 -> [g |- algeqn N1 N3 T] =

--- a/examples/logrel/algeq-typing.bel
+++ b/examples/logrel/algeq-typing.bel
@@ -74,7 +74,7 @@ mlam A => fn r => case [ |- A] of
     let [h |- S] = reify [|- A] rn in
     reflect [ |- B] [h |- algapp R[$W] S]
    )
-and reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -147,7 +147,7 @@ fn a => case a of
   let [g |- R'] = algEqRSym [g |- R] in
   let [g |- N'] = algEqNSym [g |- N] in
   [g |- algapp (R') (N')]
-and algEqNSym : (g:tctx)
+and rec algEqNSym : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N1 T] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -276,7 +276,7 @@ fn a1 => fn a2 => case a1 of
   let [g |- R1] = algEqRTrans [g |- A1'] [g |- A2'] in
   let [g |- R2] = algEqNTrans [g |- B1] [g |- B2] in
   [g |- algapp R1 R2]
-and algEqNTrans : (g:tctx)
+and rec algEqNTrans : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N3 T]
 -> [g |- algeqn N1 N3 T] =
@@ -438,7 +438,7 @@ fn d => case d of
 | [g |- d_refl D1] => [g |- D1]
 | [g |- d_sym D1] => dtp2 [g |- D1]
 | [g |- d_trans D1 D2] => dtp1 [g |- D1]
-and dtp2 : (g:ctx) [g |- deq M1 M2 T[]] -> [g |- oft M2 T[]] =
+and rec dtp2 : (g:ctx) [g |- deq M1 M2 T[]] -> [g |- oft M2 T[]] =
  / total d (dtp2 g m1 m2 t d) /
 fn d => case d of
 | [g |- d_app D1 D2] =>

--- a/examples/logrel/weak-norm-under-binders-beta-only.bel
+++ b/examples/logrel/weak-norm-under-binders-beta-only.bel
@@ -133,7 +133,7 @@ mlam gamma, A,R,NR => case [ |- A] of
     m_closed  (m_app2 [_ |- _] ms)
              (reflect [h] [|- B] [h |- _ ] [_ |- n_app NR[$W] N]))
 
-and reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
+and rec reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
             Reduce [ |- A] [g |- M] -> Halts [ |- A] [g |- M] =
  / total a (reify g a ) /
 mlam g,A,M => fn r => case [|- A] of

--- a/examples/logrel/weak-norm-under-binders-simplified.bel
+++ b/examples/logrel/weak-norm-under-binders-simplified.bel
@@ -133,7 +133,7 @@ mlam gamma, A,R,NR => case [ |- A] of
     m_closed  (m_app2 [_ |- _] ms)
              (reflect [h] [|- B] [h |- _ ] [_ |- n_app NR[$W] N]))
 
-and reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
+and rec reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
             Reduce [ |- A] [g |- M] -> Halts [ |- A] [g |- M] =
  / total a (reify g a ) /
 mlam g,A,M => fn r => case [|- A] of

--- a/examples/logrel/weak-norm-under-binders.bel
+++ b/examples/logrel/weak-norm-under-binders.bel
@@ -130,7 +130,7 @@ fn r => fn iv => case r of
 | App r' n => App (rwkn r' iv) (nwkn n iv)
 
 % Applying a variable substitution to a normal term results in a normal term
-and nwkn : Normal [g |- N] -> IsVarSub [g] [h |- $W] -> Normal [h |- N[$W]] =
+and rec nwkn : Normal [g |- N] -> IsVarSub [g] [h |- $W] -> Normal [h |- N[$W]] =
 / total r (nwkn g h w n _ r) /
 fn r => fn iv => case r of
 | Neut r' => Neut (rwkn r' iv)
@@ -177,7 +177,7 @@ mlam g, A,R => fn r =>  case [ |- A] of
     closed [|- _ ] [h |- _ ]  [h |- _ ] [h |- s_app s_refl (MS)]
            (reflect [h] [|- B] [h |- _ ] (App (rwkn r iv) n)))
 
-and reify : {g:ctx}{A:[|- tp]}{M:[g |- tm A[]]}
+and rec reify : {g:ctx}{A:[|- tp]}{M:[g |- tm A[]]}
             Reduce [ |- A] [g |- M] -> Halts [ |- A] [g |- M] =
  / total a (reify g a ) /
 mlam g,A,M => fn r => case [|- A] of

--- a/examples/lp-horn/iscan.bel
+++ b/examples/lp-horn/iscan.bel
@@ -34,7 +34,7 @@ fn tc => case tc of
  let [g |- AT1] = isatm [g |- TA1 ] in
    [g |- can_atm (AT1 )]
 
-and isatm : (g:i_ctx) [g |- toatm A D (D')]   -> [g |- atm (D')] =
+and rec isatm : (g:i_ctx) [g |- toatm A D (D')]   -> [g |- atm (D')] =
 fn ta => case ta of
 | [g |- #p.2] => [g |- #p.3]
 | [g |- ta_andel (TA1)] =>

--- a/examples/lp-horn/uni-complete-crec.bel
+++ b/examples/lp-horn/uni-complete-crec.bel
@@ -32,7 +32,7 @@ fn cn => case cn of
      [g] s_imp (\v. S1 v )
 }%
 
-and cmpai: (g:c_ctx)[g |- atomic_prfs A] ->
+and rec cmpai: (g:c_ctx)[g |- atomic_prfs A] ->
 	       [g, q:p, u:focus (A[..]) q |-  solve (atom q)] =
 % / total at (cmpai g a at)/
 fn at => case at of

--- a/examples/lp-horn/uni-complete.bel
+++ b/examples/lp-horn/uni-complete.bel
@@ -19,7 +19,7 @@ fn cn => case cn of
   let [g,q:p,u:focus A q |-  I1] = cmpai [g] [g |- D] [g |- AT1 ] in
     [g |- I1[..,_,(i_atom)]]
 
-and cmpai:  {g:c_ctx}{E:[g |- pf B[]]}[g |- atm E] ->
+and rec cmpai:  {g:c_ctx}{E:[g |- pf B[]]}[g |- atm E] ->
 	       [g, q:p, u:focus B[] q  |-  solve (atom q)] =
 % / total at (cmpai g a at)/
 mlam g, E => fn at => case [g |- E ] of

--- a/examples/lp-horn/uni-sound-crec.bel
+++ b/examples/lp-horn/uni-sound-crec.bel
@@ -18,7 +18,7 @@ fn s => case s of
      let [g,u:pf _  |-  D] = i_sound [g |- S] in
      [g |- D[..,(#p.2)]]
 
-and i_sound : (g:ctx)[g |- focus A P] -> [g, u:pf A |-  pf (atom (P[..]))] =
+and rec i_sound : (g:ctx)[g |- focus A P] -> [g, u:pf A |-  pf (atom (P[..]))] =
 / total f (i_sound g a p f)/
 fn f => case f of
 | [g |- i_andl I1] =>

--- a/examples/lp-horn/uni-sound.bel
+++ b/examples/lp-horn/uni-sound.bel
@@ -18,7 +18,7 @@ mlam g => fn s => case s of
      let [g,u:pf _  |-  D] = i_sound [g] [g |- S] in
      [g |- D[..,(#p.2)]]
 
-and i_sound : {g:ctx}[g |- focus A P] -> [g, u:pf A |-  pf (atom (P[..]))] =
+and rec i_sound : {g:ctx}[g |- focus A P] -> [g, u:pf A |-  pf (atom (P[..]))] =
 / total f (i_sound g a p f)/
 mlam g => fn f => case f of
 | [g |- i_andl I1] =>

--- a/examples/polylam/normal.bel
+++ b/examples/polylam/normal.bel
@@ -50,7 +50,7 @@ fn e => case e of
                      in
                        [g |- lam \y.M[..,y]]
 
-and neutral2exp : (g: ctx) [g |- neutral T] -> [g |- exp T] =
+and rec neutral2exp : (g: ctx) [g |- neutral T] -> [g |- exp T] =
 / total e (neutral2exp g t e) /
 fn e => case e of
 |[g |- app' R S] => let [g |- M] = neutral2exp [g |- R] in

--- a/examples/popl12/nbe.bel
+++ b/examples/popl12/nbe.bel
@@ -99,7 +99,7 @@ case [ |- A] of
 | [ |- arr T S ] =>  Slam (extendSem r)
 
 % Lesson: FACTORIZATION OF CODE HELPS TYPE RECONSTRUCTION!!!
-and extendSem : [g |- neut (arr A[] B[])] ->
+and rec extendSem : [g |- neut (arr A[] B[])] ->
                 ({h:ctx} Extends [g] [h] ->
                  Sem [h] [ |- A] -> Sem [h] [ |- B])
 =
@@ -109,7 +109,7 @@ let [h |- N ] = reify e in
 let [h |- R' ] = weak_neut s r in
   reflect [ |- _ ] [h |- rapp (R') N]
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 / trust /
 fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- atomic P ] =>  (case e of Syn [g |- R] => [g |- embed R])

--- a/examples/popl12/normeval-abbrev.bel
+++ b/examples/popl12/normeval-abbrev.bel
@@ -66,7 +66,7 @@ fn s => fn e => case e of
   let {N':[h |- norm T[]]} [h |- N' ] = nosubst s [g |- N ] in
     [h |- rapp (R') (N' ) ]
 
-and nosubst : (g:ctx)(h:ctx)
+and rec nosubst : (g:ctx)(h:ctx)
               Sub [g] [h]
 	    -> [g |- norm S[]]
             -> [h |- norm S[]] =
@@ -139,7 +139,7 @@ case [ |- A] of
 | [ |- arr T S ] =>  Slam (extendSem r)
 
 % Lesson: FACTORIZATION OF CODE HELPS TYPE RECONSTRUCTION!!!
-and extendSem : [g |- neut (arr A[] B[])] ->
+and rec extendSem : [g |- neut (arr A[] B[])] ->
                 ({h:ctx} Sub [g] [h]  -> Sem [h] [ |- A] -> Sem [h] [ |- B])
 =
 fn r => mlam h => fn s => fn e =>
@@ -147,7 +147,7 @@ let [h |- N ] = reify e in
 let [h |- R' ] = nsubst s r in
   reflect [h |- rapp (R') N]
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- atomic P ] =>  (case e of Syn [g |- R] => [g |- embed R])
 | [ |- arr T S ] =>

--- a/examples/popl12/normeval-subst.bel
+++ b/examples/popl12/normeval-subst.bel
@@ -89,7 +89,7 @@ case [ |- A] of
 
 
 % Lesson: FACTORIZATION OF CODE HELPS TYPE RECONSTRUCTION!!!
-and extendSem : (g:ctx)[g |- neut (arr A[] B[])] ->
+and rec extendSem : (g:ctx)[g |- neut (arr A[] B[])] ->
                 ({h:ctx}{$S:[h |- g]} Sem [h] [ |- A] -> Sem [h] [ |- B])
 =
 fn r => mlam h => mlam $S => fn e =>
@@ -97,7 +97,7 @@ let [h |- N ] = reify e in
 let [g |- R ] = r in
   reflect [h |- rapp R[$S] N]
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- atomic P ] =>  (case e of Syn [g |- R] => [g |- embed R])
 | [ |- arr T S ] =>

--- a/examples/popl12/normeval-total.bel
+++ b/examples/popl12/normeval-total.bel
@@ -57,7 +57,7 @@ mlam h,g, S => fn s => fn e => case e of
   let {N':[h |- norm T[]]} [h |- N' ] = nosubst s [g |- N ] in
     [h |- rapp (R') (N' ) ]
 
-and nosubst : ({T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h] [ |- T])
+and rec nosubst : ({T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h] [ |- T])
 	    -> [g |- norm S[]]
             -> [h |- norm S[]] =
 / total n (nosubst g h _ s n) /
@@ -136,7 +136,7 @@ mlam g, A => fn r => case [ |- A] of
        reflect [h] [|- S] [h |- rapp (R') N]
 )
 
-and reify : {g:ctx}{A:[|- tp]}Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : {g:ctx}{A:[|- tp]}Sem [g] [ |- A] -> [g |- norm A[]] =
  / total a (reify g a) /
 mlam g, A => fn e => case [ |- A] of
 | [ |- atomic P ] =>  (case e of Syn [g |- R] => [g |- embed R])

--- a/examples/popl12/normeval.bel
+++ b/examples/popl12/normeval.bel
@@ -54,7 +54,7 @@ fn s => fn e => case e of
   let [h |- N' ] = nosubst s [g |- N ] in
     [h |- rapp (R') (N' ) ]
 
-and nosubst : ({T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h] [ |- T])
+and rec nosubst : ({T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h] [ |- T])
 	    -> [g |- norm S[]]
             -> [h |- norm S[]] =
 / total n (nosubst g h _ s n) /
@@ -127,7 +127,7 @@ case [ |- A] of
  Slam (extendSem r)
 
 % Lesson: FACTORIZATION OF CODE HELPS TYPE RECONSTRUCTION!!!
-and extendSem : [g |- neut (arr A[] B[])] ->
+and rec extendSem : [g |- neut (arr A[] B[])] ->
                 ({h:ctx} ({T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h]  [ |- T]) ->
                  Sem [h] [ |- A] -> Sem [h] [ |- B])
 =
@@ -137,7 +137,7 @@ and extendSem : [g |- neut (arr A[] B[])] ->
     let [h |- R' ] = nsubst s r in
        reflect [|- _ ] [h |- rapp (R') N]
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 % / total e (reify g a e) /
 fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- atomic P ] =>  (case e of Syn [g |- R] => [g |- embed R])

--- a/examples/typed-compilation/cps-popl-tutorial1-crec.bel
+++ b/examples/typed-compilation/cps-popl-tutorial1-crec.bel
@@ -40,7 +40,7 @@ fn v =>  case v of
      [g |- clam \v.\c. E']
 
 
-and cpse : (g:ctx)[g |- exp A] -> [g,k:ccont A |-  contra] =
+and rec cpse : (g:ctx)[g |- exp A] -> [g,k:ccont A |-  contra] =
 fn e => case e of
 | [g |- ret (V )] =>
   let [g |- V'] = cps [g |- V ] in

--- a/examples/typed-compilation/cps-popl-tutorial2-crec.bel
+++ b/examples/typed-compilation/cps-popl-tutorial2-crec.bel
@@ -37,7 +37,7 @@ fn v => case v of
     [g |- clam \v.\c. E'[..,v,c]]
 
 
-and cpse : (g:ctx)[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
+and rec cpse : (g:ctx)[g |- exp A] -> [g, c: cvalue A -> contra |-  contra] =
 fn e => case e of
 | [g |- ret (V )] =>
   let [g |- V'] = cps [g |- V ] in

--- a/examples/typed-compilation/debruijn.bel
+++ b/examples/typed-compilation/debruijn.bel
@@ -41,7 +41,7 @@ fn v =>  case v of
    let [ |- F]  =  hoas2db [g,x:value (T[]) |-  E] in
      [ |- lam' (T[]) F]
 
-and hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
+and rec hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
   fn e =>  case e of
    | [g |- app (E1 ) (E2 )] =>
      let [ |- F1] = hoas2db [g |- E1]  in
@@ -66,7 +66,7 @@ rec db2vhoas : (g:ctx) [g |- exp' (T[])] -> [g |- value (T[])] =
       let [g,x:value (T[]) |-  F] = db2hoas  [h, x:value (T[]) |-  E[..]] in
         [g |- lam (T[]) (\x. F)]
 
-and db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
+and rec db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
   fn e => case e of
   | [g |- app' E1 E2] =>
     let [g |- F1] = db2hoas [g |- E1] in

--- a/src/core/abstract.mli
+++ b/src/core/abstract.mli
@@ -23,6 +23,8 @@ type free_var =
   | FDecl of kind * marker
   | CtxV of (Id.name * Id.cid_schema * LF.depend)
 
+type fctx = free_var LF.ctx
+
 
 exception Error of Syntax.Loc.t * error
 
@@ -42,7 +44,8 @@ val msub   : LF.msub -> LF.msub * LF.mctx
 val compkind : Comp.kind -> Comp.kind * Id.offset
 val comptyp  : Comp.typ -> Comp.typ * Id.offset
 val codatatyp  : LF.mctx -> Comp.typ -> Comp.typ -> LF.mctx * Comp.typ * Comp.typ * Id.offset
-val exp      : Comp.exp_chk -> free_var LF.ctx * Comp.exp_chk
+val exp      : Comp.exp_chk -> fctx * Comp.exp_chk
+val thm      : Comp.thm -> fctx * Comp.thm
 
 val pattern    : LF.mctx -> LF.dctx -> (LF.dctx_hat * LF.normal) -> LF.typ ->
                  LF.mctx * LF.dctx * (LF.dctx_hat * LF.normal) * LF.typ
@@ -59,4 +62,4 @@ val closedTyp : (LF.dctx * LF.typ) -> bool
 
 val printFreeMVars : LF.dctx_hat -> LF.normal -> unit
 
-val fmt_ppr_collection : Format.formatter -> free_var LF.ctx -> unit
+val fmt_ppr_collection : Format.formatter -> fctx -> unit

--- a/src/core/check.ml
+++ b/src/core/check.ml
@@ -364,6 +364,8 @@ module Comp = struct
     | I.MShift k, I.Empty -> cD1'
     | I.MShift k, cD when k < 0 ->
        raise (Error.Violation "Contextual substitution ill-formed")
+    | I.MDot (_, _), I.Empty ->
+       Error.violation "Contextual substitution ill-formed"
     | I.MShift k, cD -> (* k >= 0 *)
        id_map_ind cD1' (I.MDot (I.MV (k+1), I.MShift (k+1))) cD
 

--- a/src/core/check.ml
+++ b/src/core/check.ml
@@ -1065,4 +1065,10 @@ module Comp = struct
 
   let check cD cG (total_decs : Total.dec list) ?cIH:(cIH = Syntax.Int.LF.Empty) e ttau =
     check cD (cG,cIH) total_decs e ttau
+
+  let thm cD cG total_decs ?cIH:(cIH = Syntax.Int.LF.Empty) t ttau =
+    match t with
+    | Syntax.Int.Comp.Program e -> check cD cG total_decs ~cIH: cIH e ttau
+    | Syntax.Int.Comp.Proof p -> Misc.not_implemented "checking Harpoon proofs"
+
 end

--- a/src/core/check.mli
+++ b/src/core/check.mli
@@ -84,6 +84,15 @@ module Comp : sig
 
   exception Error of Syntax.Loc.t * error
 
+  val thm :
+    LF.mctx ->
+    gctx ->
+    Total.dec list ->
+    ?cIH: gctx ->
+    thm ->
+    tclo ->
+    unit
+
   val check :
     LF.mctx ->
     (* ^ The meta context *)

--- a/src/core/command.ml
+++ b/src/core/command.ml
@@ -450,9 +450,17 @@ let printfun =
               List.find
                 (fun x -> arg = (Id.string_of_name x.Comp.name)) entrylist
             in
-            match entry.Comp.prog with
-            | Some (Synint.Comp.RecValue (prog, ec, _ms, _env)) ->
-               P.fmt_ppr_sgn_decl ppf (Synint.Sgn.Rec[(prog,entry.Comp.typ ,ec)])
+            match Comp.(entry.prog) with
+            | Some (Synint.Comp.ThmValue (thm_name, thm_body, _ms, _env)) ->
+               let d =
+                 let open Syntax.Int.Sgn in
+                 { thm_name
+                 ; thm_typ = Comp.(entry.typ)
+                 ; thm_body
+                 ; thm_loc = Syntax.Loc.ghost
+                 }
+               in
+               P.fmt_ppr_sgn_decl ppf (Synint.Sgn.Theorem [d])
             | _  -> fprintf ppf "- %s is not a function.;\n@?" arg
           with
           | Not_found ->

--- a/src/core/ctxsub.ml
+++ b/src/core/ctxsub.ml
@@ -170,3 +170,14 @@ let rec mctxToMMSub cD0 cD = match cD with
       MDot (mdeclToMMVar cD0 n mtyp' dep, t)
 
 let mctxToMSub cD = mctxToMMSub Empty cD
+
+(** Drops `n` rightmost entries from an msub. *)
+let rec drop n t =
+  match t with
+  | _ when n <= 0 -> t
+  | MDot (_, t') -> drop (n-1) t'
+
+(** Counts the entries in an msub. *)
+let rec length = function
+  | MShift _ -> 0
+  | MDot (_, t') -> 1 + length t'

--- a/src/core/ctxsub.mli
+++ b/src/core/ctxsub.mli
@@ -29,3 +29,12 @@ val mctxToMMSub : mctx -> mctx -> msub
 
 (* lookupSchemaOpt cO psi_offset *)
 (* val lookupSchemaOpt : mctx -> int -> schema option *)
+
+(** drop n t = t'
+    Drops `n` entries from `t`. *)
+val drop : int -> msub -> msub
+
+(** length t = n
+    Counts the entries in `t`.
+ *)
+val length : msub -> int

--- a/src/core/index.ml
+++ b/src/core/index.ml
@@ -282,8 +282,8 @@ let rec get_ctxvar psi = match psi with
 
 
 let get_ctxvar_mobj (_loc,mO) = match mO with
-  | Ext.Comp.CObj cPsi -> get_ctxvar cPsi
-  | Ext.Comp.ClObj (cPsi, (Ext.LF.EmptySub _, [ _tM ])) -> get_ctxvar cPsi
+  | Ext.LF.CObj cPsi -> get_ctxvar cPsi
+  | Ext.LF.ClObj (cPsi, (Ext.LF.EmptySub _, [ _tM ])) -> get_ctxvar cPsi
   | _ -> None
 
 let rec length_typ_rec t_rec = match t_rec with
@@ -342,10 +342,10 @@ and index_typ (a : Ext.LF.typ) : Apx.LF.typ index =
             p.fmt "[index_typ] shunting_yard' of %a gives %a with %a"
               (Format.pp_print_list
                  ~pp_sep: Fmt.comma
-                 (P.fmt_ppr_lf_normal Ext.LF.Empty Ext.LF.Null P.l0))
+                 (P.fmt_ppr_lf_normal P.l0))
               nl
               Id.print a
-              (P.fmt_ppr_lf_spine Ext.LF.Empty Ext.LF.Null P.l0) tS');
+              (P.fmt_ppr_lf_spine P.l0) tS');
         index_typ (Ext.LF.Atom (loc, a, tS'))
      | _ -> throw loc IllFormedCompTyp
      end
@@ -913,14 +913,14 @@ let index_cltyp' (a : Ext.LF.cltyp) : Apx.LF.cltyp index =
      dprintf
        (fun p ->
          p.fmt "[index_cltyp'] indexing meta type %a"
-           (P.fmt_ppr_lf_typ Ext.LF.Empty Ext.LF.Null P.l0) a);
+           (P.fmt_ppr_lf_typ P.l0) a);
      index_typ a $> fun a' -> Apx.LF.MTyp a'
 
   | Ext.LF.PTyp a ->
      dprintf
        (fun p ->
          p.fmt "[index_cltyp'] indexing parameter type %a"
-           (P.fmt_ppr_lf_typ Ext.LF.Empty Ext.LF.Null P.l0) a);
+           (P.fmt_ppr_lf_typ P.l0) a);
      index_typ a $> fun a' -> Apx.LF.PTyp a'
                               (*
      in
@@ -940,7 +940,7 @@ let index_cltyp' (a : Ext.LF.cltyp) : Apx.LF.cltyp index =
        (fun p ->
          p.fmt "[index_cltyp'] indexing %a type %a"
            print_subst_class cl
-           (P.fmt_ppr_lf_dctx Ext.LF.Empty P.l0) phi);
+           (P.fmt_ppr_lf_dctx P.l0) phi);
      seq2 get_env get_fvars
      $ fun (c, fvars) ->
        let (phi', _bvars', fvars) =
@@ -1033,7 +1033,7 @@ let index_clobj cvars bvars fcvars m =
    *)
 
 let rec index_meta_obj cvars fcvars (l,cM) = match cM with
-  | Ext.Comp.CObj cpsi ->
+  | Ext.LF.CObj cpsi ->
      let (cPsi, _bvars, fcvars') =
        index_dctx disambiguate_to_fmvars cvars (BVar.create ()) fcvars cpsi
      in
@@ -1041,7 +1041,7 @@ let rec index_meta_obj cvars fcvars (l,cM) = match cM with
      , fcvars'
      )
 
-  | Ext.Comp.ClObj (cpsi, s) ->
+  | Ext.LF.ClObj (cpsi, s) ->
      let (cPsi, bvars, fcvars') =
        index_dctx disambiguate_to_fmvars cvars (BVar.create ()) fcvars cpsi
      in

--- a/src/core/index.mli
+++ b/src/core/index.mli
@@ -1,3 +1,6 @@
+module Ext = Syntax.Ext
+module Apx = Syntax.Apx
+
 type open_or_closed =
   [ `open_term
   | `closed_term
@@ -13,23 +16,24 @@ val disambiguate_to_fvars : name_disambiguator
 val disambiguate_to_fmvars : name_disambiguator
 
 val kind     : name_disambiguator ->
-               Syntax.Ext.LF.kind -> fvars * Syntax.Apx.LF.kind
+               Ext.LF.kind -> fvars * Apx.LF.kind
 
 val typ      : name_disambiguator ->
-               Syntax.Ext.LF.typ -> fvars * Syntax.Apx.LF.typ
+               Ext.LF.typ -> fvars * Apx.LF.typ
 
-val schema   : Syntax.Ext.LF.schema -> Syntax.Apx.LF.schema
+val schema   : Ext.LF.schema -> Apx.LF.schema
 
-val mctx     : Syntax.Ext.LF.mctx -> Syntax.Apx.LF.mctx
+val mctx     : Ext.LF.mctx -> Apx.LF.mctx
 
-val compkind : Syntax.Ext.Comp.kind -> Syntax.Apx.Comp.kind
+val compkind : Ext.Comp.kind -> Apx.Comp.kind
 
-val comptyp  : Syntax.Ext.Comp.typ -> Syntax.Apx.Comp.typ
+val comptyp  : Ext.Comp.typ -> Apx.Comp.typ
 
-val comptypdef : Syntax.Ext.Comp.typ * Syntax.Ext.Comp.kind
-              -> Syntax.Apx.Comp.typ * Syntax.Apx.Comp.kind
+val comptypdef : Ext.Comp.typ * Ext.Comp.kind
+              -> Apx.Comp.typ * Apx.Comp.kind
 
-val exp      : Store.Var.t -> Syntax.Ext.Comp.exp_chk -> Syntax.Apx.Comp.exp_chk
-val exp'     : Store.Var.t -> Syntax.Ext.Comp.exp_syn -> Syntax.Apx.Comp.exp_syn
-val hexp     : Store.CVar.t ->  Store.Var.t -> Syntax.Ext.Comp.exp_chk -> Syntax.Apx.Comp.exp_chk
-val hexp'    : Store.CVar.t ->  Store.Var.t -> Syntax.Ext.Comp.exp_syn -> Syntax.Apx.Comp.exp_syn
+val exp      : Store.Var.t -> Ext.Comp.exp_chk -> Apx.Comp.exp_chk
+val exp'     : Store.Var.t -> Ext.Comp.exp_syn -> Apx.Comp.exp_syn
+val hexp     : Store.CVar.t -> Store.Var.t -> Ext.Comp.exp_chk -> Apx.Comp.exp_chk
+val hexp'    : Store.CVar.t -> Store.Var.t -> Ext.Comp.exp_syn -> Apx.Comp.exp_syn
+val thm      : Store.Var.t -> Ext.Comp.thm -> Apx.Comp.thm

--- a/src/core/interactive.ml
+++ b/src/core/interactive.ml
@@ -153,6 +153,10 @@ and mapHoleBranch f = function
       let ec' =  mapHoleChk f ec  in
       Branch (l, cD, cG, p, mS, ec')
 
+let mapHoleThm f = function
+  | Program e -> Program (mapHoleChk f e)
+  | Proof p -> Misc.not_implemented "mapHoleThm"
+
 (*********************)
 (* top level tactics *)
 (*********************)

--- a/src/core/lexer.ml
+++ b/src/core/lexer.ml
@@ -153,6 +153,9 @@ let rec tokenize loc lexbuf =
   | "LF" -> const T.KW_LF
   | "fun" -> const T.KW_FUN
   | "typedef" -> const T.KW_TYPEDEF
+  | "proof" -> const T.KW_PROOF
+  | "by" -> const T.KW_BY
+  | "as" -> const T.KW_AS
 
   (* SYMBOLS *)
   | pragma -> T.PRAGMA (Misc.String.drop 2 (get_lexeme loc lexbuf))

--- a/src/core/lfcheck.ml
+++ b/src/core/lfcheck.ml
@@ -257,35 +257,35 @@ let rec checkW cD cPsi sM sA = match sM, sA with
 
   | (Root (loc, _h, _tS), _s (* id *)), (Atom _, _s') ->
     (* cD ; cPsi |- [s]tA <= type  where sA = [s]tA *)
-    begin
-      try
-        dprintf
-          (fun p ->
-            p.fmt "[ROOT check] %a ; %a |- %a <= %a"
-              (P.fmt_ppr_lf_mctx P.l0) cD
-              (P.fmt_ppr_lf_dctx cD P.l0) cPsi
-              (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM)
-              (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sA));
-        let sP = syn cD cPsi sM in
-        dprintf
-          (fun p ->
-            p.fmt "[ROOT check] @[<v>synthesized:@,%a ; %a |- %a <= %a@,against %a@]"
-              (P.fmt_ppr_lf_mctx P.l0) cD
-              (P.fmt_ppr_lf_dctx cD P.l0) cPsi
-              (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM)
-              (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sP)
-              (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sA)
-          );
-	  Typeinfo.LF.add loc (Typeinfo.LF.mk_entry cD cPsi sA)
-	    (let open Format in
-       fprintf str_formatter "Root %a"
-         (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM);
-       flush_str_formatter ());
-      let (tP', tQ') = (Whnf.normTyp sP , Whnf.normTyp sA) in
-      if not (Whnf.convTyp  (tP', Substitution.LF.id) (tQ', Substitution.LF.id)) then
-        raise (Error (loc, TypMismatch (cD, cPsi, sM, sA, sP)))
-      with SpineMismatch ->
-        raise (Error (loc, (CheckError (cD, cPsi, sM, sA))))
+     begin
+       try
+         dprintf
+           (fun p ->
+             p.fmt "[ROOT check] %a ; %a |- %a <= %a"
+               (P.fmt_ppr_lf_mctx P.l0) cD
+               (P.fmt_ppr_lf_dctx cD P.l0) cPsi
+               (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM)
+               (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sA));
+         let sP = syn cD cPsi sM in
+         dprintf
+           (fun p ->
+             p.fmt "[ROOT check] @[<v>synthesized:@,%a ; %a |- %a <= %a@,against %a@]"
+               (P.fmt_ppr_lf_mctx P.l0) cD
+               (P.fmt_ppr_lf_dctx cD P.l0) cPsi
+               (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM)
+               (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sP)
+               (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp sA)
+           );
+	       Typeinfo.LF.add loc (Typeinfo.LF.mk_entry cD cPsi sA)
+	         (let open Format in
+            fprintf str_formatter "Root %a"
+              (P.fmt_ppr_lf_normal cD cPsi P.l0) (Whnf.norm sM);
+            flush_str_formatter ());
+         let (tP', tQ') = (Whnf.normTyp sP , Whnf.normTyp sA) in
+         if not (Whnf.convTyp  (tP', Substitution.LF.id) (tQ', Substitution.LF.id)) then
+           raise (Error (loc, TypMismatch (cD, cPsi, sM, sA, sP)))
+       with SpineMismatch ->
+         raise (Error (loc, (CheckError (cD, cPsi, sM, sA))))
     end
 
   | (Root (loc, _, _), _), _ ->

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -1661,8 +1661,8 @@ let meta_obj =
           |> span
           $> fun (loc, (cPsi, tR)) ->
              match tR with
-             | Some tR -> (loc, Comp.ClObj (cPsi, tR))
-             | None -> (loc, Comp.CObj cPsi)
+             | Some tR -> (loc, LF.ClObj (cPsi, tR))
+             | None -> (loc, LF.CObj cPsi)
         in
         clobj
         |> bracks

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -243,7 +243,7 @@ type error' =
   (* ^ incorrect constructor type: the type of a constructor must be a
      base type or a function type.
    *)
-  | Custom of string (* Generic external error. *)
+  (* | Custom of string (* Generic external error. *) *)
   | WrongConstructorType of
       Id.name (* constructor name *)
       * Id.name (* expected type name *)
@@ -351,7 +351,7 @@ let print_error ppf ({path; loc; _} as e : error) =
          (Id.string_of_name c)
          (Id.string_of_name exp)
          (Id.string_of_name act)
-    | Custom s -> fprintf ppf "%s" s
+    (* | Custom s -> fprintf ppf "%s" s *)
     | Violation s -> fprintf ppf "%s" s
   in
   fprintf ppf "%a" g e;

--- a/src/core/parser.mli
+++ b/src/core/parser.mli
@@ -47,7 +47,7 @@ val only : 'a t -> 'a t
 val sgn : Syntax.Ext.Sgn.decl list t
 
 (** Parser for a Harpoon command. *)
-val harpoon_command : Syntax.Ext.Harpoon.command t
+val interactive_harpoon_command : Syntax.Ext.Harpoon.command t
 
 val numeric_total_order : Syntax.Ext.Comp.numeric_order t
 val optional_numeric_total_order : Syntax.Ext.Comp.numeric_order option t

--- a/src/core/prettyext.ml
+++ b/src/core/prettyext.ml
@@ -818,42 +818,6 @@ module Make (R : Store.Cid.RENDERER) : Printer.Ext.T = struct
     (fmt_ppr_lf_typ cD LF.Null lvl) tau
    *)
 
-  let total_to_string tdec = match tdec with
-    | None -> ""
-    | Some (Comp.Trust _) -> "/ trust /"
-    | Some (Comp.Total (_ , order, f, args)) ->
-       let rec args_to_string args = match args with
-         | [] -> ""
-         | Some n :: args' -> Id.render_name n ^ " " ^ args_to_string args'
-         | None :: args' -> " _ " ^ args_to_string args'
-       in
-       let rec order_to_string order = match order with
-         | Comp.Arg n -> Id.render_name n
-         | Comp.Lex orders ->
-            "{" ^ String.concat " " (List.map order_to_string orders) ^ "}"
-       in
-       "/ total " ^
-         (match order with
-          | Some order -> order_to_string order
-          | None -> ""
-         )
-         ^ " ( " ^ Id.render_name f ^ " " ^ args_to_string args ^ ") /"
-
-  let fmt_ppr_cmp_rec prefix lvl ppf = function
-    | Comp.RecFun (_, x, total, a, e) ->
-       fprintf ppf "@[<h>%s %s : %a %s@] =@[<v2>%a@]"
-         (to_html prefix Keyword)
-         (to_html (Id.render_name x) (ID Fun))
-         (fmt_ppr_cmp_typ lvl)  a
-         (total_to_string total)
-         (fmt_ppr_cmp_exp_chk lvl)  e
-
-  let fmt_ppr_rec lvl ppf = function
-    | [] -> ()
-    | h::t -> fmt_ppr_cmp_rec "rec" lvl ppf h;
-              List.iter (fun x -> fmt_ppr_cmp_rec "and" lvl ppf x) t;
-              fprintf ppf ";@ "
-
   let fmt_ppr_mrec prefix lvl ppf = function
     | Sgn.Typ(_, n, kA) ->
        fprintf ppf "%s %s : %a = "
@@ -931,9 +895,6 @@ module Make (R : Store.Cid.RENDERER) : Printer.Ext.T = struct
          (to_html "schema" Keyword)
          (to_html (Id.render_name  x) (ID Schema))
          (fmt_ppr_lf_schema 0) schema
-
-    | Sgn.Rec (_, lrec) ->
-       (fmt_ppr_rec l0 ppf) lrec
 
     | Sgn.Pragma (_, Sgn.NamePrag(name, s, s_opt)) ->
        fprintf ppf "@[<h>%s %s %s %s@]@\n"

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -444,8 +444,8 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
 
     | LF.MDot (f, s) ->
        fprintf ppf "%a@ ,@ %a"
-         (fmt_ppr_lf_mfront cD 1) f
          (fmt_ppr_lf_msub cD lvl) s
+         (fmt_ppr_lf_mfront cD 1) f
 
   and fmt_ppr_lf_clobj cD lvl cPsi ppf = function
     | LF.MObj m -> fmt_ppr_lf_normal cD cPsi lvl ppf m

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -135,9 +135,10 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
 
     in let deimplicitize_spine h ms = match h with
          | LF.Const c ->
-            let implicit_arguments = if !Printer.Control.printImplicit
-                                     then 0
-                                     else Store.Cid.Term.get_implicit_arguments c
+            let implicit_arguments =
+              if !Printer.Control.printImplicit
+              then 0
+              else Store.Cid.Term.get_implicit_arguments c
             in
             dropSpineLeft ms implicit_arguments
 

--- a/src/core/printer.ml
+++ b/src/core/printer.ml
@@ -90,6 +90,9 @@ module Int = struct
     val fmt_ppr_cmp_meta_typ      : LF.mctx -> lvl -> formatter -> Comp.meta_typ -> unit
     val fmt_ppr_cmp_meta_obj      : LF.mctx -> lvl -> formatter -> Comp.meta_obj -> unit
     val fmt_ppr_cmp_meta_spine    : LF.mctx -> lvl -> formatter -> Comp.meta_spine -> unit
+
+    val fmt_ppr_cmp_thm : formatter -> Comp.thm -> unit
+    val fmt_ppr_sgn_thm_decl : formatter -> Sgn.thm_decl -> unit
   end
 end
 

--- a/src/core/printer.ml
+++ b/src/core/printer.ml
@@ -104,33 +104,33 @@ module Ext = struct
     (* Contextual Format Based Pretty Printers *)
     val fmt_ppr_sgn           : formatter -> Sgn.sgn -> unit
     val fmt_ppr_sgn_decl      : formatter -> Sgn.decl -> unit
-    val fmt_ppr_lf_kind       : LF.dctx -> lvl -> formatter -> LF.kind      -> unit
-    val fmt_ppr_lf_ctyp_decl  : LF.mctx -> lvl -> formatter -> LF.ctyp_decl -> unit
-    val fmt_ppr_lf_typ_rec    : LF.mctx -> LF.dctx -> lvl -> formatter -> LF.typ_rec    -> unit
+    val fmt_ppr_lf_kind       : lvl -> formatter -> LF.kind      -> unit
+    val fmt_ppr_lf_ctyp_decl  : formatter -> LF.ctyp_decl -> unit
+    val fmt_ppr_lf_typ_rec    : formatter -> LF.typ_rec    -> unit
 
-    val fmt_ppr_lf_typ        : LF.mctx -> LF.dctx -> lvl -> formatter -> LF.typ    -> unit
-    val fmt_ppr_lf_normal     : LF.mctx -> LF.dctx -> lvl -> formatter -> LF.normal -> unit
-    val fmt_ppr_lf_head       : LF.mctx -> LF.dctx -> lvl -> formatter -> LF.head   -> unit
-    val fmt_ppr_lf_spine      : LF.mctx -> LF.dctx -> lvl -> formatter -> LF.spine  -> unit
+    val fmt_ppr_lf_typ        : lvl -> formatter -> LF.typ    -> unit
+    val fmt_ppr_lf_normal     : lvl -> formatter -> LF.normal -> unit
+    val fmt_ppr_lf_head       : lvl -> formatter -> LF.head   -> unit
+    val fmt_ppr_lf_spine      : lvl -> formatter -> LF.spine  -> unit
     val fmt_ppr_lf_sub        : ?pp_empty:(formatter -> unit -> bool) ->
-                                LF.mctx -> LF.dctx -> lvl -> formatter -> LF.sub    -> unit
+                                lvl -> formatter -> LF.sub    -> unit
 
     val fmt_ppr_lf_schema     : lvl -> formatter -> LF.schema     -> unit
     val fmt_ppr_lf_sch_elem   : lvl -> formatter -> LF.sch_elem   -> unit
 
-    val fmt_ppr_lf_dctx_hat    : LF.mctx -> lvl -> formatter -> LF.dctx  -> unit
-    val fmt_ppr_lf_dctx       : LF.mctx -> lvl -> formatter -> LF.dctx  -> unit
+    val fmt_ppr_lf_dctx_hat   : formatter -> LF.dctx  -> unit
+    val fmt_ppr_lf_dctx       : lvl -> formatter -> LF.dctx  -> unit
 
     val fmt_ppr_lf_mctx       : ?sep:(formatter -> unit -> unit)
                                 -> lvl -> formatter -> LF.mctx     -> unit
-    val fmt_ppr_cmp_kind      : LF.mctx -> lvl -> formatter -> Comp.kind -> unit
-    val fmt_ppr_cmp_typ       : LF.mctx -> lvl -> formatter -> Comp.typ -> unit
-    val fmt_ppr_cmp_exp_chk   : LF.ctyp_decl LF.ctx -> int -> Format.formatter -> Comp.exp_chk -> unit
-    val fmt_ppr_cmp_exp_syn   : LF.ctyp_decl LF.ctx -> int -> Format.formatter -> Comp.exp_syn -> unit
-    val fmt_ppr_cmp_branches  : LF.ctyp_decl LF.ctx -> int -> Format.formatter -> Comp.branch list -> unit
-    val fmt_ppr_cmp_branch    : LF.ctyp_decl LF.ctx -> int -> Format.formatter -> Comp.branch -> unit
-    val fmt_ppr_pat_obj       : LF.ctyp_decl LF.ctx -> int -> Format.formatter -> Comp.pattern -> unit
+    val fmt_ppr_cmp_kind      : lvl -> formatter -> Comp.kind -> unit
+    val fmt_ppr_cmp_typ       : lvl -> formatter -> Comp.typ -> unit
+    val fmt_ppr_cmp_exp_chk   : int -> Format.formatter -> Comp.exp_chk -> unit
+    val fmt_ppr_cmp_exp_syn   : int -> Format.formatter -> Comp.exp_syn -> unit
+    val fmt_ppr_cmp_branches  : Format.formatter -> Comp.branch list -> unit
+    val fmt_ppr_cmp_branch    : Format.formatter -> Comp.branch -> unit
+    val fmt_ppr_pat_obj       : int -> Format.formatter -> Comp.pattern -> unit
 
-    val fmt_ppr_patternOpt    : LF.mctx -> LF.dctx -> formatter -> LF.normal option -> unit
+    val fmt_ppr_patternOpt    : formatter -> LF.normal option -> unit
   end
 end

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -1827,6 +1827,8 @@ and elFBranch cD cG fbr theta_tau = match fbr with
       end;
     Int.Comp.ConsFBranch (loc, (cD1, cG1, ps1, e''), elFBranch cD cG fbr' theta_tau)
 
+let elProof cD cG p ttau = assert false
+
 (* ******************************************************************************* *)
 (* TOP LEVEL                                                                       *)
 
@@ -1880,3 +1882,7 @@ let comptypdef loc a (tau, cK) =
 let exp  = elExp  Int.LF.Empty
 
 let exp' = elExp' Int.LF.Empty
+
+let thm cG t ttau = match t with
+  | Apx.Comp.Program e -> Int.Comp.Program (elExp Int.LF.Empty cG e ttau)
+  | Apx.Comp.Proof p -> Int.Comp.Proof (elProof Int.LF.Empty cG p ttau)

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -1690,11 +1690,7 @@ and synPatRefine loc caseT (cD, cD_p) pat (tau_s, tau_p) =
       (P.fmt_ppr_lf_mctx P.l0) cD1'
       (P.fmt_ppr_lf_msub cD1' P.l0) t'
     end;
-  let rec drop t l_delta1 = match (l_delta1, t) with
-    | (0, t) -> t
-    | (k, Int.LF.MDot(_ , t') ) -> drop t' (k-1) in
-
-  let t0   = drop t' n in  (* cD1' |- t0 <= cD *)
+  let t0   = Ctxsub.drop n t' in  (* cD1' |- t0 <= cD *)
 
   let pat' = Whnf.cnormPattern (pat,  Whnf.mcomp t1 t') in
   let _    = dprint (fun () -> "cnormPat done ... ") in

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -482,7 +482,7 @@ let elClObj cD loc cPsi' clobj mtyp =
          p.fmt "[elClObj] disambiguating substitution to term at %a"
            Loc.print loc);
      let r = Int.LF.MObj (Lfrecon.elTerm Lfrecon.Pibox cD cPsi' tM (tA, LF.id)) in
-     dprint (fun () -> "̱\n[ElClObj] ELABORATION MObj DONE\n");
+     dprint (fun () -> "[ElClObj] ELABORATION MObj DONE");
      r
 
   (* proper substitution elaboration *)
@@ -526,7 +526,7 @@ let elClObj cD loc cPsi' clobj mtyp =
 let rec elMetaObj' cD loc cM cTt = match cM , cTt with
   | (Apx.Comp.CObj psi, (Int.LF.CTyp (Some w))) ->
       let cPsi' = elDCtxAgainstSchema loc Lfrecon.Pibox cD psi w in
-        Int.LF.CObj cPsi'
+      Int.LF.CObj cPsi'
 
   | (Apx.Comp.ClObj (cPhi, clobj), (Int.LF.ClTyp (mtyp, cPsi'))) ->
      begin

--- a/src/core/reconstruct.mli
+++ b/src/core/reconstruct.mli
@@ -62,3 +62,5 @@ val elExp' : Int.LF.mctx ->
 
 val exp  : Int.Comp.gctx -> Apx.Comp.exp_chk -> Int.Comp.typ * Int.LF.msub -> Int.Comp.exp_chk
 val exp' : Int.Comp.gctx -> Apx.Comp.exp_syn -> Int.Comp.exp_syn * Int.Comp.tclo
+
+val thm : Int.Comp.gctx -> Apx.Comp.thm -> Int.Comp.typ * Int.LF.msub -> Int.Comp.thm

--- a/src/core/store.ml
+++ b/src/core/store.ml
@@ -1386,6 +1386,9 @@ module Var = struct
   let of_gctx (cG : Int.Comp.gctx) : t =
     let f d v = Int.Comp.name_of_ctyp_decl d |> mk_entry |> extend v in
     List.fold_right f (Context.to_list_rev cG) (create ())
+
+  let of_list (l : Id.name list) : t =
+    List.map mk_entry l
 end
 
 
@@ -1429,6 +1432,9 @@ module CVar = struct
   let of_mctx (cD : Int.LF.mctx) : t =
     let f d v = Int.LF.name_of_ctyp_decl d |> mk_entry |> extend v in
     List.fold_right f (Context.to_list_rev cD) (create ())
+
+  let of_list (l : Id.name list) : t =
+    List.map mk_entry l
 end
 
 let clear () =

--- a/src/core/store.mli
+++ b/src/core/store.mli
@@ -368,6 +368,7 @@ module Var : sig
 
   (** Erases the context down to a list of names. *)
   val of_gctx       : Comp.gctx -> t
+  val of_list       : Id.name list -> t
 end
 
 
@@ -394,4 +395,5 @@ module CVar : sig
   val of_mctx       : LF.mctx -> t
 
   val to_string     : t -> string
+  val of_list       : Id.name list -> t
 end

--- a/src/core/synapx.ml
+++ b/src/core/synapx.ml
@@ -189,4 +189,48 @@ module Comp = struct
      | NormalPattern of LF.normal * exp_chk
      | EmptyPattern
 
+  type ctyp_decl =
+    | CTypDecl of name * typ
+
+  type gctx = ctyp_decl LF.ctx
+
+  type hypotheses =
+    { cD : LF.mctx
+    ; cG : gctx
+    }
+
+  type proof =
+    | Incomplete of Loc.t * string option
+    | Command of Loc.t * command * proof
+    | Directive of Loc.t * directive
+
+  and command =
+    | By of Loc.t * Syncom.Harpoon.invoke_kind * exp_syn * name
+    | Unbox of Loc.t * exp_syn * name
+
+  and directive =
+    | Intros of Loc.t * hypothetical
+    | Solve of Loc.t * exp_chk
+    | Split of Loc.t * exp_syn * split_branch list
+
+  and split_branch =
+    { case_label : name
+    (* we don't index the case label yet since we don't know whether
+       it should be comp constructors or LF constructors,
+       so this is deferred till type reconstruction when we know the
+       scrutinee's type.
+     *)
+    ; branch_body : hypothetical
+    ; split_branch_loc : Loc.t
+    }
+
+  and hypothetical =
+    { hypotheses : hypotheses
+    ; proof : proof
+    ; hypothetical_loc : Loc.t
+    }
+
+  type thm =
+    | Program of exp_chk
+    | Proof of proof
 end

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -93,6 +93,19 @@ module LF = struct
 
   and mctx = ctyp_decl ctx
 
+ type mfront =
+   | ClObj of dctx * sub
+   (* ClObj doesn't *really* contain just a substitution.
+      The problem is that syntactically, we can't tell
+      whether `[psi |- a]' is a boxed object or
+      substitution! So it turns out that,
+      syntactically, substitutions encompass both
+      possibilities: a substitution beginning with
+      EmptySub and having just one normal term in it
+      can represent a boxed term. We disambiguate
+      substitutions from terms at a later time. *)
+   | CObj of dctx
+
   (** Converts a spine to a list. It is visually "backwards" *)
   let rec list_of_spine (sp : spine) : (Loc.t * normal) list =
     match sp with
@@ -109,6 +122,12 @@ module LF = struct
     | NTyp (l, _) -> l
     | PatEmpty l -> l
 
+  let loc_of_head = function
+    | Name (l, _, _) -> l
+    | Hole l -> l
+    | PVar (l, _, _) -> l
+    | Proj (l, _, _) -> l
+
   (** Wraps a term into a dummy substitution. *)
   let term tM = (EmptySub (loc_of_normal tM), [tM])
 end
@@ -122,21 +141,7 @@ module Comp = struct
    | Ctype of Loc.t
    | PiKind  of Loc.t * LF.ctyp_decl * kind
 
- type mfront =
-   | ClObj of LF.dctx
-              * LF.sub
-   (* ClObj doesn't *really* contain just a substitution.
-      The problem is that syntactically, we can't tell
-      whether `[psi |- a]' is a boxed object or
-      substitution! So it turns out that,
-      syntactically, substitutions encompass both
-      possibilities: a substitution beginning with
-      EmptySub and having just one normal term in it
-      can represent a boxed term. We disambiguate
-      substitutions from terms at a later time. *)
-   | CObj of LF.dctx
-
- type meta_obj = Loc.t * mfront
+ type meta_obj = Loc.t * LF.mfront
 
  type meta_spine =                             (* Meta-Spine  mS :=         *)
    | MetaNil                                   (* | .                       *)

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -44,6 +44,10 @@ module LF = struct
     | Clo  of (normal * sub)                  (*   | Clo(N,s)                   *)
     | Tuple of Loc.t * tuple
 
+  (* TODO: Heads ought to carry their location.
+     Erasure currently needs to invent / pretend that a different
+     location is the correct one.
+   *)
   and head =
     | BVar  of offset                         (* H ::= x                        *)
     | Const of cid_term                       (*   | c                          *)

--- a/src/core/token.ml
+++ b/src/core/token.ml
@@ -69,6 +69,9 @@ type t =
   | KW_LF
   | KW_FUN
   | KW_TYPEDEF
+  | KW_PROOF
+  | KW_BY
+  | KW_AS
 
   (* Can mean identifier, operator, etc. *)
   | IDENT  of string
@@ -157,6 +160,9 @@ let print (c : class_or_string) ppf =
   | KW_LF -> case (lazy (p "LF")) (lazy (p "KW_LF"))
   | KW_FUN -> case (lazy (p "fun")) (lazy (p "KW_FUN"))
   | KW_TYPEDEF -> case (lazy (p "typedef")) (lazy (p "KW_TYPEDEF"))
+  | KW_PROOF -> case (lazy (p "proof")) (lazy (p "KW_PROOF"))
+  | KW_AS -> case (lazy (p "as")) (lazy (p "KW_AS"))
+  | KW_BY -> case (lazy (p "by")) (lazy (p "KW_BY"))
 
   | BLOCK_COMMENT s -> case (lazy (p "%%{{ %s %%}}" s)) (lazy (p "BLOCK_COMMENT"))
   | IDENT s -> case (lazy (p "%s" s)) (lazy (p "IDENT"))

--- a/src/core/total.ml
+++ b/src/core/total.ml
@@ -1302,6 +1302,20 @@ let is_meta_inductive (cD : LF.mctx) (mf : LF.mfront) : bool =
   let open Maybe in
   variable_of_mfront mf
   $> fst
+  (* this `fst` is possibly sketchy because of projected parameter
+     variables, but I don't think parameter variables can ever be
+     inductive, so I don't *think* it's a problem.
+     -je *)
   $> is_inductive_meta_variable
   $ of_bool
   |> is_some
+
+(** Checks if the scrutinee of a case is on an inductive computational
+    variable or an inductive meta-variable. *)
+let is_inductive_split (cD : LF.mctx) (cG : Comp.gctx) (i : Comp.exp_syn) : bool =
+  is_comp_inductive cG i
+  || let open Maybe in
+     Comp.is_meta_obj i
+     $> snd
+     $> is_meta_inductive cD
+     |> is_some

--- a/src/core/unify.ml
+++ b/src/core/unify.ml
@@ -1954,9 +1954,11 @@ let rec ground_sub cD = function (* why is parameter cD is unused? -je *)
           end;
         begin match () with
         | () when isId s && isMId mt && not (blockdeclInDctx cPsi) ->
-           dprint
-             (fun _ ->
-               "[unifyTerm] instantiating immediately because all substitutions are identity and there's no block in cPsi");
+           dprintf
+             begin fun p ->
+               p.fmt "[unifyTerm] @[<v>instantiating immediately:@, mmvar := @[%a@]@]"
+                 (P.fmt_ppr_lf_normal cD cPsi P.l0) tM2
+             end;
            instantiateMMVar (instantiation, tM2, !constraints)
         | () when blockdeclInDctx (Whnf.cnormDCtx (cPsi1, Whnf.m_id)) ->
            dprnt "[unifyTerm] there's a block decl in cPsi";

--- a/src/core/whnf.ml
+++ b/src/core/whnf.ml
@@ -1754,6 +1754,10 @@ let mctxMVarPos cD u =
     | Comp.ConsFBranch (loc, (cD, cG, patS, e), fbr') ->
       Comp.ConsFBranch (loc, (cD, cG, patS, cnormExp (e, t)), cnormFBranches (fbr',t))
 
+  let cnormThm (t, theta) = match t with
+    | Comp.Program e -> Comp.Program (cnormExp (e, theta))
+    | Comp.Proof p -> Misc.not_implemented "cnormThm Proof"
+
   let rec cwhnfCtx (cG, t) = match cG with
     | Empty  -> Empty
     | Dec(cG, Comp.CTypDecl (x, tau, flag)) -> Dec (cwhnfCtx (cG,t), Comp.CTypDecl (x, Comp.TypClo (tau, t), flag))

--- a/src/core/whnf.mli
+++ b/src/core/whnf.mli
@@ -128,6 +128,7 @@ val cwhnfCtx   : Comp.gctx * msub -> Comp.gctx
 
 val cnormExp   : Comp.exp_chk * msub -> Comp.exp_chk
 val cnormExp'  : Comp.exp_syn * msub -> Comp.exp_syn
+val cnormThm   : Comp.thm * msub -> Comp.thm
 
 val normCtx    : Comp.gctx -> Comp.gctx
 val normCTyp   : Comp.typ  -> Comp.typ

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -318,7 +318,7 @@ type 'a error = (Format.formatter -> unit, 'a) Either.t
  *)
 let parse_input (input : string) : Command.command error =
   let open B in
-  Runparser.parse_string "<prompt>" input Parser.(only harpoon_command)
+  Runparser.parse_string "<prompt>" input Parser.(only interactive_harpoon_command)
   |> snd |> Parser.to_either
   |> Either.lmap (fun e ppf -> Parser.print_error ppf e)
 

--- a/src/harpoon/translate.ml
+++ b/src/harpoon/translate.ml
@@ -1,0 +1,3 @@
+module I = Beluga.Syntax.Int.Comp
+
+let translate (p : I.proof) : I.exp_chk = assert false

--- a/t/code/error/misnamedproj.bel
+++ b/t/code/error/misnamedproj.bel
@@ -26,7 +26,8 @@ fn e => case e of
     [g |- app' (T1[..] ) (T2[..])]
 | [g |- ret (V[..] )] => convv [g |- V[..] ]
 
-and convv: (g:ctx)[g |- value (T[])] -> [g |- term] =
+and
+rec convv: (g:ctx)[g |- value (T[])] -> [g |- term] =
 fn v => case v of
 | [g |- #p._t[..]] => [g |- #p.x[..]]
 | [g |- lam (A[]) (\v. E)] =>

--- a/t/code/success/LFHoles/debruijn.bel
+++ b/t/code/success/LFHoles/debruijn.bel
@@ -41,7 +41,7 @@ fn v =>  case v of
    let [ |- F]  =  hoas2db [g,x:value (T[]) |-  E] in
      [ |- lam' (T[]) F]
 
-and hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
+and rec hoas2db : (g:ctx) [g |- exp (T[])] ->  [ |- exp' T] =
   fn e =>  case e of
    | [g |- app (E1[..] ) (E2[..] )] =>
      let [ |- F1] = hoas2db [g |- E1[..]]  in
@@ -66,7 +66,7 @@ rec db2vhoas : (g:ctx) [g |- exp' T] -> [g |- value T] =
       let [g,x:value (T[]) |-  F] = db2hoas  [h, x:value (T[]) |- E[]] in
         [g |- lam (T[]) (\x. F)]
 
-and db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
+and rec db2hoas : (g:ctx) [g |- exp' T] -> [g |- exp T] =
   fn e => case e of
   | [g |- app' E1 E2] =>
     let [g |- F1[..]] = db2hoas [g |- E1] in

--- a/t/code/success/base/dependency.bel
+++ b/t/code/success/base/dependency.bel
@@ -12,20 +12,20 @@ nd_allI: ({a:i} nd (A a)) → nd (all (\x. A x)).
 
 nd_neg : nd A → nd (neg A).
 
-proof: nd A -> type.
+prf: nd A -> type.
 
-pr_all: ({a:i} proof (D a)) → proof (nd_allI (\a. D a)).
+pr_all: ({a:i} prf (D a)) → prf (nd_allI (\a. D a)).
 
-pr_neg: proof D → proof (nd_neg D).
+pr_neg: prf D → prf (nd_neg D).
 
 %
 % pr_all : {A :  i -> o}
 %          {D: {a : i} nd (A a)}
-%           ({a : i} proof (A a) (D a)) ->
-%            proof (all (\ x . A x)) (nd_allI (\x . A x) (\a . D a)).
+%           ({a : i} prf (A a) (D a)) ->
+%            prf (all (\ x . A x)) (nd_allI (\x . A x) (\a . D a)).
 %
 
 
-prove: proof D -> ({a:i}proof (E a)) -> type.
+prove: prf D -> ({a:i}prf (E a)) -> type.
 
 prove_all: ({a:i} prove (D a)  (\b. (pr_neg (E a)))) → prove (pr_all (\a. D a))  (\a. E a).

--- a/t/code/success/ctx-underscore-2.bel
+++ b/t/code/success/ctx-underscore-2.bel
@@ -70,7 +70,7 @@ mlam A => fn r => case [ |- A] of
     let [_ |- S] = reify [|- A] rn in
     reflect [ |- B] [_ |- algapp R[$W] S]
    )
-and reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [_ |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [_ |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -140,7 +140,7 @@ fn a => case a of
   let [_ |- R'] = algEqRSym [_ |- R] in
   let [_ |- N'] = algEqNSym [_ |- N] in
   [_ |- algapp (R') (N')]
-and algEqNSym : (g:tctx)
+and rec algEqNSym : (g:tctx)
   [g |- algeqn N1 N2 T[]]
 -> [g |- algeqn N2 N1 T[]] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -268,7 +268,7 @@ fn a1 => fn a2 => case a1 of
   let [_ |- R1] = algEqRTrans [_ |- A1'] [_ |- A2'] in
   let [_ |- R2] = algEqNTrans [_ |- B1] [_ |- B2] in
   [_ |- algapp R1 R2]
-and algEqNTrans : (g:tctx)
+and rec algEqNTrans : (g:tctx)
   [g |- algeqn N1 N2 T[]]
 -> [g |- algeqn N2 N3 T[]]
 -> [g |- algeqn N1 N3 T[]] =

--- a/t/code/success/ctx-underscore.bel
+++ b/t/code/success/ctx-underscore.bel
@@ -70,7 +70,7 @@ mlam A => fn r => case [ |- A] of
     let [_ |- S] = reify [|- A] rn in
     reflect [ |- B] [_ |- algapp R[$W] S]
    )
-and reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [_ |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [_ |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -140,7 +140,7 @@ fn a => case a of
   let [_ |- R'] = algEqRSym [_ |- R] in
   let [_ |- N'] = algEqNSym [_ |- N] in
   [_ |- algapp (R') (N')]
-and algEqNSym : (g:tctx)
+and rec algEqNSym : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N1 T] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -268,7 +268,7 @@ fn a1 => fn a2 => case a1 of
   let [_ |- R1] = algEqRTrans [_ |- A1'] [_ |- A2'] in
   let [_ |- R2] = algEqNTrans [_ |- B1] [_ |- B2] in
   [_ |- algapp R1 R2]
-and algEqNTrans : (g:tctx)
+and rec algEqNTrans : (g:tctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N3 T]
 -> [g |- algeqn N1 N3 T] =

--- a/t/code/success/infix/tc.bel
+++ b/t/code/success/infix/tc.bel
@@ -72,7 +72,7 @@ schema expCtx = exp ;
 rec synth : {g:expCtx} {E : [g |- exp]} [ |- oft-option] =
   mlam g => mlam E =>
      [ |- none]
-and check : {g:expCtx} {E : [g |- exp]} {T : [ |- tp]} [ |- boolean] =
+and rec check : {g:expCtx} {E : [g |- exp]} {T : [ |- tp]} [ |- boolean] =
   mlam g => mlam E => mlam T =>
     [ |- false]
 ;

--- a/t/code/success/multi_arg_mlam/algeq.bel
+++ b/t/code/success/multi_arg_mlam/algeq.bel
@@ -127,7 +127,7 @@ rec algEqR_Monotone :   IsVarSub [g] [g'] [h] [h' |- $W[..]]
 fn iv => fn r => case r of
 | AlgVar v => algVar (wknVar v iv)
 | AlgApp r' n' => AlgApp (algEqR_Monotone iv r') (algEqN_Monotone iv n')
-and algEqN_Monotone : IsVarSub [g] [g'] [h] [h' |- $W[..]]
+and rec algEqN_Monotone : IsVarSub [g] [g'] [h] [h' |- $W[..]]
                     -> AlgEqN [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A]
                     -> AlgEqN [h] [h' |-  M1[$W]] [h' |-  M2[$W]] [ |- A] =
 fn iv => let iv : IsVarSub [h] [g'] [h] [h' |- $W[..]] = iv in fn r => case r of
@@ -157,7 +157,7 @@ mlam A => fn r => let r : AlgEqR [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] = r
    (mlam h, h', $W, N1, N2 => fn rh, iv, rn =>
     reflect [ |- B] (AlgApp (algEqR_Monotone iv r) (reify rh rn))
    )
-and reify : CtxRel [g] [g'] -> LogEq [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] -> AlgEqN [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] =
+and rec reify : CtxRel [g] [g'] -> LogEq [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] -> AlgEqN [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] =
 fn r, e => let e : LogEq [g] [g' |-  M1[..]] [g' |-  M2[..]] [ |- A] = e in case e of
 | LogBase a => a
 | LogArr [g' |-  M1[..]] [g' |-  M2[..]] f =>
@@ -254,7 +254,7 @@ rec algEqRSym :
 fn a => case a of
 | AlgVar v => AlgVar v
 | AlgApp a1 a2 => AlgApp (algEqRSym a1) (algEqNSym a2)
-and algEqNSym :
+and rec algEqNSym :
   AlgEqN [g] [g' |-  N1[..]] [g' |-  N2[..]] [ |- T]
 -> AlgEqN [g] [g' |-  N2[..]] [g' |-  N1[..]] [ |- T] =
 fn a => case a of
@@ -377,7 +377,7 @@ fn a1, a2 => case (a1,a2) of
 | (AlgApp a1' b1, AlgApp a2' b2) =>
   let ReflTp = algEqRUnique a1' a2' in
   AlgApp (algEqRTrans a1' a2') (algEqNTrans b1 b2)
-and algEqNTrans :
+and rec algEqNTrans :
   AlgEqN [g] [g' |-  N1[..]] [g' |-  N2[..]] [ |- T]
 -> AlgEqN [g] [g' |-  N2[..]] [g' |-  N3[..]] [ |- T]
 -> AlgEqN [g] [g' |-  N1[..]] [g' |-  N3[..]] [ |- T] =

--- a/t/code/success/postpone-unificiation.bel
+++ b/t/code/success/postpone-unificiation.bel
@@ -70,7 +70,7 @@ mlam A => fn r => case [ |- A] of
     % let [h |- S[..]] = reify [|- A] rn in
     reflect [ |- B] [h |- algapp R[$W] ?]
    )
-and reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]}Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- i ] =>
@@ -140,7 +140,7 @@ fn a => case a of
   let [g |- R'[..]] = algEqRSym [g |- R[..]] in
   let [g |- N'[..]] = algEqNSym [g |- N[..]] in
   [g |- algapp (R'[..]) (N'[..])]
-and algEqNSym : (g:tctx)
+and rec algEqNSym : (g:tctx)
   [g |- algeqn (N1[..]) (N2[..]) T]
 -> [g |- algeqn (N2[..]) (N1[..]) T] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -268,7 +268,7 @@ fn a1 => fn a2 => case a1 of
   let [g |- R1[..]] = algEqRTrans [g |- A1'[..]] [g |- A2'[..]] in
   let [g |- R2[..]] = algEqNTrans [g |- B1[..]] [g |- B2[..]] in
   [g |- algapp (R1[..]) (R2[..])]
-and algEqNTrans : (g:tctx)
+and rec algEqNTrans : (g:tctx)
   [g |- algeqn (N1[..]) (N2[..]) T]
 -> [g |- algeqn (N2[..]) (N3[..]) T]
 -> [g |- algeqn (N1[..]) (N3[..]) T] =

--- a/t/code/success/substvars/nbe-datatype.bel
+++ b/t/code/success/substvars/nbe-datatype.bel
@@ -71,7 +71,7 @@ case [ |- A] of
    reflect [h |- rapp (R[$W[..]]) (N[..])]
   )
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => let (e : Sem [g] [ |- A]) = e in
 case e of
 | Syn [g |- R[..]] => [g |- embed (R[..])]

--- a/t/code/success/substvars/nbe.bel
+++ b/t/code/success/substvars/nbe.bel
@@ -69,7 +69,7 @@ case [ |- A] of
    reflect [h |- rapp (R[$W]) (N[..])]
   )
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => let (e : Sem [g] [ |- A]) = e in
 case e of
 | Syn [g |- R[..]] => [g |- embed (R[..])]

--- a/t/code/success/substvars/nbe2.bel
+++ b/t/code/success/substvars/nbe2.bel
@@ -61,11 +61,13 @@ case [ |- A] of
 | [ |- b ] => Base [g |- embed (R[..])]
 | [ |- arr T S ] =>  Arr [g] (body [g |- R[..]])
 
-and body : (g:ctx) {R:[g |- neut (arr T[] S[])]}{h:ctx}{$W : [h |- g]} Sem [h] [ |- T] -> Sem [h] [ |- S] =
+and
+rec body : (g:ctx) {R:[g |- neut (arr T[] S[])]}{h:ctx}{$W : [h |- g]} Sem [h] [ |- T] -> Sem [h] [ |- S] =
 mlam R => mlam h => mlam $W => fn e =>
 let [h |- N[..]] = reify e in reflect [h |- rapp (R[$W[..]]) (N[..])]
 
-and reify : Sem [g] [ |- A] -> [g |- norm A[]] =
+and
+rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 fn e => case e of
 | Base [g |- R[..]] => [g |- R[..]]
 | Arr [g] f =>

--- a/t/code/success/substvars/weak-norm-under-binders.bel
+++ b/t/code/success/substvars/weak-norm-under-binders.bel
@@ -91,7 +91,7 @@ rec rwkn : IsNeutral [g |- R[..]] -> IsVarSub [g]  [h |- $W] -> IsNeutral [h |- 
 fn r => fn iv => case r of
 | Var i => Var (wknVar' i iv)
 | App r' n => App (rwkn r' iv) (nwkn n iv)
-and nwkn : IsNormal [g |- N[..]] -> IsVarSub [g] [h |- $W] -> IsNormal [h |- N[$W]] =
+and rec nwkn : IsNormal [g |- N[..]] -> IsVarSub [g] [h |- $W] -> IsNormal [h |- N[$W]] =
 fn r => fn iv => case r of
 | Neut r' => Neut (rwkn r' iv)
 | Lam n => Lam (nwkn n (extVarSub iv));
@@ -106,7 +106,7 @@ case [ |- A] of
     let Halts [h |- MS[..]] n = reify rm2 in
     closed2 [h |- stepapp refl (MS[..])] (reflect (App (rwkn r iv) n)))
 
-and reify : Reduce [ |- A] [g |- M[..]] -> Halts [ |- A] [g |- M[..]] =
+and rec reify : Reduce [ |- A] [g |- M[..]] -> Halts [ |- A] [g |- M[..]] =
 fn r => case r of
 | Base h => h
 | Arr [g |- M[..]] f =>

--- a/t/code/success/total/logrel-names.bel
+++ b/t/code/success/total/logrel-names.bel
@@ -147,7 +147,7 @@ mlam A => fn r => case [ |- A] of
   let ih2 = reflect [|- T2] p2 in
   LogProd ih1 ih2
 | [ |- tp/unit] => LogUnit
-and reify : {A:[|- tp]} Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
+and rec reify : {A:[|- tp]} Log [g |- M1 sim M2] [ |- A] -> [g |- algeqn M1 M2 A[]] =
  / total a (reify g m1 m2 a) /
 mlam A => fn e => case [ |- A] of
 | [ |- tp/nm ] =>
@@ -294,7 +294,7 @@ fn a => case a of
   let [g |- A2'] = algEqRSym [g |- A2] in
   [g |- algeqbinp A1' A2']
 | [g |- algeqnamep] => [g |- algeqnamep]
-and algEqNSym : (g:rctx)
+and rec algEqNSym : (g:rctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N1 T] =
 / total a (algEqNSym g n1 n2 t a) /
@@ -486,7 +486,7 @@ fn a1 => fn a2 => case a1 of
   let [g |- A2''] = algEqRTrans [g |- A2] [g |- A2'] in
   [g |- algeqbinp A1'' A2'']
 | [g |- algeqnamep] => let [g |- algeqnamep] = a2 in [g |- algeqnamep]
-and algEqNTrans : (g:rctx)
+and rec algEqNTrans : (g:rctx)
   [g |- algeqn N1 N2 T]
 -> [g |- algeqn N2 N3 T]
 -> [g |- algeqn N1 N3 T] =
@@ -684,7 +684,7 @@ fn d => case d of
 | [g |- d_sym D1] => dtp2 [g |- D1]
 | [g |- d_trans D1 D2] => dtp1 [g |- D1]
 | todo => ?
-and dtp2 : (g:ctx) [g |- deq M1 M2 T[]] -> [g |- oft M2 T[]] =
+and rec dtp2 : (g:ctx) [g |- deq M1 M2 T[]] -> [g |- oft M2 T[]] =
  / total d (dtp2 g m1 m2 t d) /
 fn d => case d of
 | [g |- d_app D1 D2] =>

--- a/t/harpoon/compile/ceval-complete.input
+++ b/t/harpoon/compile/ceval-complete.input
@@ -1,0 +1,47 @@
+examples/compile/cpm/test.cfg
+complete
+[|- eval E V] -> [|- mstep (st K (return V)) (answer W)] -> [|- mstep (st K (ev E)) (answer W)]
+1
+split x85
+unbox (z85) as S
+solve [|- next S st_z]
+unbox (z85) as S
+by ih (complete [|- X17] [|- next S (st_return (\v. return (s_val v)) _)]) as ih
+unbox (ih) as IH
+solve [|- next IH st_s]
+by ih (complete [|- Y16] z85) as ih
+unbox (ih) as IH
+by ih (complete [|- X16] [|- next (next IH st_match1_z) (st_return (\v. match1 v Z14[] (\y. Z15[y])) _)]) as ih'
+unbox ih' as IH'
+solve [|- next IH' st_match]
+unbox z85 as S'
+by ih complete [|- Y14] [|- S'] as ih
+unbox ih as IH
+by ih complete [|- X14] [|- next (next IH st_match1_s) (st_return (\v. match1 v Z13[] (\y. X12[y])) _)] as ih'
+unbox ih' as IH'
+solve [|- next IH' st_match]
+unbox z85 as S'
+by ih complete [|- Z11] [|- next S' (st_return (\x. return (pair_val X11[] x)) _)] as S2 unboxed
+by ih complete [|- Y12] [|- next (next S2 st_pair1) (st_return (\x. pair1 x X10[]) _)] as S1 unboxed
+solve [|- next S1 st_pair]
+unbox z85 as S'
+by ih complete [|- Y10] [|- next (next S' st_fst1) (st_return (\v. fst1 v) _)] as S1 unboxed
+solve [|- next S1 st_fst]
+unbox z85 as S'
+by ih complete [|- Z8] [|- next (next S' st_snd1) (st_return (\v. snd1 v ) _)] as S1 unboxed
+solve [|- next S1 st_snd]
+unbox z85 as S'
+solve [|- next S' st_lam]
+by ih complete [|- X6] z85 as S2 unboxed
+by ih complete [|- Z6] [|- next (next S2 st_app2) (st_return (\v. app2 (lam_val (\x. Z4[x])) v) _)] as S2' unboxed
+by ih complete [|- Y7] [|- next (next S2' st_app1) (st_return (\x1. app1 x1 Z5[]) _)] as S1 unboxed
+solve [|- next S1 st_app]
+by ih complete [|- Y4] z85 as S2 unboxed
+by ih complete [|- X4] [|- next S2 (st_return (\x1. ev (Z2[x1])) _)] as S1 unboxed
+solve [|- next S1 st_letv]
+by ih complete [|- X2] z85 as S unboxed
+solve [|- next S st_letn]
+by ih complete [|- Y1] z85 as S unboxed
+solve [|- next S st_fix]
+unbox z85 as S'
+solve [|- next S' st_vl]

--- a/t/harpoon/tp-refl.bel
+++ b/t/harpoon/tp-refl.bel
@@ -1,0 +1,21 @@
+% An extremely simple test to make sure dependent pattern matching works in Harpoon.
+
+LF tp : type =
+  | i : tp
+  | arr : tp → tp → tp
+;
+
+LF eq : tp → tp → type =
+  | eq_i : eq i i
+  | eq_arr : eq A1 A2 → eq B1 B2 → eq (arr A1 B1) (arr A2 B2)
+;
+
+rec tp-refl : {EXTRA : [⊢ tp]} {A : [⊢ tp]} [ ⊢ eq A A] =
+mlam EXTRA, A ⇒
+case [⊢ A] of
+  | [⊢ i] ⇒ [⊢ eq_i]
+  | [⊢ arr A B] ⇒
+        let [⊢ EQ_A] = tp-refl [⊢ EXTRA] [⊢ A] in
+        let [⊢ EQ_B] = tp-refl [⊢ EXTRA] [⊢ B] in
+        [⊢ eq_arr EQ_A EQ_B]
+;

--- a/t/harpoon/tp-refl.input
+++ b/t/harpoon/tp-refl.input
@@ -1,0 +1,9 @@
+t/harpoon/tp-refl.bel
+tp-refl
+{EXTRA : [|- tp]} {A : [|- tp]} [|- eq A A]
+2
+split [|- A]
+solve [|- eq_i]
+by ih tp-refl [|- EXTRA] [|- Y] as EQ_Y unboxed
+by ih tp-refl [|- EXTRA] [|- X] as EQ_X unboxed
+solve [|- eq_arr EQ_Y EQ_X]


### PR DESCRIPTION
Add dependent pattern matching to Harpoon. The pattern matching capabilities of Harpoon should now equal Beluga's, since they both use `synPatRefine`, which has been significantly refactored by this patch.

A test is added for DPM in Harpoon (admissibility of reflexivity for a structural equality). It used some new syntactic features, so this patch also includes the WIP Harpoon frontend code. In particular, one needs to repeat the `rec` keyword now when writing mutual theorems, since allow writing mutual `rec` programs and Harpoon `proof` proofs.