### PR TITLE
Use a generative functor for `HoleId` module

### DIFF
--- a/src/core/holeId.ml
+++ b/src/core/holeId.ml
@@ -1,10 +1,8 @@
-open Support.Module
-
 type t = int
 
 let of_int x = x
 
-module Make (_ : UNIT) = struct
+module Make () = struct
   let counter = ref 0
   let next () =
     let x = !counter in

--- a/src/core/holeId.mli
+++ b/src/core/holeId.mli
@@ -1,5 +1,3 @@
-open Support.Module
-
 type name =
   | Anonymous
   | Named of string
@@ -15,7 +13,7 @@ val string_of_hole_id : t -> string
     private integer reference, that can be made inaccessible outside
     of holes.ml
  *)
-module Make (_ : UNIT) : sig
+module Make () : sig
   (** Generates the next hole ID. *)
   val next : unit -> t
 end

--- a/src/core/holes.ml
+++ b/src/core/holes.ml
@@ -251,7 +251,7 @@ let unsafe_parse_lookup_strategy loc (s : string) : lookup_strategy =
 
 (* instantiate a counter for hole IDs;
    this module is kept private to Holes *)
-module ID = HoleId.Make (Module.Unit)
+module ID = HoleId.Make ()
 
 let allocate () = ID.next ()
 let assign id h =

--- a/src/support/module.ml
+++ b/src/support/module.ml
@@ -1,5 +1,0 @@
-(** The empty module. This is the module-level equivalent of unit. *)
-module type UNIT = sig end
-
-(** The canonical UNIT module. *)
-module Unit : UNIT = struct end


### PR DESCRIPTION
A `UNIT` module was introduced to effectively have a no argument functor for the `HoleId` module.
This is no longer required with the introduction of [generative functors](https://ocaml.org/manual/generativefunctors.html) since OCaml 4.02.