### PR TITLE
Introduce a readline library

### DIFF
--- a/beluga.opam
+++ b/beluga.opam
@@ -10,5 +10,5 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "gen" "sedlex" "extlib" "dune-build-info"
+  "gen" "sedlex" "extlib" "dune-build-info" "linenoise"
 ]

--- a/run_harpoon_test.sh
+++ b/run_harpoon_test.sh
@@ -15,8 +15,7 @@ shift
 
 sig=$(sed -n '1p' "${input_path}")
 
-exec rlwrap \
-     bin/harpoon \
+exec bin/harpoon \
      --sig "${sig}" \
      --implicit \
      --test "${input_path}" \

--- a/src/harpoon/dune
+++ b/src/harpoon/dune
@@ -2,7 +2,7 @@
   (name main)
   (public_name harpoon)
   (package beluga)
-  (libraries support beluga dune-build-info))
+  (libraries linenoise support beluga dune-build-info))
 (env
   (dev
     (flags (:standard -w Azep-44-48-50-58 -warn-error Ap-37-48-50-60))))

--- a/src/harpoon/inputPrompt.ml
+++ b/src/harpoon/inputPrompt.ml
@@ -1,0 +1,40 @@
+open Support
+
+type t = string -> string option -> unit -> string option
+
+let terminal : t =
+  fun msg history_file () ->
+  let open Maybe in
+  LNoise.linenoise msg
+  $> fun str ->
+     match history_file with
+     | None -> str
+     | Some path ->
+        let _ = LNoise.history_load ~filename:path in
+        let _ = LNoise.history_add str in
+        let _ = LNoise.history_save ~filename:path in
+        str
+
+let create_file (path, k) (test_start : int option) : t =
+  let h = open_in path in
+  let g =
+    let open GenMisc in
+    of_in_channel_lines h
+    |> iter_through (fun x -> print_string (x ^ "\n"))
+  in
+  begin
+    match test_start with
+    | None -> ()
+    | Some ln -> GenMisc.drop_lines g (ln - 1)
+  end;
+  match k with
+  | `incomplete ->
+     fun msg history_file ->
+     GenMisc.sequence [g; terminal msg history_file]
+  | `complete ->
+     fun _ _ -> g
+
+let create test_file test_start : t =
+  match test_file with
+  | None -> terminal
+  | Some f -> create_file f test_start

--- a/src/harpoon/inputPrompt.mli
+++ b/src/harpoon/inputPrompt.mli
@@ -1,0 +1,3 @@
+type t = string -> string option -> unit -> string option
+
+val create : Options.test_file option -> int option -> t

--- a/src/harpoon/main.ml
+++ b/src/harpoon/main.ml
@@ -47,52 +47,22 @@ open Support
 
 module B = Beluga
 
-module E = B.Syntax.Ext
-module I = B.Syntax.Int
-
-module PC = B.Printer.Control
-
 (** Defines error type and formatting. *)
 module Error = struct
   type t =
-    | ArgParseLengthMismatch
-      of string (* option name *)
-         * int (* expected number of arguments *)
-         * int (* actual number of arguments *)
-    | MissingMandatoryOption
-      of string (* option name *)
-         * string (* hint *)
     | DanglingArguments
       of string list
-    | OrderTooComplicated
-    | OrderDoesntMatch
-    | InvalidIncomplete
 
   exception E of t
   let throw e = raise (E e)
 
   open Format
   let format_error ppf = function
-    | ArgParseLengthMismatch (name, exp, act) ->
-       fprintf ppf "Option %s requires %d arguments. Got %d.@."
-         name
-         exp
-         act
-    | MissingMandatoryOption (name, hint) ->
-       fprintf ppf "Mandatory option %s is missing.@,(It %s.)@."
-         name
-         hint
     | DanglingArguments args ->
        fprintf ppf "Unexpected remaining command-line arguments:@,  @[%a@]@."
          (pp_print_list ~pp_sep: Fmt.comma
             (fun ppf -> fprintf ppf "%s"))
          args
