### PR TITLE
Add a part of harpoon serialization

### DIFF
--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2954,10 +2954,11 @@ let interactive_harpoon_command =
       ; keyword "defer" &> pure `defer
       ]
   in
-  let select_command, create_command =
+  let select_command, create_command, serialize_command =
     let f k = keyword k &> name in
     ( f "select" $> (fun x -> `select x)
     , f "create" $> (fun x -> `create x)
+    , keyword "serialize" &> pure `serialize
     )
   in
   let theorem_command =
@@ -2974,7 +2975,7 @@ let interactive_harpoon_command =
   in
   let session_command =
     keyword "session"
-    &> choice [ basic_command; select_command; create_command ]
+    &> choice [ basic_command; select_command; create_command; serialize_command ]
     $> fun cmd -> H.Session cmd
   in
   let subgoal_command =

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -305,7 +305,7 @@ module Harpoon = struct
     | Type of Comp.exp_syn
     | Info of info_kind * Id.name
     | Theorem of [ basic_command | `select of Id.name | `show_ihs | `show_proof ]
-    | Session of [ basic_command | `select of Id.name | `create of Id.name ]
+    | Session of [ basic_command | `select of Id.name | `create of Id.name | `serialize ]
     | Subgoal of basic_command
 
     (* Actual tactics *)

--- a/src/harpoon/automation.ml
+++ b/src/harpoon/automation.ml
@@ -206,8 +206,8 @@ end = struct
     let items =
       Hashtbl.fold (fun k (v, _) acc -> (k, v) :: acc) st []
     in
-    Format.fprintf ppf "@[<v>%a@,@]"
-      (Format.pp_print_list ~pp_sep: Format.pp_print_cut serialize_item) items
+    Format.fprintf ppf "@[<v>--harpoon @[<h>%a@].@,@]"
+      (Format.pp_print_list ~pp_sep: Format.pp_print_space serialize_item) items
 
   let get_info st (k : Command.automation_kind) : info =
     (* find here is guaranteed to succeed by the external invariant

--- a/src/harpoon/automation.mli
+++ b/src/harpoon/automation.mli
@@ -8,6 +8,7 @@ module State : sig
   type t
 
   val make : unit -> t
+  val serialize : Format.formatter -> t -> unit
 end
 
 val toggle : State.t -> Command.automation_kind -> Command.automation_change -> unit

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -401,7 +401,7 @@ module Prover = struct
           Theorem.show_proof t
        | `select name ->
           begin match
-            Misc.DynArray.findi_opt
+            Misc.DynArray.rfind_opt_idx
               c.Session.theorems
               (fun t -> Theorem.has_name_of t name)
           with
@@ -437,7 +437,7 @@ module Prover = struct
        | `defer -> State.defer_session s
        | `create name ->
           begin match
-            Misc.DynArray.findi_opt
+            Misc.DynArray.rfind_opt_idx
               s.State.sessions
               (fun c -> Id.equals c.Session.name name)
           with
@@ -453,7 +453,7 @@ module Prover = struct
           end
        | `select name ->
           begin match
-            Misc.DynArray.findi_opt
+            Misc.DynArray.rfind_opt_idx
               s.State.sessions
               (fun c -> Id.equals c.Session.name name)
           with

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -129,6 +129,14 @@ module Prover = struct
       ; name
       }
 
+    let serialize ppf (s : t) =
+      let fmt_ppr_theorems =
+        Format.pp_print_list ~pp_sep: Format.pp_print_cut Theorem.serialize
+      in
+      Format.fprintf ppf "@[<v>%a [@,%a]@,@]"
+        Id.print s.name
+        fmt_ppr_theorems (DynArray.to_list s.theorems)
+
     (** Gets the list of mutual declarations corresponding to the
         currently loaded theorems in the active session.
      *)
@@ -194,6 +202,20 @@ module Prover = struct
       ; ppf
       ; stop
       }
+
+    let serialize_stop ppf =
+      function
+      | `stop -> Format.fprintf ppf "stop"
+      | `go_on -> Format.fprintf ppf "go_on"
+
+    let serialize ppf (s : t) =
+      let fmt_ppr_sessions =
+        Format.pp_print_list ~pp_sep: Format.pp_print_cut Session.serialize
+      in
+      Format.fprintf ppf "@[<v>%a@,@,%a@,%a@]"
+        serialize_stop s.stop
+        Automation.State.serialize s.automation_state
+        fmt_ppr_sessions (DynArray.to_list s.sessions)
 
     let printf s x = Format.fprintf s.ppf x
 
@@ -467,6 +489,8 @@ module Prover = struct
              Session.enter c;
              DynArray.insert s.State.sessions 0 c'
           end
