### PR TITLE
Implement computational _

### DIFF
--- a/examples/codatatypes/howes-method/howe-total.bel
+++ b/examples/codatatypes/howes-method/howe-total.bel
@@ -177,7 +177,7 @@ mlam M => case [_ |- M] of
 
 rec osim_howe : (g:ctx) OSim [|- T] [g |- M] [g |- N] -> Howe [|- T] [g |- M] [g |- N] =
 / total s (osim_howe g t m n s) /
-    fun s => howe_osim_trans (howe_refl [_ |- _]) s
+    fun s => howe_osim_trans (howe_refl _) s
 ;
 
 rec sim_howe : Sim [|- T] [|- M] [|- N] -> Howe [|- T] [|- M] [|- N] =
@@ -261,12 +261,12 @@ case h of
     | Howe_unit s => howe_osim_trans (howe_refl [h |- _]) (osim_cus [h |- $S2] s)
     | Howe_var [g |- #p] s => howe_subst_var h hs
     | Howe_lam h' s =>
-      Howe_lam (howe_subst h' (HCons (howe_subst_wkn [|- _] hs) (howe_refl [h,x:term _ |- x])))
+      Howe_lam (howe_subst h' (HCons (howe_subst_wkn _ hs) (howe_refl [h,x:term _ |- x])))
                (osim_cus [h |- $S2] s)
     | Howe_app h1' h2' s =>
       Howe_app (howe_subst h1' hs) (howe_subst h2' hs) (osim_cus [h |- $S2] s)
     | Howe_fix h' s =>
-      Howe_fix (howe_subst h' (HCons (howe_subst_wkn [|- _] hs) (howe_refl [h,x:term _ |- x])))
+      Howe_fix (howe_subst h' (HCons (howe_subst_wkn _ hs) (howe_refl [h,x:term _ |- x])))
                (osim_cus [h |- $S2] s)
     | Howe_nil s => howe_osim_trans (howe_refl [h |- _]) (osim_cus [h |- $S2] s)
     | Howe_cons h1' h2' s =>
@@ -274,7 +274,7 @@ case h of
     | Howe_case h' h1' h2' s =>
       Howe_case (howe_subst h' hs) (howe_subst h1' hs)
                 (howe_subst h2'
-                      (HCons (HCons (howe_subst_wkn [|- _] (howe_subst_wkn [|- _] hs))
+                      (HCons (HCons (howe_subst_wkn _ (howe_subst_wkn _ hs))
                              (howe_refl [h,x:term _, y:term _ |- x]))
                           (howe_refl [h,x:term _, y:term _ |- y])))
                 (osim_cus [h |- $S2] s)

--- a/examples/codatatypes/howes-method/howe.bel
+++ b/examples/codatatypes/howes-method/howe.bel
@@ -168,7 +168,7 @@ fun [g |- unit] => Howe_unit osim_refl
 ;
 
 rec osim_howe : (g:ctx) OSim [|- T] [g |- M] [g |- N] -> Howe [|- T] [g |- M] [g |- N] =
-    fun s => howe_osim_trans (howe_refl [_ |- _]) s
+    fun s => howe_osim_trans (howe_refl _) s
 ;
 
 rec sim_howe : Sim [|- T] [|- M] [|- N] -> Howe [|- T] [|- M] [|- N] =
@@ -238,12 +238,12 @@ case h of
     | Howe_unit s => howe_osim_trans (howe_refl [h |- _]) (osim_cus [h |- $S2] s)
     | Howe_var [g |- #p] s => howe_subst_var h hs
     | Howe_lam h' s =>
-      Howe_lam (howe_subst h' (HCons (howe_subst_wkn [|- _] hs) (howe_refl [h,x:term _ |- x])))
+      Howe_lam (howe_subst h' (HCons (howe_subst_wkn _ hs) (howe_refl [h,x:term _ |- x])))
                (osim_cus [h |- $S2] s)
     | Howe_app h1' h2' s =>
       Howe_app (howe_subst h1' hs) (howe_subst h2' hs) (osim_cus [h |- $S2] s)
     | Howe_fix h' s =>
-      Howe_fix (howe_subst h' (HCons (howe_subst_wkn [|- _] hs) (howe_refl [h,x:term _ |- x])))
+      Howe_fix (howe_subst h' (HCons (howe_subst_wkn _ hs) (howe_refl [h,x:term _ |- x])))
                (osim_cus [h |- $S2] s)
     | Howe_nil s => howe_osim_trans (howe_refl [h |- _]) (osim_cus [h |- $S2] s)
     | Howe_cons h1' h2' s =>
@@ -251,7 +251,7 @@ case h of
     | Howe_case h' h1' h2' s =>
       Howe_case (howe_subst h' hs) (howe_subst h1' hs)
                 (howe_subst h2'
-                      (HCons (HCons (howe_subst_wkn [|- _] (howe_subst_wkn [|- _] hs))
+                      (HCons (HCons (howe_subst_wkn _ (howe_subst_wkn _ hs))
                              (howe_refl [h,x:term _, y:term _ |- x]))
                           (howe_refl [h,x:term _, y:term _ |- y])))
                 (osim_cus [h |- $S2] s)

--- a/examples/cpp13/cchoist.bel
+++ b/examples/cpp13/cchoist.bel
@@ -269,7 +269,7 @@ rec weakenEnv1:(g:tctx)
 mlam Env1, Env2, Env3 => fn prf => fn m => case prf of
 | App_nil =>  m
 | App_cons p =>
-  let [g,l: target _ |- M'] = weakenEnv1 [|- _ ] [|- _ ] [|- _] p m in
+  let [g,l: target _ |- M'] = weakenEnv1 _ _ _ p m in
     [g,l:target _  |- M' [.., crst l] ]
 ;
 
@@ -283,11 +283,11 @@ mlam Env1, Env2, Env3 => fn prf => fn n => case prf of
 | App_nil =>
   let ExEnv a = append [|- Env2] [|- env_nil] in
   let [ |- refl] = append_nil a in
-    weakenEnv1 [|- _ ] [|- _ ] [ |- _ ] a n
+    weakenEnv1 _ _ _ a n
 | App_cons p =>
   let [g,l:target (cross S[] L1'[]) |- N]  = n in
   let [g,x:target S[], l:target L3'[] |- N'[..,x,l]] =
-     weakenEnv2 [|- _ ] [|- _ ][|- _ ] p [g,x:target S[],l:target L1'[] |-  N[ .. , ccons x l]] in
+     weakenEnv2 _ _ _ p [g,x:target S[],l:target L1'[] |-  N[ .. , ccons x l]] in
     [g,l:target (cross S[] L3'[]) |- N'[ .. , cfst l , crst l] ]
 
 ;
@@ -311,16 +311,16 @@ fn e => fn sigma => let (sigma : Map [h] [g]) = sigma in case e of
   let Result r1 [|- Env1]  = hcc [g |- M ] sigma in
   let Result r2 [|- Env2]  = hcc [g |- N ] sigma in
   let ExEnv (a12 : Append [|- _ ] [|- _ ] [|- Env3])  = append [|- Env1] [|- Env2] in
-  let [h, l:target L |- P] = weakenEnv2 [|- _ ] [|- _ ] [|- _ ] a12 r1  in
-  let [h, l:target L |- Q] = weakenEnv1 [|- _ ] [|- _ ] [|- _ ] a12 r2 in
+  let [h, l:target L |- P] = weakenEnv2 _ _ _ a12 r1  in
+  let [h, l:target L |- Q] = weakenEnv1 _ _ _ a12 r2 in
     Result [h, l:target L |- copen P \e.\xf.\xenv. capp xf (ccons  Q [..,l] xenv)] [|- Env3]
 
 | [g |- letv M \x. N] =>
   let Result r1 [|- Env1] = hcc [g |- M] sigma in
   let Result r2 [|- Env2] = hcc [g,x: source _ |- N] (extend sigma) in
   let ExEnv (a12 : Append [|- _] [|- _] [|- Env3]) = append [|- Env1] [|- Env2] in
-  let [h, l:target L[] |- P]                      = weakenEnv2 [|- _ ] [|- _ ] [|- _ ] a12 r1  in
-  let [h,x:target T1[], l:target L[] |- Q]        = weakenEnv1 [|- _ ] [|- _ ] [|- _ ] a12 r2 in
+  let [h, l:target L[] |- P]                      = weakenEnv2 _ _ _ a12 r1 in
+  let [h,x:target T1[], l:target L[] |- Q]        = weakenEnv1 _ _ _ a12 r2 in
     Result [h, l:target L[] |- clet P (\x. Q[..,x,l])] [|- Env3]
 
 | [g |- lam \x.M] =>
@@ -336,8 +336,8 @@ fn e => fn sigma => let (sigma : Map [h] [g]) = sigma in case e of
   let Result r1 [|- Env1] = hcc [g |- M] sigma in
   let Result r2 [|- Env2] = hcc [g |- N] sigma in
   let ExEnv (a12 : Append [|- _] [|- _] [|- Env3]) = append [|- Env1] [|- Env2] in
-  let [h, l:target L[] |- P]                      = weakenEnv2 [|- _ ] [|- _ ] [|- _ ] a12 r1 in
-  let [h, l:target L[] |- Q]                      = weakenEnv1 [|- _ ] [|- _ ] [|- _ ] a12 r2 in
+  let [h, l:target L[] |- P]                      = weakenEnv2 _ _ _ a12 r1 in
+  let [h, l:target L[] |- Q]                      = weakenEnv1 _ _ _ a12 r2 in
     Result [h, l:target L[] |- ccons P Q]  [|- Env3]
 
 | [g |- fst M] =>

--- a/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
+++ b/examples/literate_beluga/2Advanced/Normalization_by_Evaluation.bel
@@ -83,7 +83,7 @@ We evaluate a term in an environment providing semantic values for each free var
 rec eval : [g |- tm S[]] -> Env [g] [h] -> Sem [h] [ |- S]  =
 fn t => fn s => let s : Env [g] [h] = s in
 case t of
-| [g |- #p ] =>  s [ |- _] [g |- #p ]
+| [g |- #p ] => s _ [g |- #p ]
 | [g |- lam (\x. E) ] =>
   Arr [h] (mlam h' => mlam $W => fn e =>
      eval [g,x:tm _ |- E] (env_ext (env_wkn [h'] [h] [h' |- $W] s) e))

--- a/examples/literate_beluga/2Advanced/Weak_Normalization.bel
+++ b/examples/literate_beluga/2Advanced/Weak_Normalization.bel
@@ -163,7 +163,7 @@ rec main : {g:ctx}{M:[g |- tm A[]]} RedSub [g] [ |- $S[^]] -> Reduce [|- A] [ |-
     bwd_closed [ |- beta] (main [g,x:tm _] [g,x |- M1] (Dot rs rN)))
  | [g |- app M1 M2] =>
   let Arr ha f = main [g] [g |- M1] rs in
-  f [ |- _ ] (main [g] [g |- M2] rs)
+  f _ (main [g] [g |- M2] rs)
 | [g' |-  c] => I [ |- halts/m refl val/c]
 ;
 

--- a/examples/logrel/algeq-simplified.bel
+++ b/examples/logrel/algeq-simplified.bel
@@ -305,7 +305,7 @@ mlam T => fn e1 => fn e2 => case [|- T] of
   LogArr [g |-  M] [g |-  P] (mlam h,$W,V1,V2 => fn v =>
    logEqTrans [|- T2] (f1 [h] [h |- $W] [h |-  V1] [h |-  V2] v)
                       (f2 [h] [h |- $W] [h |-  V2] [h |-  V2]
-                      (logEqTrans [|- T1] (logEqSym [|- _ ] v) v)));
+                      (logEqTrans [|- T1] (logEqSym _ v) v)));
 
 schema ctx = tm;
 
@@ -378,7 +378,7 @@ rec logEqSubSym :
  / total e (logEqSubSym g g h sigma sigma' e) /
 fn e => case e of
 | Nil => Nil
-| Dot e' e1 => Dot (logEqSubSym e') (logEqSym  [|- _ ] e1);
+| Dot e' e1 => Dot (logEqSubSym e') (logEqSym _ e1);
 
 % % Transitivity of logical equivalence on substitutions
 rec logEqSubTrans :
@@ -388,7 +388,7 @@ rec logEqSubTrans :
 / total e1 (logEqSubTrans g g h s1 s2 s3 e1) /
 fn e1 => fn e2 => case e1 of
 | Nil => let Nil = e2 in Nil
-| Dot e1' x1 => let Dot e2' x2 = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans [|- _ ] x1 x2);
+| Dot e1' x1 => let Dot e2' x2 = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans _ x1 x2);
 
 
 % Fundamental theorem
@@ -406,16 +406,16 @@ case d of
    LogArr [h |-  lam (\x. M1[$S1[..], x])] [h |-  lam (\x. M2[$S2[..], x])]
      (mlam h0, $W, N1, N2 => fn rn =>
      let q2 = thm d1 (Dot (wknLogSub [h0] [h] [h0 |- $W] s) rn) in
-     closed [ |- _ ] [h0 |-  trans1 beta refl] [h0 |-  trans1 beta refl] q2
+     closed _ [h0 |-  trans1 beta refl] [h0 |-  trans1 beta refl] q2
    )
 | DecExt d1 =>
   LogArr [h |-  _] [h |-  _] (mlam h0,$W,N1,N2 => fn rn =>
    thm d1 (Dot (wknLogSub [h0] [h] [h0 |- $W] s) rn)
   )
 | DecBeta d1 d2 =>
-   closed [|- _ ] [h |-  trans1 beta refl] [h |-  refl] (thm d1 (Dot s (thm d2 s)))
-| DecSym d1 => logEqSym [|- _ ] (thm d1 (logEqSubSym s))
-| DecTrans d1 d2 => logEqTrans [|- _ ] (thm d1 s) (thm d2 (logEqSubTrans (logEqSubSym s) s))
+   closed _ [h |-  trans1 beta refl] [h |-  refl] (thm d1 (Dot s (thm d2 s)))
+| DecSym d1 => logEqSym _ (thm d1 (logEqSubSym s))
+| DecTrans d1 d2 => logEqTrans _ (thm d1 s) (thm d2 (logEqSubTrans (logEqSubSym s) s))
 ;
 
 inductive IdSub : {G:[|-dctx]}{g:ctx}(g':tctx){$Id:[g' |- g]} ctype =
@@ -433,11 +433,11 @@ rec idLogSub : IdSub [|-G] [g] [g' |- $Id]
 | ISnoc (r' : IdSub [|- G] [g] [g' |- $Id]) =>
   let q = idLogSub r' in
   Dot (wknLogSub [g',b:block x:tm,a:algeqNeu x x _] [g'] [g',b |-..] (idLogSub r'))
-      (reflect [ |- _] [g',b:block x:tm,y:algeqNeu x x _ |- b.2])
+      (reflect _ [g',b:block x:tm,y:algeqNeu x x _ |- b.2])
 ;
 
 rec completeness : IdSub [|-G] [g] [g' |- $Id]
 -> Decl [|-G] [g |- M1 sim M2] [ |- T]
 -> [g' |- algeq M1[$Id] M2[$Id] T[]] =
  / total (completeness) /
-   fn r => fn e => reify [|-_] (thm e (idLogSub r));
+   fn r => fn e => reify _ (thm e (idLogSub r));

--- a/examples/logrel/algeq-simplified1.bel
+++ b/examples/logrel/algeq-simplified1.bel
@@ -298,7 +298,7 @@ mlam T => fn e1 => fn e2 => case [|- T] of
   LogArr [g |-  M] [g |-  P] (mlam h,$W,V1,V2 => fn v =>
    logEqTrans [|- T2] (f1 [h] [h |- $W] [h |-  V1] [h |-  V2] v)
                       (f2 [h] [h |- $W] [h |-  V2] [h |-  V2]
-                      (logEqTrans [|- T1] (logEqSym [|- _ ] v) v)));
+                      (logEqTrans [|- T1] (logEqSym _ v) v)));
 
 schema ctx = tm;
 
@@ -371,7 +371,7 @@ rec logEqSubSym :
  / total e (logEqSubSym g g h sigma sigma' e) /
 fn e => case e of
 | Nil => Nil
-| Dot e' e1 => Dot (logEqSubSym e') (logEqSym  [|- _ ] e1);
+| Dot e' e1 => Dot (logEqSubSym e') (logEqSym  _ e1);
 
 % % Transitivity of logical equivalence on substitutions
 rec logEqSubTrans :
@@ -381,7 +381,7 @@ rec logEqSubTrans :
 / total e1 (logEqSubTrans g g h s1 s2 s3 e1) /
 fn e1 => fn e2 => case e1 of
 | Nil => let Nil = e2 in Nil
-| Dot e1' x1 => let Dot e2' x2 = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans [|- _ ] x1 x2);
+| Dot e1' x1 => let Dot e2' x2 = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans _ x1 x2);
 
 
 % Fundamental theorem
@@ -399,16 +399,16 @@ case d of
    LogArr [h |-  lam (\x. M1[$S1[..], x])] [h |-  lam (\x. M2[$S2[..], x])]
      (mlam h0, $W, N1, N2 => fn rn =>
      let q2 = thm d1 (Dot (wknLogEqSub [h0] [h] [h0 |- $W] s) rn) in
-     closed [ |- _ ] [h0 |-  trans1 beta refl] [h0 |-  trans1 beta refl] q2
+     closed _ [h0 |-  trans1 beta refl] [h0 |-  trans1 beta refl] q2
    )
 | DecExt d1 =>
   LogArr [h |-  _] [h |-  _] (mlam h0,$W,N1,N2 => fn rn =>
    thm d1 (Dot (wknLogEqSub [h0] [h] [h0 |- $W] s) rn)
   )
 | DecBeta d1 d2 =>
-   closed [|- _ ] [h |-  trans1 beta refl] [h |-  refl] (thm d1 (Dot s (thm d2 s)))
-| DecSym d1 => logEqSym [|- _ ] (thm d1 (logEqSubSym s))
-| DecTrans d1 d2 => logEqTrans [|- _ ] (thm d1 s) (thm d2 (logEqSubTrans (logEqSubSym s) s))
+   closed _ [h |-  trans1 beta refl] [h |-  refl] (thm d1 (Dot s (thm d2 s)))
+| DecSym d1 => logEqSym _ (thm d1 (logEqSubSym s))
+| DecTrans d1 d2 => logEqTrans _ (thm d1 s) (thm d2 (logEqSubTrans (logEqSubSym s) s))
 ;
 
 inductive IdSub : {G:[|-dctx]}{g:ctx}(g':tctx){$Id:[g' |- g]} ctype =
@@ -426,11 +426,11 @@ rec idLogEqSub : IdSub [|-G] [g] [g' |- $Id]
 | ISnoc (r' : IdSub [|- G] [g] [g' |- $Id]) =>
   let q = idLogEqSub r' in
   Dot (wknLogEqSub [g',b:block x:tm,a:algeqr x x _] [g'] [g',b |-..] (idLogEqSub r'))
-      (reflect [ |- _] [g',b:block x:tm,y:algeqr x x _ |- b.2])
+      (reflect _ [g',b:block x:tm,y:algeqr x x _ |- b.2])
 ;
 
 rec completeness : IdSub [|-G] [g] [g' |- $Id]
 -> DecEq [|-G] [g |-  M1] [g |-  M2] [ |- T]
 -> [g' |- algeqn M1[$Id] M2[$Id] T[]] =
  / total (completeness) /
-   fn r => fn e => reify [|-_] (thm e (idLogEqSub r));
+   fn r => fn e => reify _ (thm e (idLogEqSub r));

--- a/examples/logrel/algeq-typing.bel
+++ b/examples/logrel/algeq-typing.bel
@@ -312,7 +312,7 @@ mlam T => fn e1 => fn e2 => case [|- T] of
   LogArr [g |-  M] [g |-  P] (mlam h,$W,V1,D1,V2,D2 => fn v =>
    logEqTrans [|- T2] (f1 [h] [h |- $W] [h |-  V1] [h|- D1] [h |-  V2] [h |- D2] v)
                       (f2 [h] [h |- $W] [h |-  V2] [h|- D2] [h |-  V2] [h |- D2]
-                      (logEqTrans [|- T1] (logEqSym [|- _ ] v) v)));
+                      (logEqTrans [|- T1] (logEqSym _ v) v)));
 
 
 deq : tm -> tm -> tp -> type.
@@ -366,7 +366,7 @@ rec logEqSubSym :
  / total e (logEqSubSym g h sigma sigma' e) /
 fn e => case e of
 | Nil => Nil
-| Dot e' e1 [h |- D1] [h |- D2] => Dot (logEqSubSym e') (logEqSym  [|- _ ] e1) [h |- D2] [h |- D1];
+| Dot e' e1 [h |- D1] [h |- D2] => Dot (logEqSubSym e') (logEqSym _ e1) [h |- D2] [h |- D1];
 
 % Transitivity of logical equivalence on substitutions
 rec logEqSubTrans :
@@ -376,7 +376,7 @@ rec logEqSubTrans :
 / total e1 (logEqSubTrans g g h s1 s2 s3 e1) /
 fn e1 => fn e2 => case e1 of
 | Nil => let Nil = e2 in Nil
-| Dot e1' x1 [h |- D1] [h |- D2] => let Dot e2' x2 [h |- D3] [h |- D4] = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans [|- _ ] x1 x2) [h |- D1] [h |- D4];
+| Dot e1' x1 [h |- D1] [h |- D2] => let Dot e2' x2 [h |- D3] [h |- D4] = e2 in Dot (logEqSubTrans e1' e2') (logEqTrans _ x1 x2) [h |- D1] [h |- D4];
 
 
 rec lookup : {g:ctx}{#p:[g |- block (x:tm, u: oft x Q[])]} LogSub [g] [h |- $S1] [h |- $S2]
@@ -477,7 +477,7 @@ case d of
   let [h |- E1] = dtp1 [h |- D2[$S1]] in
   let [h |- E2] = dtp2 [h |- D2[$S2]] in
    let q0 = thm [g,b:block x:tm,y:oft x _ |- D1[..,b.1,b.2]] (Dot s (thm [g |- D2] s)  [h |- E1] [h |- E2]) in
-   closed [|- _] [h |- trans1 beta refl] [h |- refl] q0
+   closed _ [h |- trans1 beta refl] [h |- refl] q0
 | [g |- d_lam \x.\y. E1] =>
   let ([g |- _ ] : [g |- deq (lam \x.M1) (lam \x.M2) (arr P[] Q[])]) = d in
   LogArr [h |- lam (\x. M1[$S1[..],x])] [h |- lam (\x. M2[$S2[..],x])]
@@ -493,8 +493,8 @@ case d of
     thm [g,b:block x:tm,y:oft x _ |- D0[..,b.1,b.2]] q0
   )
 | [g |- d_refl D1] => thm' [g |- D1] s
-| [g |- d_sym D1] => logEqSym [|- _] (thm [g |- D1] (logEqSubSym s))
-| [g |- d_trans D1 D2] => logEqTrans [|- _] (thm [g |- D1] s) (thm [g |- D2] (logEqSubTrans (logEqSubSym s) s))
+| [g |- d_sym D1] => logEqSym _ (thm [g |- D1] (logEqSubSym s))
+| [g |- d_trans D1 D2] => logEqTrans _ (thm [g |- D1] s) (thm [g |- D2] (logEqSubTrans (logEqSubSym s) s))
 ;
 
 

--- a/examples/logrel/weak-norm-closed-ideal.bel
+++ b/examples/logrel/weak-norm-closed-ideal.bel
@@ -93,11 +93,11 @@ rec eval : {g:ctx}{M:[g |- tm A[]]} RedSub [g] [ |- $S[^]] -> Reduce [|- A]  [ |
 | [g |- lam (\x. M1)] =>
  Arr [ |- halts/m refl val/lam]
    (mlam N => fn rN =>
-    closed [|- _ ] [ |- _ ] [ |- _ ]
+    closed _ _ _
            [ |- beta] (eval [g,x:tm _] [g,x |- M1] (Dot rs rN)))
  | [g |- app M1 M2] =>
   let Arr ha f = eval [g] [g |- M1] rs in
-  f [ |- _ ] (eval [g] [g |- M2] rs)
+  f _ (eval [g] [g |- M2] rs)
 | [g' |-  c] => I [ |- halts/m refl val/c]
 ;
 

--- a/examples/logrel/weak-norm-total-mix-lf-inductive.bel
+++ b/examples/logrel/weak-norm-total-mix-lf-inductive.bel
@@ -136,13 +136,13 @@ rec bwd_closed' : {A:[|- tp]}{M:[|- tm A]}{M':[|- tm A]} Step [ |- M] [ |-  M'] 
   let Arr ha f = r in
     Arr (halts_step s ha)
 	(mlam N => fn rn =>
-	 bwd_closed' [|- B] [|- _ ] [|- _ ] (Stepapp s) (f [ |- N] rn))
+	 bwd_closed' [|- B] _ _ (Stepapp s) (f [ |- N] rn))
 ;
 
 
 rec bwd_closed : Step [ |- M] [ |- M'] -> Reduce [|- A] [ |- M'] -> Reduce [|- A] [ |- M] =
 / total (bwd_closed) /
-fn s, r =>   bwd_closed' [|- _ ] [|- _ ] [|- _ ]  s r;
+fn s, r => bwd_closed' _ _ _ s r;
 
 
 %{{
@@ -200,7 +200,7 @@ mlam gamma, M => fn rs => case [gamma |- M] of
 
 | [gamma |- app M1 M2] =>
   let Arr ha f = main [gamma] [gamma |- M1] rs in
-  f [ |- _ ] (main [gamma] [gamma |- M2] rs)
+  f _ (main [gamma] [gamma |- M2] rs)
 | [gamma |-  c] =>  I (Halts Refl Val/c)
 ;
 

--- a/examples/logrel/weak-norm-total-products-explicit-typing.bel
+++ b/examples/logrel/weak-norm-total-products-explicit-typing.bel
@@ -139,7 +139,7 @@ mlam g => fn d => fn s => case d of
       (mlam N => fn r => bwd_closed [ |- beta ] (main [g,x:tm] d1 (Dot s r)))
 | App d1 d2 =>
   let Arr h f = main [g] d1 s in
-  f [|- _] (main [g] d2 s)
+  f _ (main [g] d2 s)
 | C => I [|- halts/m refl val/c ]
 | Fst d => let Prod h r1 r2 = main [g] d s in r1
 | Snd d => let Prod h r1 r2 = main [g] d s in r2

--- a/examples/logrel/weak-norm-total-products.bel
+++ b/examples/logrel/weak-norm-total-products.bel
@@ -165,13 +165,13 @@ rec bwd_closed' : {A:[|- tp]}{M:[|- tm A]}{M':[|- tm A]}
   let Arr ha f = r in
     Arr (halts_step [ |- MS] ha)
 	(mlam N => fn rn =>
-	 bwd_closed' [|- B] [|- _ ] [|- _ ] [ |- stepapp MS] (f [ |- N] rn))
+	 bwd_closed' [|- B] _ _ [ |- stepapp MS] (f [ |- N] rn))
 
 | [|- cross A B] =>
    let Cross ha r1 r2 = r in
    Cross (halts_step [|- MS] ha)
-	 (bwd_closed' [|- A] [|- _ ] [|- _ ] [|- stepfst MS] r1)
-	 (bwd_closed' [|- B] [|- _ ] [|- _ ] [|- stepsnd MS] r2)
+	 (bwd_closed' [|- A] _ _ [|- stepfst MS] r1)
+	 (bwd_closed' [|- B] _ _ [|- stepsnd MS] r2)
 
 ;
 
@@ -217,7 +217,7 @@ rec pair_mstep1 : {M1:[|- tm A]}{M2:[|- tm B]}[|- mstep M1 V1] ->
 mlam M1, M2 => fn ms1 => case ms1 of
 | [|- refl] => [|- refl]
 | [|- onestep S MS] =>
-  let [|- MS'] = pair_mstep1 [|- _ ] [|- M2] [|- MS] in
+  let [|- MS'] = pair_mstep1 _ [|- M2] [|- MS] in
      [ |- onestep (step_pairl S) MS']
 ;
 
@@ -227,7 +227,7 @@ rec pair_mstep2 : {V:[|- tm A]}{M2:[|- tm B]}[|- mstep M2 V2] ->
 mlam V, M2 => fn ms2 => case ms2 of
 | [|- refl] => [|- refl]
 | [|- onestep S MS] =>
-  let [|- MS'] = pair_mstep2 [|- V ] [|- _ ] [|- MS] in
+  let [|- MS'] = pair_mstep2 [|- V ] _ [|- MS] in
      [ |- onestep (step_pairr S) MS']
 ;
 
@@ -266,7 +266,7 @@ mlam gamma, M => fn rs => case [gamma |- M] of
 
 | [gamma |- app M1 M2] =>
   let Arr ha f = main [gamma] [gamma |- M1] rs in
-  f [ |- _ ] (main [gamma] [gamma |- M2] rs)
+  f _ (main [gamma] [gamma |- M2] rs)
 | [gamma |-  c] =>  I [ |- halts/m refl val/c]
 
 | [gamma |- pair M1 M2] =>
@@ -274,7 +274,7 @@ mlam gamma, M => fn rs => case [gamma |- M] of
   let r2 = main [gamma] [gamma |- M2] rs in
   let h1 = reduce_halts r1 in
   let h2 = reduce_halts r2 in
-  Cross (pair_halts [|- _] [|- _] h1 h2)
+  Cross (pair_halts _ _ h1 h2)
 	(bwd_closed [|- step1pair] r1)
 	(bwd_closed [|- step2pair] r2)
 

--- a/examples/logrel/weak-norm-total.bel
+++ b/examples/logrel/weak-norm-total.bel
@@ -139,7 +139,7 @@ rec bwd_closed' : {A:[|- tp]}{M:[|- tm A]}{M':[|- tm A]}{S:[ |- step M M']} Redu
   let Arr ha f = r in
     Arr (halts_step [ |- MS] ha)
 	(mlam N => fn rn =>
-	 bwd_closed' [|- B] [|- _ ] [|- _ ] [ |- stepapp MS] (f [ |- N] rn))
+	 bwd_closed' [|- B] _ _ [ |- stepapp MS] (f [ |- N] rn))
 ;
 
 rec bwd_closed : {S:[ |- step M M']} Reduce [|- A] [ |- M'] -> Reduce [|- A] [ |- M] =
@@ -204,7 +204,7 @@ mlam gamma, M => fn rs => case [gamma |- M] of
 
 | [gamma |- app M1 M2] =>
   let Arr ha f = main [gamma] [gamma |- M1] rs in
-  f [ |- _ ] (main [gamma] [gamma |- M2] rs)
+  f _ (main [gamma] [gamma |- M2] rs)
 | [gamma |-  c] =>  I [ |- halts/m refl val/c]
 ;
 

--- a/examples/logrel/weak-norm-under-binders-beta-only.bel
+++ b/examples/logrel/weak-norm-under-binders-beta-only.bel
@@ -97,7 +97,7 @@ fn s,r => case s of
 | [g |- s_refl] => r
 | [g |- s_trans S MS] =>
   let r' = m_closed [g |- MS] r in
-  closed [|- _] [_ |- _] [_ |- _] [_ |- S] r'
+  closed _ _ _ [_ |- S] r'
 ;
 
 rec m_app2 : (g:nctx) {M:[g |- tm (arr A[] B[])]} [g |- mstep N N'] -> [g |- mstep (app M N) (app M N')] =
@@ -114,7 +114,7 @@ rec m_lam : (g:nctx) {M:[g, x:tm A[] |- tm B[]]} [g, b:block (x:tm A[], u:neutra
 mlam M => fn s => case s of
 | [g, b:block (x:tm A[], u:neutral x) |- s_refl] => [g |- s_refl]
 | [g, b:block (x:tm A[], u:neutral x) |- s_trans S[..,b.1] MS] =>
-  let [g |- MS'] = m_lam [_ |- _] [g,b:block (x:tm A[], u:neutral x) |- MS] in
+  let [g |- MS'] = m_lam _ [g,b:block (x:tm A[], u:neutral x) |- MS] in
   [g |- s_trans (s_lam (\x. S)) MS']
 
 ;
@@ -130,7 +130,7 @@ mlam gamma, A,R,NR => case [ |- A] of
   Arr [gamma |- R] (Halts [gamma |- R] [gamma |- s_refl] [gamma |- n_neut NR])
   (mlam h => mlam $W => mlam M2 => fn rm2 =>
     let Halts [_ |- _] ms [_ |- N] = reify [h] [|- A] [h |- M2] rm2 in
-    m_closed  (m_app2 [_ |- _] ms)
+    m_closed  (m_app2 _ ms)
              (reflect [h] [|- B] [h |- _ ] [_ |- n_app NR[$W] N]))
 
 and rec reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
@@ -155,9 +155,9 @@ rec monotone : (h:nctx) {$W:[h |- g]} Reduce  [ |- A] [g |- M] -> Reduce [ |- A]
 / total (monotone) /
 mlam $W => fn r =>
 case r of
-| Base (Halts [_ |- _] [g |- S] [g |- NR]) => Base (Halts [_ |- _] [_ |- S[$W]] [_ |- NR[$W]])
+| Base (Halts [_ |- _] [g |- S] [g |- NR]) => Base (Halts _ [_ |- S[$W]] [_ |- NR[$W]])
 | Arr [g |- M] (Halts [_ |- _] [g |- S] [g |- NR]) f =>
-  Arr [_ |- M[$W]] (Halts [_ |- _] [_ |- S[$W]] [_ |- NR[$W]])
+  Arr [_ |- M[$W]] (Halts _ [_ |- S[$W]] [_ |- NR[$W]])
    (mlam h', $W2, N => fn rn =>
     f [h'] [h' |- $W[$W2]] [h' |-  N] rn);
 
@@ -194,20 +194,20 @@ mlam M => fn rs => let (rs : LogSub [gamma] [phi |- $S] ) = rs in
   let Arr [phi |- _ ] h f = eval [gamma |-  M1]  rs in
    f [phi] [phi |- ..] [phi |- M2[$S]] (eval [gamma |-  M2] rs)
 | [gamma |-  lam (\x. M1)] =>
-   let rx = reflect [phi,b:block x:tm _,y:neutral x] [|- _] [phi,b |- b.1] [phi,b |- b.2] in
+   let rx = reflect [phi,b:block x:tm _,y:neutral x] _ [phi,b |- b.1] [phi,b |- b.2] in
    let q0 = eval [gamma,x:tm _ |- M1]
                  (Dot (monotoneSub [phi,b:block x:tm _,y:neutral x |- ..] rs) rx) in
    let
         Halts [phi,b:block x:tm A1[],y:neutral x |- _]
               [phi,b:block x:tm A1[],y:neutral x |- MS]
               [phi,b:block x:tm A1[],y:neutral x |- NV]
-     = reify [phi,b:block x:tm _,y:neutral x] [|- _] [phi,b |- M1[$S[..],b.1]] q0 in
+     = reify [phi,b:block x:tm _,y:neutral x] _ [phi,b |- M1[$S[..],b.1]] q0 in
    Arr [phi |- lam (\x. M1[$S[..], x])]
-   (Halts [_ |- _]
+   (Halts _
      (m_lam [phi, x:tm A1[]  |- M1[$S[..],x]]  [phi, b:block (x:tm A1[], y:neutral x) |- MS])
      [phi |- n_lam (\x.\y. NV[..,<x;y>])])
    (mlam psi,$W,N => fn rN =>
-     closed [|- _ ] [psi |- app (lam \x.M1[$S[$W[..]],x]) N ] [psi |- M1[$S[$W[..]], N] ]
+     closed _ [psi |- app (lam \x.M1[$S[$W[..]],x]) N ] [psi |- M1[$S[$W[..]], N] ]
             [psi |-  s_beta] (eval [gamma,x:tm _ |-  M1] (Dot (monotoneSub [psi |- $W] rs) rN)))
 ;
 
@@ -225,12 +225,12 @@ fn r => case r of
 | INil => Nil
 | ISnoc r' =>
   Dot (monotoneSub [_,b:block x:tm _,y:neutral x |- ..] (idLogSub r'))
-      (reflect [_] [|- _] [_ |- _] [_,b:block x:tm _,y:neutral x |- b.2])
+      (reflect [_] _ _ [_,b:block x:tm _,y:neutral x |- b.2])
 ;
 
 rec weakNorm : {M:[g |- tm A[]]} IdSub [g] [g' |- $Id] -> Halts  [ |- A] [g' |- M[$Id]] =
 / total (weakNorm) /
-mlam M => fn s => reify [_] [|- _] [_ |- _] (eval [_ |- M] (idLogSub s));
+mlam M => fn s => reify [_] _ _ (eval [_ |- M] (idLogSub s));
 
 % We probably want to show also that for any g:ctx there exists g':nctx and $Id:[g' |- g]
 % such that IdSub [g] [g' |- $Id]...

--- a/examples/logrel/weak-norm-under-binders-simplified.bel
+++ b/examples/logrel/weak-norm-under-binders-simplified.bel
@@ -97,7 +97,7 @@ fn s,r => case s of
 | [g |- s_refl] => r
 | [g |- s_trans S MS] =>
   let r' = m_closed [g |- MS] r in
-  closed [|- _] [_ |- _] [_ |- _] [_ |- S] r'
+  closed _ _ _ [_ |- S] r'
 ;
 
 rec m_app2 : (g:nctx) {M:[g |- tm (arr A[] B[])]} [g |- mstep N N'] -> [g |- mstep (app M N) (app M N')] =
@@ -114,7 +114,7 @@ rec m_lam : (g:nctx) {M:[g,x:tm A[] |- tm B[]]} [g,x:tm A[] |- mstep M M'] -> [g
 mlam M => fn s => case s of
 | [g,x:tm A[] |- s_refl] => [g |- s_refl]
 | [g,x:tm A[] |- s_trans S MS] =>
-  let [g |- MS'] = m_lam [_ |- _] [g,x:tm A[] |- MS] in
+  let [g |- MS'] = m_lam _ [g,x:tm A[] |- MS] in
   [g |- s_trans (s_lam (\x. S)) MS']
 
 ;
@@ -130,7 +130,7 @@ mlam gamma, A,R,NR => case [ |- A] of
   Arr [gamma |- R]
   (mlam h => mlam $W => mlam M2 => fn rm2 =>
     let Halts [_ |- _] ms [_ |- N] = reify [h] [|- A] [h |- M2] rm2 in
-    m_closed  (m_app2 [_ |- _] ms)
+    m_closed  (m_app2 _ ms)
              (reflect [h] [|- B] [h |- _ ] [_ |- n_app NR[$W] N]))
 
 and rec reify : {g:nctx}{A:[|- tp]}{M:[g |- tm A[]]}
@@ -147,8 +147,8 @@ mlam g,A,M => fn r => case [|- A] of
             [g,b:block x:tm A[],y:neutral x |- MS]
             [g,b:block x:tm A[],y:neutral x |- N] = m in
   let [g,b:block x:tm A[],y:neutral x |- MS'[..,b.1]] = [g,b:block x:tm A[],y:neutral x |- MS] in % I am not sure why I have to do this separately
-  let [g |- MS''] = m_lam [_ |- _] [g,x:tm A[] |- MS'] in
-  Halts [_ |- _] [g |- s_trans (s_eta _) MS''] [g |- n_lam (\x. \y. N[..,<x;y>])]
+  let [g |- MS''] = m_lam _ [g,x:tm A[] |- MS'] in
+  Halts _ [g |- s_trans (s_eta _) MS''] [g |- n_lam (\x. \y. N[..,<x;y>])]
 ;
 
 
@@ -165,7 +165,7 @@ rec monotone : (h:nctx) {$W:[h |- g]} Reduce  [ |- A] [g |- M] -> Reduce [ |- A]
 / total (monotone) /
 mlam $W => fn r =>
 case r of
-| Base (Halts [_ |- _] [g |- S] [g |- NR]) => Base (Halts [_ |- _] [_ |- S[$W]] [_ |- NR[$W]])
+| Base (Halts [_ |- _] [g |- S] [g |- NR]) => Base (Halts _ [_ |- S[$W]] [_ |- NR[$W]])
 | Arr [g |- M] f =>
   Arr [_ |- M[$W]]
    (mlam h', $W2, N => fn rn =>
@@ -215,7 +215,7 @@ mlam M => fn rs => let (rs : LogSub [gamma] [phi |- $S] ) = rs in
 | [gamma |-  lam (\x. M1)] =>
    Arr [phi |- lam (\x. M1[$S[..], x])]
    (mlam psi,$W,N => fn rN =>
-     closed [|- _ ] [psi |- app (lam \x.M1[$S[$W[..]],x]) N ] [psi |- M1[$S[$W[..]], N] ]
+     closed _ [psi |- app (lam \x.M1[$S[$W[..]],x]) N ] [psi |- M1[$S[$W[..]], N] ]
             [psi |-  s_beta] (eval [gamma,x:tm _ |-  M1] (Dot (monotoneSub [psi |- $W] rs) rN)));
 
 % -----------------------------------------------------------------------------
@@ -232,12 +232,12 @@ fn r => case r of
 | INil => Nil
 | ISnoc r' =>
   Dot (monotoneSub [_,b:block x:tm _,y:neutral x |- ..] (idLogSub r'))
-      (reflect [_] [|- _] [_ |- _] [_,b:block x:tm _,y:neutral x |- b.2])
+      (reflect [_] _ _ [_,b:block x:tm _,y:neutral x |- b.2])
 ;
 
 rec weakNorm : {M:[g |- tm A[]]} IdSub [g] [g' |- $Id] -> Halts  [ |- A] [g' |- M[$Id]] =
 / total (weakNorm) /
-mlam M => fn s => reify [_] [|- _] [_ |- _] (eval [_ |- M] (idLogSub s));
+mlam M => fn s => reify [_] _ _ (eval [_ |- M] (idLogSub s));
 
 % We probably want to show also that for any g:ctx there exists g':nctx and $Id:[g' |- g]
 % such that IdSub [g] [g' |- $Id]...

--- a/examples/logrel/weak-norm-under-binders.bel
+++ b/examples/logrel/weak-norm-under-binders.bel
@@ -174,7 +174,7 @@ mlam g, A,R => fn r =>  case [ |- A] of
   Arr [g |- R]
   (mlam h => mlam $W => mlam M2 => fn iv => fn rm2 =>
     let Halts [h |- MS] n = reify [h] [|- A] [h |- M2] rm2 in
-    closed [|- _ ] [h |- _ ]  [h |- _ ] [h |- s_app s_refl (MS)]
+    closed _ [h |- _ ]  [h |- _ ] [h |- s_app s_refl (MS)]
            (reflect [h] [|- B] [h |- _ ] (App (rwkn r iv) n)))
 
 and rec reify : {g:ctx}{A:[|- tp]}{M:[g |- tm A[]]}
@@ -235,7 +235,7 @@ mlam g => case [g] of
 | [ ] => Nil
 | [g',x:tm A[]] =>
   Dot (wknRedSub (idRedSub [g']) (shiftIsVarSub [g']))
-      (reflect [g', x:tm A[]] [|- _ ] [g', x:tm A[] |- x ] (Var (IsVar [g',x:tm A[] |-  x])));
+      (reflect [g', x:tm A[]] _ [g', x:tm A[] |- x ] (Var (IsVar [g',x:tm A[] |-  x])));
 
 % -----------------------------------------------------------------------------
 % Main Lemma:
@@ -253,7 +253,7 @@ mlam M => fn rs => let (rs : RedSub [g] [h |- $S] ) = rs in
 | [g' |-  lam (\x. M1)] =>
    Arr [h |- lam (\x. M1[$S[..], x])]
    (mlam h' => mlam $W => mlam N => fn isVS => fn rN =>
-     closed [|- _ ] [h' |- _ ] [h' |- _ ]
+     closed _ [h' |- _ ] [h' |- _ ]
             [h' |-  s_beta] (eval [g',x:tm _ |-  M1] (Dot (wknRedSub rs isVS) rN)));
 
 % -----------------------------------------------------------------------------
@@ -261,4 +261,4 @@ mlam M => fn rs => let (rs : RedSub [g] [h |- $S] ) = rs in
 
 rec weakNorm : {g:ctx}{M:[g |- tm A[]]} Halts  [ |- A] [g |- M] =
 / total (weakNorm) /
-mlam g => mlam M => reify [g] [|- _] [g |- M]  (eval [g |- M] (idRedSub [g]));
+mlam g => mlam M => reify [g] _ [g |- M]  (eval [g |- M] (idRedSub [g]));

--- a/examples/logrel/weak-norm.bel
+++ b/examples/logrel/weak-norm.bel
@@ -180,7 +180,7 @@ rec main : {g:ctx}{M:[g |- tm A[]]} RedSub [g] [ |- $S[^]] -> Reduce [|- A] [ |-
     bwd_closed [ |- beta] (main [g,x:tm _] [g,x |- M1] (Dot rs rN)))
  | [g |- app M1 M2] =>
   let Rarr ha f = main [g] [g |- M1] rs in
-  f [ |- _ ] (main [g] [g |- M2] rs)
+  f _ (main [g] [g |- M2] rs)
 | [g' |-  c] => Rb [ |- halts/m refl val/c]
 ;
 

--- a/examples/popl12/nbe.bel
+++ b/examples/popl12/nbe.bel
@@ -107,7 +107,7 @@ and rec extendSem : [g |- neut (arr A[] B[])] ->
 fn r => mlam h => fn s => fn e =>
 let [h |- N ] = reify e in
 let [h |- R' ] = weak_neut s r in
-  reflect [ |- _ ] [h |- rapp (R') N]
+  reflect _ [h |- rapp (R') N]
 
 and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 / trust /
@@ -116,7 +116,7 @@ fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- arr T S ] =>
   (case e of
    | (Slam f)  =>
-     let s = (f [g,x:neut T[] ] (Succ [g] Zero) (reflect [ |- _ ] [g ,x:neut T[] |-  x])) in
+     let s = (f [g,x:neut T[] ] (Succ [g] Zero) (reflect _ [g ,x:neut T[] |-  x])) in
      let [g,x:neut T[] |-  E] = reify s
      in [g |- nlam (\x. E)])
 ;

--- a/examples/popl12/normeval-total.bel
+++ b/examples/popl12/normeval-total.bel
@@ -65,7 +65,7 @@ fn s => fn n =>
 let (s : {T:[ |- tp]} NeutVar [g] [ |- T] ->  NeutVar [h] [ |- T]) = s in
 case n of
 | {R:[g |- neut (atomic P[])]} [g |- embed (R ) ] =>
-  let [h |- R' ] = nsubst [h] [g] [|- _ ] s [g |- R ] in [h |- embed (R' )]
+  let [h |- R' ] = nsubst [h] [g] _ s [g |- R ] in [h |- embed (R' )]
 
  | {N:[g,x:neut S[]  |-  norm S'[]]}
    [g |- nlam (\x. N) ]  =>
@@ -82,7 +82,7 @@ rec subst : ({T:[ |- tp]} NeutVar [g] [ |- T] -> NeutVar [h] [ |- T])
 fn s => fn e =>
 let (s : {T:[ |- tp]} NeutVar [g] [ |- T] -> NeutVar [h] [ |- T]) = s in
 case e of
-| Syn [g |- R] => Syn (nsubst [h] [g] [|- _ ] s [g |- R])
+| Syn [g |- R] => Syn (nsubst [h] [g] _ s [g |- R])
 | Slam  [g] [|- A] [|- B] f =>
     Slam [h] [|- A] [|- B]
       (mlam h' => fn s' => fn e => f [h'] (mlam T => fn y => s' [ |- T] (s [ |- T] y)) e)
@@ -154,5 +154,5 @@ mlam T => fn y => let TmVar [ |- #p] = y in impossible [ |- #p] ;
 
 rec nbe : [ |- tm A] -> [ |- norm A] =
 / total (nbe) /
-fn t => reify  [] [|- _] (eval t initialMap)
+fn t => reify [] _ (eval t initialMap)
 ;

--- a/examples/popl12/normeval.bel
+++ b/examples/popl12/normeval.bel
@@ -135,7 +135,7 @@ and rec extendSem : [g |- neut (arr A[] B[])] ->
  fn r => mlam h => fn s => fn e =>
     let [h |- N ] = reify e in
     let [h |- R' ] = nsubst s r in
-       reflect [|- _ ] [h |- rapp (R') N]
+       reflect _ [h |- rapp (R') N]
 
 and rec reify : Sem [g] [ |- A] -> [g |- norm A[]] =
 % / total e (reify g a e) /
@@ -144,7 +144,7 @@ fn e => let (e : Sem [g] [ |- A]) = e in case [ |- A] of
 | [ |- arr T S ] =>
   (case e of
    | (Slam f)  =>
-     let s = (f [g,x:neut T[] ] weaken (reflect [|- _ ] [g ,x:neut T[] |-  x])) in
+     let s = (f [g,x:neut T[] ] weaken (reflect _ [g ,x:neut T[] |-  x])) in
      let [g,x:neut T[] |-  E] = reify s
      in [g |- nlam (\x. E)])
 ;

--- a/examples/unique/unique-crec.bel
+++ b/examples/unique/unique-crec.bel
@@ -84,7 +84,7 @@ mlam g => mlam E => fn d => fn f => case [g |- E ] of
     % #r.2 : type_of (#r.1) S'  = f : type_of (#p.1) T'
     % S' = T' ,  #r=#p  , R = S'
 
-    refl [ |- _ ]
+     refl _
 ;
 
 

--- a/examples/unique/unique.bel
+++ b/examples/unique/unique.bel
@@ -68,8 +68,8 @@ mlam g => mlam E => fn d => fn f => case [g |- E ] of
   let [g |- t_lam (\x.(\u. F))] = f in
   let [ |- C2] = unique [g,b: block x:exp, _t:type_of x T1[]]
                       [g,b |- E[..,b.1] ] [g,b |- D[..,b.1,b.2]] [g,b |- F[..,b.1,b.2]] in
- let [ |- C1] = refl [ |- T1 ] in
-   [ |- e_arr C1 C2]
+  let [ |- C1] = refl [ |- T1 ] in
+  [ |- e_arr C1 C2]
 
 | [g |- #p.1] =>
    % #p: l          block a:exp. type_of a R
@@ -86,8 +86,7 @@ mlam g => mlam E => fn d => fn f => case [g |- E ] of
    % #r.2 : type_of (#r.1) S'  = f : type_of (#p.1) T'
    % S' = T' ,  #r=#p  , R = S'
 
-    refl [ |- _ ]
-
+    refl _
 ;
 
 

--- a/src/core/apxnorm.ml
+++ b/src/core/apxnorm.ml
@@ -318,6 +318,8 @@ let rec cnormApxExp cD delta e (cD'', t) = match e with
 
   | Apx.Comp.Hole (loc, name) -> Apx.Comp.Hole (loc, name)
 
+  | Apx.Comp.BoxHole loc -> Apx.Comp.BoxHole loc
+
 and cnormApxExp' cD delta i cDt = match i with
   | Apx.Comp.Var (_, _x) -> i
   | Apx.Comp.DataConst (_, _c) -> i
@@ -774,12 +776,12 @@ let fmvApxHat loc fMVs cD (l_cd1, l_delta, k) phat =
   | _ -> phat
 
 let rec fmvApxExp fMVs cD ((l_cd1, l_delta, k) as d_param) e = match e with
-  | Apx.Comp.Syn (loc, i)       -> Apx.Comp.Syn (loc, fmvApxExp' fMVs cD d_param  i)
-  | Apx.Comp.Fn (loc, f, e)    ->
+  | Apx.Comp.Syn (loc, i) -> Apx.Comp.Syn (loc, fmvApxExp' fMVs cD d_param  i)
+  | Apx.Comp.Fn (loc, f, e) ->
      Apx.Comp.Fn (loc, f, fmvApxExp fMVs cD d_param  e)
-  | Apx.Comp.Fun (loc, fbr)    ->
+  | Apx.Comp.Fun (loc, fbr) ->
      Apx.Comp.Fun (loc, fmvApxFBranches fMVs cD d_param fbr)
-  | Apx.Comp.MLam (loc, u, e)   ->
+  | Apx.Comp.MLam (loc, u, e) ->
      Apx.Comp.MLam (loc, u, fmvApxExp fMVs cD (l_cd1, l_delta, (k+1))  e)
   | Apx.Comp.Pair (loc, e1, e2) ->
      let e1' = fmvApxExp fMVs cD d_param  e1 in
@@ -804,7 +806,10 @@ let rec fmvApxExp fMVs cD ((l_cd1, l_delta, k) as d_param) e = match e with
   | Apx.Comp.Case (loc, prag, i, branch) ->
      Apx.Comp.Case (loc, prag, fmvApxExp' fMVs cD d_param  i,
                     fmvApxBranches fMVs cD d_param  branch)
+
   | Apx.Comp.Hole (loc, name) -> Apx.Comp.Hole (loc, name)
+
+  | Apx.Comp.BoxHole loc -> Apx.Comp.BoxHole loc
 
 and fmvApxExp' fMVs cD ((l_cd1, l_delta, k) as d_param)  i = match i with
   | Apx.Comp.Var (_, _x) -> i

--- a/src/core/index.ml
+++ b/src/core/index.ml
@@ -1269,6 +1269,8 @@ let rec index_exp cvars vars fcvars = function
 
   | Ext.Comp.Hole (loc, name) -> Apx.Comp.Hole (loc, name)
 
+  | Ext.Comp.BoxHole loc -> Apx.Comp.BoxHole loc
+
 and index_exp' cvars vars fcvars =
   function
   | Ext.Comp.Name (loc, x) ->

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2380,6 +2380,7 @@ and cmp_exp_chk' =
             Comp.Pair (Loc.join l1 l2, e1, e2))
       in
       let hole = hole |> span $> fun (loc, h) -> Comp.Hole (loc, h) in
+      let box_hole = token T.UNDERSCORE |> span $> fun (loc, _) -> Comp.BoxHole loc in
       let meta_obj =
         meta_obj
         |> span
@@ -2394,6 +2395,7 @@ and cmp_exp_chk' =
           ; impossible (* empty case expression *)
           ; nested (* an expression nested in parens or a tuple *)
           ; hole
+          ; box_hole
           ; meta_obj
           ; lets (* let expressions: true let and pattern let *)
           ]

--- a/src/core/prettyext.ml
+++ b/src/core/prettyext.ml
@@ -713,6 +713,8 @@ module Make (R : Store.Cid.RENDERER) : Printer.Ext.T = struct
 
     | Comp.Hole (_) -> fprintf ppf " ? "
 
+    | Comp.BoxHole _ -> fprintf ppf " _ "
+
     | Comp.Impossible (_, i) ->
       fprintf ppf "%s %a"
         (to_html "impossible" Keyword)

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -682,7 +682,7 @@ let rec elCompTyp cD tau = match tau with
       let cS' = elMetaSpine loc cD cS (tK, C.m_id) in
         Int.Comp.TypBase (loc, a ,cS')
 
-| Apx.Comp.TypCobase (loc, a, cS) ->
+  | Apx.Comp.TypCobase (loc, a, cS) ->
       let _ = dprint (fun () -> "[elCompCotyp] Cobase : " ^ R.render_cid_comp_cotyp a) in
       let tK = (CompCotyp.get a).CompCotyp.Entry.kind in
       dprintf
@@ -1029,12 +1029,12 @@ and elExpW cD cG e theta_tau = match (e, theta_tau) with
         Int.Comp.Let (loc, i', (x,  e'))
 
 
-  | (Apx.Comp.Box (loc, cM), (Int.Comp.TypBox (_loc, cT), theta)) ->
+  | (Apx.Comp.Box (loc, cM), (Int.Comp.TypBox (_, cT), theta)) ->
      let cM = elMetaObj cD cM (cT, theta) in
      let cU = Whnf.cnormMTyp (cT, theta) in
      Int.Comp.Box (loc, cM, cU)
 
-  | Apx.Comp.Impossible (loc, i), (tau, theta) ->
+  | (Apx.Comp.Impossible (loc, i), (tau, theta)) ->
      let i', ttau' = elExp' cD cG i in
      let _, (i', _) =
        Check.Comp.genMApp loc F.(not ++ Int.LF.is_explicit) cD (i', ttau')
@@ -1085,15 +1085,33 @@ and elExpW cD cG e theta_tau = match (e, theta_tau) with
      let name = HoleId.name_of_option name in
      Int.Comp.Hole (loc, id, name)
 
+  | (Apx.Comp.BoxHole loc, (Int.Comp.TypBox (_, cT), theta)) ->
+     let cM =
+       ( Loc.ghost
+       , Apx.Comp.ClObj
+           ( Apx.LF.CtxHole
+           , Apx.LF.Dot
+               ( Apx.LF.Obj (Apx.LF.Root (Loc.ghost, Apx.LF.Hole, Apx.LF.Nil))
+               , Apx.LF.EmptySub
+               )
+           )
+       )
+     in
+     let cM = elMetaObj cD cM (cT, theta) in
+     let cU = Whnf.cnormMTyp (cT, theta) in
+     Int.Comp.Box (loc, cM, cU)
+
   (* TODO postpone to reconstruction *)
   (* Error handling cases *)
-  | (Apx.Comp.Fn (loc, _x, _e),  tau_theta ) ->
+  | (Apx.Comp.Fn (loc, _, _),  tau_theta ) ->
       raise (Check.Comp.Error (loc, Check.Comp.BasicMismatch (`fn, cD, cG, tau_theta)))
-  | (Apx.Comp.MLam (loc, _u, _e), tau_theta) ->
+  | (Apx.Comp.MLam (loc, _, _), tau_theta) ->
       raise (Check.Comp.Error (loc, Check.Comp.BasicMismatch (`mlam, cD, cG, tau_theta)))
-  | (Apx.Comp.Pair(loc, _ , _ ), tau_theta) ->
+  | (Apx.Comp.Pair(loc, _, _), tau_theta) ->
       raise (Check.Comp.Error (loc, Check.Comp.BasicMismatch (`pair, cD, cG, tau_theta)))
-  | (Apx.Comp.Box (loc, _ ) , tau_theta) ->
+  | (Apx.Comp.Box (loc, _), tau_theta) ->
+      raise (Check.Comp.Error (loc, Check.Comp.BasicMismatch (`box, cD, cG, tau_theta)))
+  | (Apx.Comp.BoxHole loc, tau_theta) ->
       raise (Check.Comp.Error (loc, Check.Comp.BasicMismatch (`box, cD, cG, tau_theta)))
 
 and elExp' cD cG i =
@@ -1189,8 +1207,8 @@ and elExp' cD cG i =
          k
          P.(fmt_ppr_cmp_exp_syn cD cG l0) i'
        end;
-     begin match e , tau_theta' with
-     | e , (Int.Comp.TypArr (loc', tau2, tau), theta) ->
+     begin match e, tau_theta' with
+     | e, (Int.Comp.TypArr (loc', tau2, tau), theta) ->
         dprintf
           begin fun p ->
           p.fmt "[elExp'] @[<v>i' = @[%a@]@,inferred type: @[%a@]@,\
@@ -1227,15 +1245,41 @@ and elExp' cD cG i =
             MetaObj are off *)
         (i'', (tau', Whnf.m_id))
 
-     | Apx.Comp.Box (_,mC) , (Int.Comp.TypPiBox (_, Int.LF.Decl(_,ctyp,_), tau), theta) ->
-        dprintf begin fun p ->
+     | Apx.Comp.Box (_, cM), (Int.Comp.TypPiBox (_, Int.LF.Decl (_, ctyp, _), tau), theta) ->
+        dprintf
+          begin fun p ->
           p.fmt "[elExp'] @[<v>Apply -> elMetaObj at type\
                  @,@[%a@]@]"
             P.(fmt_ppr_cmp_meta_typ cD) (Whnf.cnormMTyp (ctyp, theta))
           end;
-        let cM = elMetaObj cD mC (ctyp, theta) in
+        let cM = elMetaObj cD cM (ctyp, theta) in
         ( Int.Comp.MApp (loc, i', cM, Whnf.cnormMTyp (ctyp, theta), `explicit)
-        , (tau, Int.LF.MDot (metaObjToFt cM, theta)))
+        , (tau, Int.LF.MDot (metaObjToFt cM, theta))
+        )
+
+     | Apx.Comp.BoxHole _, (Int.Comp.TypPiBox (_, Int.LF.Decl (_, ctyp, _), tau), theta) ->
+        dprintf
+          begin fun p ->
+          p.fmt "[elExp'] @[<v>Apply -> elMetaObj at type\
+                 @,@[%a@]@]"
+            P.(fmt_ppr_cmp_meta_typ cD) (Whnf.cnormMTyp (ctyp, theta))
+          end;
+        let cM =
+          ( Loc.ghost
+          , Apx.Comp.ClObj
+              ( Apx.LF.CtxHole
+              , Apx.LF.Dot
+                  ( Apx.LF.Obj (Apx.LF.Root (Loc.ghost, Apx.LF.Hole, Apx.LF.Nil))
+                  , Apx.LF.EmptySub
+                  )
+              )
+          )
+        in
+        let cM = elMetaObj cD cM (ctyp, theta) in
+        ( Int.Comp.MApp (loc, i', cM, Whnf.cnormMTyp (ctyp, theta), `explicit)
+        , (tau, Int.LF.MDot (metaObjToFt cM, theta))
+        )
+
      | _ ->
         raise
           ( Check.Comp.Error

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -114,7 +114,7 @@ let fmt_ppr_leftover_vars ppf : leftover_vars -> unit =
 let ppr_leftover_vars = fmt_ppr_leftover_vars Format.std_formatter
 
 let rec get_target_cid_comptyp tau = match tau with
-  | Int.Comp.TypBase (_, a, _ ) -> a
+  | Int.Comp.TypBase (_, a, _) -> a
   | Int.Comp.TypArr (_, _, tau) -> get_target_cid_comptyp tau
   | Int.Comp.TypPiBox (_, _, tau) -> get_target_cid_comptyp tau
   | _ ->
@@ -122,8 +122,8 @@ let rec get_target_cid_comptyp tau = match tau with
        "[get_target_cid_comptyp] no target comp typ"
 
 let rec get_target_cid_compcotyp tau = match tau with
-  | Int.Comp.TypCobase (_, a, _ ) -> a
-  | Int.Comp.TypArr (_, tau , _) ->
+  | Int.Comp.TypCobase (_, a, _) -> a
+  | Int.Comp.TypArr (_, tau, _) ->
      get_target_cid_compcotyp tau
      (* XXX it's strange that this walks backwards, but is called "get *target*".
         Perhaps for codatatypes this should be "source" ? -je *)
@@ -133,15 +133,18 @@ let rec get_target_cid_compcotyp tau = match tau with
        "[get_target_cid_compcotyp] no target comp cotyp"
 
 let freeze_from_name tau = match tau with
-  |Ext.Sgn.Typ ( _, n, _) ->  let a = Typ.index_of_name n in
-                               Typ.freeze a;
-                               ()
-  |Ext.Sgn.CompTyp (_, n, _, _) -> let a =   CompTyp.index_of_name n in
-                               CompTyp.freeze a;
-                               ()
-   |Ext.Sgn.CompCotyp (_, n, _) -> let a =   CompCotyp.index_of_name n in
-                               CompCotyp.freeze a;
-                                ()
+  | Ext.Sgn.Typ (_, n, _) ->
+     let a = Typ.index_of_name n in
+     Typ.freeze a;
+     ()
+  | Ext.Sgn.CompTyp (_, n, _, _) ->
+     let a = CompTyp.index_of_name n in
+     CompTyp.freeze a;
+     ()
+  | Ext.Sgn.CompCotyp (_, n, _) ->
+     let a = CompCotyp.index_of_name n in
+     CompCotyp.freeze a;
+     ()
 
 let sgnDeclToHtml = function
   | Ext.Sgn.Comment (_, x) -> Html.appendAsComment x

--- a/src/core/synapx.ml
+++ b/src/core/synapx.ml
@@ -150,6 +150,7 @@ module Comp = struct
      | Case   of Loc.t * case_pragma * exp_syn * branch list    (* case i of bs *)
      | Impossible of Loc.t * exp_syn                            (* impossible i *)
      | Hole   of Loc.t * string option                          (* ?name *)
+     | BoxHole of Loc.t                                         (* _ *)
 
   and exp_syn =
      | Var    of Loc.t * offset                                     (* x              *)

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -157,18 +157,19 @@ module Comp = struct
    | TypPiBox of Loc.t * LF.ctyp_decl * typ           (*    | Pi u::U.tau        *)
    | TypInd of typ
 
- and exp_chk =                                 (* Computation-level expressions *)
-   | Syn        of Loc.t * exp_syn                           (*  e ::= i                 *)
-   | Fn         of Loc.t * name * exp_chk                    (*    | fn x => e           *)
-   | Fun        of Loc.t * fun_branches                      (*    | fun fbranches       *)
-   | MLam       of Loc.t * name * exp_chk                    (*    | mlam f => e         *)
-   | Pair       of Loc.t * exp_chk * exp_chk                 (*    | (e1 , e2)           *)
-   | LetPair    of Loc.t * exp_syn * (name * name * exp_chk) (*    | let (x,y) = i in e  *)
-   | Let        of Loc.t * exp_syn * (name * exp_chk)        (*    | let x = i in e      *)
-   | Box        of Loc.t * meta_obj                          (*    | [C]                 *)
-   | Impossible of Loc.t * exp_syn                           (*    | impossible i        *)
-   | Case       of Loc.t * case_pragma * exp_syn * branch list  (*    | case i of branches *)
-   | Hole       of Loc.t * string option     				         (*    | ?name               *)
+ and exp_chk =                                                 (* Computation-level expressions *)
+   | Syn        of Loc.t * exp_syn                             (*  e ::= i                      *)
+   | Fn         of Loc.t * name * exp_chk                      (*    | fn x => e                *)
+   | Fun        of Loc.t * fun_branches                        (*    | fun fbranches            *)
+   | MLam       of Loc.t * name * exp_chk                      (*    | mlam f => e              *)
+   | Pair       of Loc.t * exp_chk * exp_chk                   (*    | (e1 , e2)                *)
+   | LetPair    of Loc.t * exp_syn * (name * name * exp_chk)   (*    | let (x,y) = i in e       *)
+   | Let        of Loc.t * exp_syn * (name * exp_chk)          (*    | let x = i in e           *)
+   | Box        of Loc.t * meta_obj                            (*    | [C]                      *)
+   | Impossible of Loc.t * exp_syn                             (*    | impossible i             *)
+   | Case       of Loc.t * case_pragma * exp_syn * branch list (*    | case i of branches       *)
+   | Hole       of Loc.t * string option                       (*    | ?name                    *)
+   | BoxHole    of Loc.t                                       (*    | _                        *)
 
  and exp_syn =
    | Name   of Loc.t * name                        (*  i ::= x/c               *)
@@ -212,7 +213,7 @@ module Comp = struct
  type total_dec =
    | NumericTotal of Loc.t * numeric_order option
    | NamedTotal of Loc.t * named_order option * name * name option list
-	 | Trust of Loc.t
+     | Trust of Loc.t
 
  type ctyp_decl =
    | CTypDecl of name * typ

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -81,7 +81,7 @@ module LF = struct
     | Shift of offset                         (* sigma ::= ^(psi,n)             *)
     | SVar  of offset * int * sub (* BEWARE: offset and int are both ints,
                                      and in the opposite order compared to FSVar and MSVar.
-				     offset is the index into Delta and describes the SVar.
+                                     offset is the index into Delta and describes the SVar.
                                      This is a pain to fix *)
     | FSVar of offset * fvarsub               (*   | s[sigma]                   *)
     | Dot   of front * sub                    (*   | Ft . s                     *)


### PR DESCRIPTION
Resolves #200.

Note: This does not replace the followings:
1. Type argument
2. Let pattern (or any other patterns? I didn't test them, but I think they won't work too)
3. `[_]` used for context