-    | OrderTooComplicated ->
-       fprintf ppf "Induction order too complicated@."
-    | OrderDoesntMatch ->
-       fprintf ppf "Induction order doesn't match theorem statement.@."
-    | InvalidIncomplete ->
-       fprintf ppf "--incomplete can be specified only after --test"
 end
 
 (* Register error formatting. *)
@@ -106,246 +76,19 @@ let _ =
     | _ -> None
     end
 
-type test_kind = [ `incomplete | `complete ]
-
-(** The command-line options specified to Harpoon. *)
-type ('a, 'b) options =
-  { path : 'a (* the path of the signature file to load, could be a cfg *)
-  ; all_paths : 'b (* the list of paths resolved from the signature file to load *)
-  ; test_file : (string * test_kind) option (* the harpoon test file to load *)
-  ; test_start : int option (* the first line from which the harpoon test file is considered as input *)
-  }
-
-type elaborated_options =
-  (string, string list) options
-type valid_options =
-  (string, unit) options
-type partial_options =
-  (string option, unit) options
-
-let initial_options : partial_options =
-  { path = None
-  ; all_paths = ()
-  ; test_file = None
-  ; test_start = None
-  }
-
-let usage () : unit =
-  let usageString : (_, out_channel, unit) format =
-    ""
-    ^^ "Usage: %s <mandatory options> <other options>\n"
-    ^^ "\n"
-    ^^ "Mandatory options:\n"
-    ^^ "  --sig path             specify the input signature\n"
-    ^^ "\n"
-    ^^ "Other options:\n"
-    ^^ "  --test path            specify the test input file that is used as\n"
-    ^^ "                         a test input instead of stdin user input\n"
-    ^^ "  --incomplete           mark the test input file as incomplete so that\n"
-    ^^ "                         stdin user input is followed after the test input\n"
-    ^^ "                         (valid only when --test option is provided)\n"
-    ^^ "  --test-start number    specify the first line of test file considered\n"
-    ^^ "                         as test input\n"
-    ^^ "  --debug                use debugging mode (writes to debug.out in CWD)\n"
-    ^^ "  --implicit             print implicit variables\n"
-    ^^ "  --help                 print this message\n"
-    ^^ "\n"
-  in
-  Printf.eprintf usageString
-    Sys.argv.(0)
-
-module Validate :
-sig
-  val options : partial_options -> valid_options
-end = struct
-  let check opt_name hint =
-    function
-    | None -> Error.(throw (MissingMandatoryOption (opt_name, hint)))
-    | Some x -> x
-
-  (** Checks that mandatory options are specified, throwing exceptions
-      if they're missing. *)
-  let options (o : partial_options) : valid_options =
-    { o with
-      path =
-        check
-          "--sig"
-          "specifies the input signature"
-          o.path
-    }
-end
-
-module Elab :
-sig
-  val options : valid_options -> elaborated_options
-end = struct
-  let forbid_leftover_vars path = function
-    | None -> ()
-    | Some vars ->
-       let open B in
-       let open Format in
-       if !Debug.chatter <> 0 then
-         fprintf std_formatter "@[<v>## Leftover variables: %s  ##@,  @[%a@]@]@."
-           path
-           Recsgn.fmt_ppr_leftover_vars vars;
-       raise (Abstract.Error (Syntax.Loc.ghost, Abstract.LeftoverVars))
-
-  let load_file path =
-    let open B in
-    let sgn, leftover_vars =
-      Parser.(Runparser.parse_file path (only sgn) |> extract)
-      |> Recsgn.apply_global_pragmas
-      |> Recsgn.recSgnDecls
-    in
-    Store.Modules.reset ();
-    forbid_leftover_vars path leftover_vars
-
-  (** Loads the specified signature and elaborates the theorem.
-      Returns also the path of the last file loaded.
-      (This is where Harpoon will store proofs.)
-   *)
-  let options (o : valid_options) : elaborated_options =
-    let all_paths = B.Cfg.process_file_argument o.path in
-    List.iter load_file all_paths;
-    { o with all_paths }
-end
-
-(** Gets exactly the first `n` elements from a list.
-    If the list contains fewer than `n` elements, the length of the
-    list is returned on the Left.
- *)
-let rec take_exactly n =
-  let open Either in
-  function
-  | xs when n <= 0 -> Right ([], xs)
-  | x :: xs ->
-     bimap
-       (fun k -> k + 1)
-       (Pair.lmap (fun xs -> x :: xs))
-       (take_exactly (n-1) xs)
-  | [] -> Left 0
-
-let sanitize_statement_string (stmt : string) : string =
-  let length = String.length stmt in
-  match stmt.[0], stmt.[length - 1] with
-  | '"', '"' -> String.sub stmt 1 (length - 2)
-  | '\'', '\'' -> String.sub stmt 1 (length - 2)
-  | _ -> stmt
-
-let rec parse_arguments options : string list -> string list * partial_options =
-  function
-  | [] -> [], options
-  | arg :: rest ->
-     let with_args_for a n k =
-       let open Either in
-       match take_exactly n rest with
-       | Left k ->
-          let open Error in
-          throw (ArgParseLengthMismatch (a, n, k))
-       | Right (args, rest) -> k args rest
-     in
-     let parse_the_rest_with k x rest =
-       parse_arguments (k x) rest
-     in
-     let parse_the_rest () =
-       parse_the_rest_with (Misc.id) options rest
-     in
-     match arg with
-     | "--debug" ->
-        B.Debug.enable ();
-        Printexc.record_backtrace true;
-        parse_the_rest ()
-     | "--implicit" ->
-        PC.printImplicit := true;
-        parse_the_rest ()
-     | "--sig" ->
-        with_args_for "--sig" 1
-          (parse_the_rest_with
-             (fun [path] ->
-               { options with path = Some path }))
-     | "--test" ->
-        with_args_for "--test" 1
-          (parse_the_rest_with
-             (fun [test_path] ->
-               { options with test_file = Some (test_path, `complete) }))
-     | "--incomplete" ->
-        begin match options.test_file with
-        | None -> Error.(throw InvalidIncomplete)
-        | Some (f, k) ->
-           parse_arguments { options with test_file = Some (f, `incomplete) } rest
-        end
-     | "--test-start" ->
-       with_args_for "--test-start" 1
-         (parse_the_rest_with
-            (fun [test_start] ->
-               { options with test_start = Some (int_of_string test_start) }))
-     | "--help" ->
-        usage ();
-        exit 1
-     | _ ->
-        rest, options
-
 let forbid_dangling_arguments = function
   | [] -> ()
   | rest -> Error.(throw (DanglingArguments rest))
 
-(**
-   Module for user interface
-   TODO: Extract this module as a file
-         (It may also need to extract option parsing functions/types)
- *)
-module Prompt : sig
-  type t = string -> string option -> unit -> string option
-
-  val make_prompt : (string * test_kind) option -> int option -> t
-end = struct
-  type t = string -> string option -> unit -> string option
-
-  let stdin_prompt msg history_file () =
-    let open Maybe in
-    LNoise.linenoise msg
-    $> fun str ->
-       match history_file with
-       | None -> str
-       | Some path ->
-          let _ = LNoise.history_load ~filename:path in
-          let _ = LNoise.history_add str in
-          let _ = LNoise.history_save ~filename:path in
-          str
-
-  let make_file_prompt path (k : test_kind) (test_start : int option) =
-    let h = open_in path in
-    let g =
-      let open GenMisc in
-      of_in_channel_lines h
-      |> iter_through (fun x -> print_string (x ^ "\n"))
-    in
-    begin
-      match test_start with
-      | None -> ()
-      | Some ln -> GenMisc.drop_lines g (ln - 1)
-    end;
-    match k with
-    | `incomplete ->
-       fun msg history_file ->
-       GenMisc.sequence [g; stdin_prompt msg history_file]
-    | `complete ->
-       fun _ _ -> g
-
-  let make_prompt test_file test_start : t =
-    match test_file with
-    | None -> stdin_prompt
-    | Some (path, k) -> make_file_prompt path k test_start
-end
-
 let realMain () =
   B.Debug.init (Some "debug.out");
   let (arg0 :: args) = Array.to_list Sys.argv in
-  let rest, options = parse_arguments initial_options args in
+  let rest, options = Options.parse_arguments args in
   forbid_dangling_arguments rest;
-  let options = options |> Validate.options |> Elab.options in
+  let options = options |> Options.validate |> Options.elaborate in
+  let open Options in
   Prover.start_toplevel
-    (Prompt.make_prompt options.test_file options.test_start)
+    (InputPrompt.create options.test_file options.test_start)
     Format.std_formatter
 
 let main () =

--- a/src/harpoon/options.ml
+++ b/src/harpoon/options.ml
@@ -1,0 +1,218 @@
+open Support
+
+module B = Beluga
+
+module PC = B.Printer.Control
+
+module Error = struct
+  type t =
+    | ArgParseLengthMismatch
+      of string (* option name *)
+         * int (* expected number of arguments *)
+         * int (* actual number of arguments *)
+    | MissingMandatoryOption
+      of string (* option name *)
+         * string (* hint *)
+    | InvalidIncomplete
+
+  exception E of t
+  let throw e = raise (E e)
+
+  open Format
+  let format_error ppf = function
+    | ArgParseLengthMismatch (name, exp, act) ->
+       fprintf ppf "Option %s requires %d arguments. Got %d.@."
+         name
+         exp
+         act
+    | MissingMandatoryOption (name, hint) ->
+       fprintf ppf "Mandatory option %s is missing.@,(It %s.)@."
+         name
+         hint
+    | InvalidIncomplete ->
+       fprintf ppf "--incomplete can be specified only after --test"
+end
+
+(* Register error formatting. *)
+let _ =
+  let open Error in
+  B.Error.register_printer'
+    begin fun e ->
+    match e with
+    | E e ->
+       Some (B.Error.print (fun ppf -> format_error ppf e))
+    | _ -> None
+    end
+
+type test_kind = [ `incomplete | `complete ]
+type test_file = string * test_kind
+
+(** The command-line options specified to Harpoon. *)
+type ('a, 'b) t =
+  { path : 'a (* the path of the signature file to load, could be a cfg *)
+  ; all_paths : 'b (* the list of paths resolved from the signature file to load *)
+  ; test_file : test_file option (* the harpoon test file to load *)
+  ; test_start : int option (* the first line from which the harpoon test file is considered as input *)
+  }
+
+type elaborated_t =
+  (string, string list) t
+type valid_t =
+  (string, unit) t
+type partial_t =
+  (string option, unit) t
+
+let initial_t : partial_t =
+  { path = None
+  ; all_paths = ()
+  ; test_file = None
+  ; test_start = None
+  }
+
+(** TODO
+    Generate this from options if possible.
+    (by ppx or something)
+ *)
+let usage () : unit =
+  let usageString : (_, out_channel, unit) format =
+    ""
+    ^^ "Usage: %s <mandatory options> <other options>\n"
+    ^^ "\n"
+    ^^ "Mandatory options:\n"
+    ^^ "  --sig path             specify the input signature\n"
+    ^^ "\n"
+    ^^ "Other options:\n"
+    ^^ "  --test path            specify the test input file that is used as\n"
+    ^^ "                         a test input instead of stdin user input\n"
+    ^^ "  --incomplete           mark the test input file as incomplete so that\n"
+    ^^ "                         stdin user input is followed after the test input\n"
+    ^^ "                         (valid only when --test option is provided)\n"
+    ^^ "  --test-start number    specify the first line of test file considered\n"
+    ^^ "                         as test input\n"
+    ^^ "  --debug                use debugging mode (writes to debug.out in CWD)\n"
+    ^^ "  --implicit             print implicit variables\n"
+    ^^ "  --help                 print this message\n"
+    ^^ "\n"
+  in
+  Printf.eprintf usageString
+    Sys.argv.(0)
+
+(** Parses argument list and
+    returns parsed result and leftover arguments.
+ *)
+let parse_arguments args : string list * partial_t =
+  (** Gets exactly the first `n` elements from a list.
+      If the list contains fewer than `n` elements, the length of the
+      list is returned on the Left.
+   *)
+  let rec take_exactly n =
+    let open Either in
+    function
+    | xs when n <= 0 -> Right ([], xs)
+    | x :: xs ->
+       bimap
+         (fun k -> k + 1)
+         (Pair.lmap (fun xs -> x :: xs))
+         (take_exactly (n-1) xs)
+    | [] -> Left 0
+  in
+  let rec parse_from options =
+    function
+    | [] -> [], options
+    | arg :: rest ->
+       let with_args_for a n k =
+         let open Either in
+         match take_exactly n rest with
+         | Left k ->
+            let open Error in
+            throw (ArgParseLengthMismatch (a, n, k))
+         | Right (args, rest) -> k args rest
+       in
+       let parse_the_rest_with k x rest =
+         parse_from (k x) rest
+       in
+       let parse_the_rest () =
+         parse_the_rest_with (Misc.id) options rest
+       in
+       match arg with
+       | "--debug" ->
+          B.Debug.enable ();
+          Printexc.record_backtrace true;
+          parse_the_rest ()
+       | "--implicit" ->
+          PC.printImplicit := true;
+          parse_the_rest ()
+       | "--sig" ->
+          with_args_for "--sig" 1
+            (parse_the_rest_with
+               (fun [path] ->
+                 { options with path = Some path }))
+       | "--test" ->
+          with_args_for "--test" 1
+            (parse_the_rest_with
+               (fun [test_path] ->
+                 { options with test_file = Some (test_path, `complete) }))
+       | "--incomplete" ->
+          begin match options.test_file with
+          | None -> Error.(throw InvalidIncomplete)
+          | Some (f, k) ->
+             parse_from { options with test_file = Some (f, `incomplete) } rest
+          end
+       | "--test-start" ->
+          with_args_for "--test-start" 1
+            (parse_the_rest_with
+               (fun [test_start] ->
+                 { options with test_start = Some (int_of_string test_start) }))
+       | "--help" ->
+          usage ();
+          exit 1
+       | _ ->
+          rest, options
+  in
+  parse_from initial_t args
+
+(** Checks whether partial options have all mandatory options or not,
+    and lift its type to valid_options
+ *)
+let validate (o : partial_t) : valid_t =
+  let check opt_name hint =
+    function
+    | None -> Error.(throw (MissingMandatoryOption (opt_name, hint)))
+    | Some x -> x
+  in
+  { o with
+    path =
+      check
+        "--sig"
+        "specifies the input signature"
+        o.path
+  }
+
+(** Loads the specified signature and elaborates the theorem.
+    Returns also the path of the last file loaded.
+    (This is where Harpoon will store proofs.)
+ *)
+let elaborate (o : valid_t) : elaborated_t =
+  let open B in
+  let forbid_leftover_vars path = function
+    | None -> ()
+    | Some vars ->
+       let open Format in
+       if !Debug.chatter <> 0 then
+         fprintf std_formatter "@[<v>## Leftover variables: %s  ##@,  @[%a@]@]@."
+           path
+           Recsgn.fmt_ppr_leftover_vars vars;
+       raise (Abstract.Error (Syntax.Loc.ghost, Abstract.LeftoverVars))
+  in
+  let load_file path =
+    let sgn, leftover_vars =
+      Parser.(Runparser.parse_file path (only sgn) |> extract)
+      |> Recsgn.apply_global_pragmas
+      |> Recsgn.recSgnDecls
+    in
+    Store.Modules.reset ();
+    forbid_leftover_vars path leftover_vars
+  in
+  let all_paths = Cfg.process_file_argument o.path in
+  List.iter load_file all_paths;
+  { o with all_paths }

--- a/src/harpoon/options.mli
+++ b/src/harpoon/options.mli
@@ -1,0 +1,22 @@
+type test_kind = [ `incomplete | `complete ]
+type test_file = string * test_kind
+
+type ('a, 'b) t =
+  { path : 'a (* the path of the signature file to load, could be a cfg *)
+  ; all_paths : 'b (* the list of paths resolved from the signature file to load *)
+  ; test_file : test_file option (* the harpoon test file to load *)
+  ; test_start : int option (* the first line from which the harpoon test file is considered as input *)
+  }
+
+type partial_t =
+  (string option, unit) t
+type valid_t =
+  (string, unit) t
+type elaborated_t =
+  (string, string list) t
+
+val initial_t : partial_t
+
+val parse_arguments : string list -> string list * partial_t
+val validate : partial_t -> valid_t
+val elaborate : valid_t -> elaborated_t

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -31,8 +31,6 @@ let _ =
       end
     end
 
-type prompt = string -> string option -> unit -> string option
-
 module Prover = struct
   open Theorem
 
@@ -41,7 +39,7 @@ module Prover = struct
     (* ^ The theorems currently being proven. *)
     
     ; automation_state : Automation.automation_state
-    ; prompt : prompt
+    ; prompt : InputPrompt.t
     ; ppf : Format.formatter
     }
 
@@ -62,7 +60,7 @@ module Prover = struct
     
   let make_state
         (ppf : Format.formatter)
-        (prompt : prompt)
+        (prompt : InputPrompt.t)
       : state =
     let theorems = DynArray.make 16 in
     { theorems
@@ -393,7 +391,7 @@ let rec loop (s : Prover.state) : unit =
         loop s
 
 let start_toplevel
-      (prompt : prompt)
+      (prompt : InputPrompt.t)
       (ppf : Format.formatter) (* The formatter used to display messages *)
     : unit =
   let s = Prover.make_state ppf prompt in

--- a/src/harpoon/prover.mli
+++ b/src/harpoon/prover.mli
@@ -1,10 +1,9 @@
 module Id = Beluga.Id
 module Comp = Beluga.Syntax.Int.Comp
 
-(** The input source for the Harpoon toplevel.
-    It's simply a generator of lines.
-    See helpers in Support.Misc.Gen.
+(** The input prompty for the Harpoon toplevel.
+    See main.ml and linenoise library document for details.
  *)
-type input_source = string Gen.t
+type prompt = string -> string option -> unit -> string option
 
-val start_toplevel : input_source -> Format.formatter -> unit
+val start_toplevel : prompt -> Format.formatter -> unit

--- a/src/harpoon/prover.mli
+++ b/src/harpoon/prover.mli
@@ -4,6 +4,4 @@ module Comp = Beluga.Syntax.Int.Comp
 (** The input prompty for the Harpoon toplevel.
     See main.ml and linenoise library document for details.
  *)
-type prompt = string -> string option -> unit -> string option
-
-val start_toplevel : prompt -> Format.formatter -> unit
+val start_toplevel : InputPrompt.t -> Format.formatter -> unit


### PR DESCRIPTION
Introduce [linenoise](https://github.com/ocaml-community/ocaml-linenoise), a readline library, to read stdin in a more user-frendly way.

This PR only affects harpoon.