+       | `serialize ->
+          State.serialize s.State.ppf s
        end
     | Command.Subgoal cmd ->
        begin match cmd with

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -133,8 +133,7 @@ module Prover = struct
       let fmt_ppr_theorems =
         Format.pp_print_list ~pp_sep: Format.pp_print_cut Theorem.serialize
       in
-      Format.fprintf ppf "@[<v>%a [@,%a]@,@]"
-        Id.print s.name
+      Format.fprintf ppf "@[<v>%a@,@]"
         fmt_ppr_theorems (DynArray.to_list s.theorems)
 
     (** Gets the list of mutual declarations corresponding to the
@@ -203,17 +202,11 @@ module Prover = struct
       ; stop
       }
 
-    let serialize_stop ppf =
-      function
-      | `stop -> Format.fprintf ppf "stop"
-      | `go_on -> Format.fprintf ppf "go_on"
-
     let serialize ppf (s : t) =
       let fmt_ppr_sessions =
         Format.pp_print_list ~pp_sep: Format.pp_print_cut Session.serialize
       in
-      Format.fprintf ppf "@[<v>%a@,@,%a@,%a@]"
-        serialize_stop s.stop
+      Format.fprintf ppf "@[<v>%a@,%a@,@]"
         Automation.State.serialize s.automation_state
         fmt_ppr_sessions (DynArray.to_list s.sessions)
 

--- a/src/harpoon/theorem.ml
+++ b/src/harpoon/theorem.ml
@@ -62,12 +62,13 @@ let serialize ppf (t : t) =
   let s = t.initial_state in
   let fmt_ppr_order ppf =
     function
-    | Some (Arg o) -> Format.fprintf ppf "%d" o
+    | Some (Arg o) -> Format.fprintf ppf "/ total %d /" o
     | None -> ()
     | _ -> failwith "Invalid order"
   in
-  Format.fprintf ppf "@[<v>%a@,%a@,%a@,@]"
+  Format.fprintf ppf "@[<v>proof %a : %a =@,%a@,%a@,;@,@]"
     Id.print t.name
+    (P.fmt_ppr_cmp_typ s.context.cD P.l0) (Whnf.cnormCTyp s.goal)
     fmt_ppr_order t.order
     (P.fmt_ppr_cmp_proof s.context.cD s.context.cG) (incomplete_proof s)
 

--- a/src/harpoon/theorem.ml
+++ b/src/harpoon/theorem.ml
@@ -58,6 +58,21 @@ let has_cid_of t cid = t.cid = cid
 let theorem_statement (t : t) =
   Whnf.cnormCTyp t.initial_state.goal
 
+let serialize (t : t) : string =
+  let buf = Buffer.create 256 in
+  let s = t.initial_state in
+  let fmt_ppr_order ppf =
+    function
+    | Some (Arg o) -> Format.fprintf ppf "%d" o
+    | None -> ()
+    | _ -> failwith "Invalid order"
+  in
+  Format.fprintf (Format.formatter_of_buffer buf) "@[<v>%a@,%a@,%a@]@."
+    Id.print t.name
+    fmt_ppr_order t.order
+    (P.fmt_ppr_cmp_proof s.context.cD s.context.cG) (incomplete_proof s);
+  Buffer.contents buf
+
 (** Computes the index of the current subgoal we're working on. *)
 let current_subgoal_index gs = 0
 

--- a/src/harpoon/theorem.ml
+++ b/src/harpoon/theorem.ml
@@ -58,8 +58,7 @@ let has_cid_of t cid = t.cid = cid
 let theorem_statement (t : t) =
   Whnf.cnormCTyp t.initial_state.goal
 
-let serialize (t : t) : string =
-  let buf = Buffer.create 256 in
+let serialize ppf (t : t) =
   let s = t.initial_state in
   let fmt_ppr_order ppf =
     function
@@ -67,11 +66,10 @@ let serialize (t : t) : string =
     | None -> ()
     | _ -> failwith "Invalid order"
   in
-  Format.fprintf (Format.formatter_of_buffer buf) "@[<v>%a@,%a@,%a@]@."
+  Format.fprintf ppf "@[<v>%a@,%a@,%a@,@]"
     Id.print t.name
     fmt_ppr_order t.order
-    (P.fmt_ppr_cmp_proof s.context.cD s.context.cG) (incomplete_proof s);
-  Buffer.contents buf
+    (P.fmt_ppr_cmp_proof s.context.cD s.context.cG) (incomplete_proof s)
 
 (** Computes the index of the current subgoal we're working on. *)
 let current_subgoal_index gs = 0

--- a/src/harpoon/theorem.mli
+++ b/src/harpoon/theorem.mli
@@ -20,6 +20,8 @@ val has_name_of : t -> Id.name -> bool
 val has_cid_of : t -> Id.cid_prog -> bool
 val theorem_statement : t -> typ
 
+val serialize : t -> string
+
 val next_subgoal : t -> proof_state option
 val show_proof : t -> unit
 val show_subgoals : t -> unit

--- a/src/harpoon/theorem.mli
+++ b/src/harpoon/theorem.mli
@@ -20,7 +20,7 @@ val has_name_of : t -> Id.name -> bool
 val has_cid_of : t -> Id.cid_prog -> bool
 val theorem_statement : t -> typ
 
-val serialize : t -> string
+val serialize : Format.formatter -> t -> unit
 
 val next_subgoal : t -> proof_state option
 val show_proof : t -> unit

--- a/src/support/misc.ml
+++ b/src/support/misc.ml
@@ -120,7 +120,7 @@ module DynArray = struct
     | d -> Some (DynArray.get d 0)
 
   (** Finds the *last* element in the array satisfying p, and returns also its index. *)
-  let findi_opt (type a) (d : a DynArray.t) (p : a -> bool) : (int * a) option =
+  let rfind_opt_idx (type a) (d : a DynArray.t) (p : a -> bool) : (int * a) option =
     let rec go = function
       | -1 -> None
       | k ->


### PR DESCRIPTION
Resolve partially #152

This PR adds serilazations of harpoon related data types. I think they are parse-able and reinstantiable, but I'm not 100% sure.