### PR TITLE
semi-automated proof search loop for Beluga 

### DIFF
--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -6,10 +6,9 @@ LF nat : type =
 ;
 
 
-
 % Even/Odd Properties of nat
 
-LF even : nat → type =
+LF even : nat → type = 
   | even_z : even z
   | even_ss : even N → even (S (S N))
 ;
@@ -37,7 +36,7 @@ inductive Od : [⊢ nat] → ctype =
 
 
 
-% New object- num, and its' properties
+% New object- num, and its properties
 
 LF num : nat → type =
    | num_z : num z
@@ -62,7 +61,7 @@ rec again_all_num : {N : [⊢ nat]} {M : [⊢ nat]} [⊢ num M] → [⊢ num N] 
 mlam n,m ⇒ fn U ⇒ all_num [⊢ n]
 ;
 
-
+rec numThenEven : {N : [⊢ nat]} [⊢ num N] → [⊢ even z] = mlam N ⇒ fn n ⇒ [⊢ even_z];
 
 % ctx schema declaration.
 
@@ -70,7 +69,7 @@ schema ctx = nat;
 
 
 
-% nat addition operation, and its' properties 
+% nat addition operation, and its properties 
 
 plus : nat -> nat -> nat -> type.
 p_z : {N: nat} plus z N N.
@@ -249,12 +248,15 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 						
 	    
 }%
+%{
 
 % Box
 
 % B1
---mquery 1 * * [⊢ even z].
+--mquery 2 * * [⊢ even z].
 % [ |- even_z]
+% numThenEven [ |- z] [ |- num_z]
+
 
 % B2
 --mquery 1 * * [⊢ plus z z z].
@@ -271,13 +273,11 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % two_ctx []
 % two_imp_ctx
 
-
 % B5
 --mquery 3 * 1 [D:nat ⊢ plus (S z) (S z) (S (S z))].
 % [D : nat |- p_s (p_z S z)]
 % two_ctx [D : nat]
 % two_imp_ctx
-
 
 % B6
 --mquery 5 * 1  [⊢ num (S (S (S z)))].
@@ -285,8 +285,11 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % all_num [ |- S (S (S z))]
 % all_all_num [ |- S (S (S z))] [ |- num_s (num_s (num_s num_z))]
 % all_all_num [ |- S (S (S z))] (all_num [ |- S (S (S z))])
-%No solution found: Maximum depth reached! -- Current Depth 2 , Maximum Depth allowed 1 
+% No solution found: Maximum depth reached! -- Current Depth 2 , Maximum Depth allowed 1 
 
+% B7
+--mquery 1 * * [⊢ even (S (S (S (S z))))].
+% [ |-even_ss (even_ss even_z)]
 
 
 % Atomic
@@ -300,9 +303,13 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * LE [⊢ z] [⊢ z].
 % zLE
 
+}%
+
 % A3
 --mquery 1 * * lessEq [⊢ S (S (S z))] [⊢ S (S z)] [⊢ S (S z)].
 % sle (sle lez)
+
+%{
 
 % A4 
 --mquery 1 * * Ev [⊢ S (S (S (S z)))].
@@ -312,6 +319,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 2 * * lessEq [⊢ S z] [⊢ S (S z)] [⊢ S z].
 % les (zle)
 % oneLEtwo
+
 
 % A6
 --mquery 1 * * Le [⊢ z] [⊢ S (S z)].
@@ -348,24 +356,21 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam D => [ |- p_z D]
 
 % F6
---mquery 4 * * {E: [⊢ even z]} [⊢ even z] → [⊢ even z].
+--mquery 3 * * {E: [⊢ even z]} [⊢ even z] → [⊢ even z].
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- X]
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- E]
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- even_z]
-% mlam E => fn z6 => let [ |- X7] = z6 in z6
 
 
 
 % F7
---mquery 5 * * {N : [⊢ nat]} [⊢ num N] → [⊢ num N].
-% mlam N => fn z6 => let [ |- X] = y7 in [ |- X] 
-% mlam N => fn z6 => let [ |- X] = z6 in z6
+--mquery 4 * * {N : [⊢ nat]} [⊢ num N] → [⊢ num N].
+% mlam N => fn z6 => let [ |- X] = z6 in [ |- X] 
 % mlam N => fn z6 => let [ |- X] = z6 in all_num [ |- N]
 % mlam N => fn z6 => let [ |- X] = z6 in
 %    all_all_num [ |- N] [⊢ X]
 % mlam N => fn z6 => let [ |- X] = z6 in
 %    all_all_num [ |- N] (all_num [ |- N])
-
 
 
 % F8
@@ -382,6 +387,20 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % Query error: Wrong number of solutions -- expected 1 in * tries, but found 0
 
 
+% F11
+--mquery 1 * * [⊢ even (S z)] → [⊢ even (S (S (S z)))].
+% fn x8 => let [ |- Y32] = x8 in [ |- even_ss Y32]
+
+
+
+--mquery 1 * * [⊢ num N].
+
+
+}%
+
+--mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ num M] → [⊢ even M]) → [⊢ even (S (S N))].
+
+% --query 2 2 D : even N. 
 
 
 %%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%
@@ -404,3 +423,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 
 % -mctx match, dctx match, get answer from multiple sources, size of ctx, number of subgoals of focused clause
 % note any ctx match means ctx1 = ctx2 or ctx1 < ctx2 or ctx2 < ctx1 or ctx1 n ctx2 =\= {} or ctx1 n ctx2 = {}, 5 cases!!!
+
+
+

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -279,9 +279,8 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % B1
 --mquery 3 * 1 [⊢ even z].
 % [ |- even_z]
-% will find if numTheEven commented out- nummThenEven (mlam N => [ |- all N])
-% ERROR: cannot find numThenEven [ |- z] [ |- num_z]
-
+% numThenEven [ |- z] [ |- num_z]
+% numThenEven [ |- S z] [ |- num_s num_z]
 
 % B2
 --mquery 1 * * [⊢ plus z z z].
@@ -303,7 +302,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % [D : nat |- p_s (p_z S z)]
 % two_ctx [D : nat]
 % two_imp_ctx
-
 
 % B6
 --mquery 5 * 1  [⊢ num (S (S (S z)))].
@@ -329,13 +327,9 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * LE [⊢ z] [⊢ z].
 % zLE
 
-
-
 % A3
 --mquery 1 * * lessEq [⊢ S (S (S z))] [⊢ S (S z)] [⊢ S (S z)].
 % sle (sle lez)
-
-
 
 % A4
 --mquery 1 * * Ev [⊢ S (S (S (S z)))].
@@ -345,7 +339,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 2 * * lessEq [⊢ S z] [⊢ S (S z)] [⊢ S z].
 % les (zle)
 % oneLEtwo
-
 
 % A6
 --mquery 1 * * Le [⊢ z] [⊢ S (S z)].
@@ -369,7 +362,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * {N : [⊢ nat]} {E: [⊢ even N]} [⊢ even z].
 % mlam N => mlam E => [ |- even_z]
 
-
 % F4
 --mquery 4 * * {N : [⊢ nat]} [⊢ num N].
 % mlam N => all_num [ |- N]
@@ -377,7 +369,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam N => all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N]))
 % mlam N => all_all_num [ |- N]
 %    (all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N])))
-
 
 % F5
 --mquery 1 * * {D : [⊢ nat]} [⊢ plus z D D].
@@ -389,7 +380,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- E]
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- even_z]
 
-
 % F7
 --mquery 4 * * {N : [⊢ nat]} [⊢ num N] → [⊢ num N].
 % mlam N => fn z6 => let [ |- X] = z6 in [ |- X]
@@ -399,52 +389,36 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam N => fn z6 => let [ |- X] = z6 in
 %    all_all_num [ |- N] (all_num [ |- N])
 
-
 % F8
 --mquery 2 * * {M : [⊢ nat]} {N : [⊢ nat]} [⊢ num N].
 % mlam M => mlam N => all_num [ |- N]
 % mlam M => mlam N => all_all_num [ |- N] (all_num [ |- N])
-
 
 % F9
 --mquery 1 * * {N : [⊢ nat]} [⊢ even N] → [⊢ num N] → [⊢ even (S (S N))].
 % mlam N => fn z7 => fn x7 =>
 %   let [ |- X28] = x7 in let [ |- Z28] = z7 in [ |- even_ss Z28]
 
-
 % F10
 --mquery 1 * * {N : [⊢ nat]} ([⊢ num N] → [⊢ even N]) → [⊢ even (S (S N))].
 % Query error: Wrong number of solutions -- expected 1 in * tries, but found 0
-
 
 % F11
 --mquery 1 * * [⊢ even (S z)] → [⊢ even (S (S (S z)))].
 % fn x8 => let [ |- Y32] = x8 in [ |- even_ss Y32]
 
-
-
-
-
 --mquery 1 * * [N:nat ⊢ numm N].
 % [N : nat |- all N]
 
-
-
 --mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ numm M] → [⊢ even M]) → [⊢ even (S (S N))].
-% ERROR
-
-
+%  mlam N => fn y9 => y9 [ |- S (S N)] [ |- all S (S N)]
 
 --mquery 2 * 1 [ |- numm (S (S (S z)))].
 % [ |- all S (S (S z))]
 % all_all_numm [ |- S (S (S z))] [ |- all S (S (S z))]
 
-
-
 --mquery 1 * * {N : [⊢ nat]} lessEq [⊢ S (S (S N))] [⊢ S (S z)] [⊢ S (S z)].
-% ERROR
-
-
+% mlam N => sle (sle lez)
 
 --mquery 3 * * Ev [⊢ N].
 % ZEv

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -61,7 +61,30 @@ rec again_all_num : {N : [⊢ nat]} {M : [⊢ nat]} [⊢ num M] → [⊢ num N] 
 mlam n,m ⇒ fn U ⇒ all_num [⊢ n]
 ;
 
+
 rec numThenEven : {N : [⊢ nat]} [⊢ num N] → [⊢ even z] = mlam N ⇒ fn n ⇒ [⊢ even_z];
+
+LF numm : nat → type =
+  | all : {N : nat} numm N
+;
+
+rec all_all_numm : {N : [ ⊢ nat]} [⊢ numm N] → [⊢ numm N] =
+/ total m (all_all_numm n m) /
+mlam n ⇒ fn m ⇒ m
+;
+
+rec nummThenEven : ({N : [⊢ nat]} [⊢ numm N]) → [⊢ even z] = fn n ⇒ [⊢ even_z];
+
+% rec test_num: {M: [⊢ nat]} {Q: [⊢ nat]} {N: [⊢ nat]} [⊢ num N] =
+% / total n (test_num n) /
+% mlam M,Q,N ⇒ case [⊢ N] of
+%  | [⊢ z] ⇒ [⊢ num_z]
+%  | [⊢ S M] ⇒ let [⊢ num_m ] = all_num [⊢ M] in
+%	      [⊢ num_s num_m]
+%;
+% In mquery F8, can't find instantiations for M and Q, but they
+% are unused so unnecessary
+
 
 % ctx schema declaration.
 
@@ -249,12 +272,15 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 
 }%
 
+
 % Box
 
+
 % B1
---mquery 2 * * [⊢ even z].
+--mquery 3 * 1 [⊢ even z].
 % [ |- even_z]
-% numThenEven [ |- z] [ |- num_z]
+% will find if numTheEven commented out- nummThenEven (mlam N => [ |- all N])
+% ERROR: cannot find numThenEven [ |- z] [ |- num_z]
 
 
 % B2
@@ -277,6 +303,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % [D : nat |- p_s (p_z S z)]
 % two_ctx [D : nat]
 % two_imp_ctx
+
 
 % B6
 --mquery 5 * 1  [⊢ num (S (S (S z)))].
@@ -302,9 +329,13 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * LE [⊢ z] [⊢ z].
 % zLE
 
+
+
 % A3
 --mquery 1 * * lessEq [⊢ S (S (S z))] [⊢ S (S z)] [⊢ S (S z)].
 % sle (sle lez)
+
+
 
 % A4
 --mquery 1 * * Ev [⊢ S (S (S (S z)))].
@@ -338,6 +369,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * {N : [⊢ nat]} {E: [⊢ even N]} [⊢ even z].
 % mlam N => mlam E => [ |- even_z]
 
+
 % F4
 --mquery 4 * * {N : [⊢ nat]} [⊢ num N].
 % mlam N => all_num [ |- N]
@@ -345,6 +377,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam N => all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N]))
 % mlam N => all_all_num [ |- N]
 %    (all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N])))
+
 
 % F5
 --mquery 1 * * {D : [⊢ nat]} [⊢ plus z D D].
@@ -355,7 +388,6 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- X]
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- E]
 % mlam E => fn x2 => let [ |- X] = x2 in [ |- even_z]
-
 
 
 % F7
@@ -369,13 +401,16 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 
 
 % F8
---mquery 1 * * {M : [⊢ nat]} {N : [⊢ nat]} [⊢ num N].
+--mquery 2 * * {M : [⊢ nat]} {N : [⊢ nat]} [⊢ num N].
 % mlam M => mlam N => all_num [ |- N]
+% mlam M => mlam N => all_all_num [ |- N] (all_num [ |- N])
+
 
 % F9
 --mquery 1 * * {N : [⊢ nat]} [⊢ even N] → [⊢ num N] → [⊢ even (S (S N))].
 % mlam N => fn z7 => fn x7 =>
 %   let [ |- X28] = x7 in let [ |- Z28] = z7 in [ |- even_ss Z28]
+
 
 % F10
 --mquery 1 * * {N : [⊢ nat]} ([⊢ num N] → [⊢ even N]) → [⊢ even (S (S N))].
@@ -386,11 +421,37 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * [⊢ even (S z)] → [⊢ even (S (S (S z)))].
 % fn x8 => let [ |- Y32] = x8 in [ |- even_ss Y32]
 
---mquery 1 * * [⊢ num N].
 
---mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ num M] → [⊢ even M]) → [⊢ even (S (S N))].
 
-% --query 2 2 D : even N.
+
+
+--mquery 1 * * [N:nat ⊢ numm N].
+% [N : nat |- all N]
+
+
+
+--mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ numm M] → [⊢ even M]) → [⊢ even (S (S N))].
+% ERROR
+
+
+
+--mquery 2 * 1 [ |- numm (S (S (S z)))].
+% [ |- all S (S (S z))]
+% all_all_numm [ |- S (S (S z))] [ |- all S (S (S z))]
+
+
+
+--mquery 1 * * {N : [⊢ nat]} lessEq [⊢ S (S (S N))] [⊢ S (S z)] [⊢ S (S z)].
+% ERROR
+
+--mquery 3 * * Ev [⊢ N].
+% ZEv
+% ERROR
+
+--mquery 3 * * [⊢ even N].
+% [ |- even_z]
+% [ |- even_ss even_z]
+% [ |- even_ss (even_ss even_z)]
 
 
 %%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -444,14 +444,19 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * {N : [⊢ nat]} lessEq [⊢ S (S (S N))] [⊢ S (S z)] [⊢ S (S z)].
 % ERROR
 
+
+
 --mquery 3 * * Ev [⊢ N].
 % ZEv
-% ERROR
+% SEv ZEv
+% SEv (SEv ZEv)
 
 --mquery 3 * * [⊢ even N].
 % [ |- even_z]
 % [ |- even_ss even_z]
 % [ |- even_ss (even_ss even_z)]
+
+
 
 
 %%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -82,9 +82,6 @@ rec nummThenEven : ({N : [⊢ nat]} [⊢ numm N]) → [⊢ even z] = fn n ⇒ [�
 %  | [⊢ S M] ⇒ let [⊢ num_m ] = all_num [⊢ M] in
 %	      [⊢ num_s num_m]
 %;
-% In mquery F8, can't find instantiations for M and Q, but they
-% are unused so unnecessary
-
 
 % ctx schema declaration.
 
@@ -315,6 +312,21 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * [⊢ even (S (S (S (S z))))].
 % [ |-even_ss (even_ss even_z)]
 
+% B8
+--mquery 1 * * [N:nat ⊢ numm N].
+% [N : nat |- all N]
+
+% B9
+--mquery 2 * 1 [ |- numm (S (S (S z)))].
+% [ |- all S (S (S z))]
+% all_all_numm [ |- S (S (S z))] [ |- all S (S (S z))]
+
+% B10
+--mquery 3 * * [⊢ even N].
+% [ |- even_z]
+% [ |- even_ss even_z]
+% [ |- even_ss (even_ss even_z)]
+
 
 % Atomic
 
@@ -343,11 +355,19 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % A6
 --mquery 1 * * Le [⊢ z] [⊢ S (S z)].
 % SLe (zLE)
-%
+
+% A7
+--mquery 3 * * Ev [⊢ N].
+% ZEv
+% SEv ZEv
+% SEv (SEv ZEv)
+
+% A8
+--mquery 1 * * lessEq [⊢ S (S (S N))] [⊢ S (S z)] [⊢ S (S z)].
+% sle (sle lez)
 
 
-
-% Forall
+% Forall + implication
 
 % F1
 --mquery 1 * * {N: [⊢ nat]} {N2: [⊢ nat]} {N3: [⊢ nat]} [⊢ even z].
@@ -407,52 +427,14 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * [⊢ even (S z)] → [⊢ even (S (S (S z)))].
 % fn x8 => let [ |- Y32] = x8 in [ |- even_ss Y32]
 
---mquery 1 * * [N:nat ⊢ numm N].
-% [N : nat |- all N]
-
+% F12
 --mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ numm M] → [⊢ even M]) → [⊢ even (S (S N))].
 %  mlam N => fn y9 => y9 [ |- S (S N)] [ |- all S (S N)]
 
---mquery 2 * 1 [ |- numm (S (S (S z)))].
-% [ |- all S (S (S z))]
-% all_all_numm [ |- S (S (S z))] [ |- all S (S (S z))]
-
+% F13
 --mquery 1 * * {N : [⊢ nat]} lessEq [⊢ S (S (S N))] [⊢ S (S z)] [⊢ S (S z)].
 % mlam N => sle (sle lez)
 
---mquery 3 * * Ev [⊢ N].
-% ZEv
-% SEv ZEv
-% SEv (SEv ZEv)
-
---mquery 3 * * [⊢ even N].
-% [ |- even_z]
-% [ |- even_ss even_z]
-% [ |- even_ss (even_ss even_z)]
-
-
-
-
-%%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%
-%-------------------|------|----------------------
-%  Sig              |      |
-%  ctx match        |      |
-%-------------------|------|----------------------
-%  ctx do not match |      |
-%-------------------|------|-----------------------
-%  Gamma            |      |
-%  ctx match        |      |
-%-------------------|------|-----------------------------
-%  ctx do not match |      |
-%-------------------|------|-------------------------------------
-%  Theorems         |      |
-%  cM               |      |
-%  cDNM             |      |
-
-
-
-% -mctx match, dctx match, get answer from multiple sources, size of ctx, number of subgoals of focused clause
-% note any ctx match means ctx1 = ctx2 or ctx1 < ctx2 or ctx2 < ctx1 or ctx1 n ctx2 =\= {} or ctx1 n ctx2 = {}, 5 cases!!!
 
 
 

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -1,0 +1,406 @@
+% Object- nat
+
+LF nat : type =
+  | z : nat
+  | S : nat → nat
+;
+
+
+
+% Even/Odd Properties of nat
+
+LF even : nat → type =
+  | even_z : even z
+  | even_ss : even N → even (S (S N))
+;
+
+LF ev : nat → type =
+  | e_z : ev z
+  | e_s : odd N → ev (S N)
+and odd : nat → type =
+  | o_sz : odd (S z)
+  | o_s : ev N → odd (S N)
+;
+
+inductive Ev : [⊢ nat] → ctype =
+  | ZEv : Ev [⊢ z]
+  | SEv : Ev [⊢ N] → Ev [⊢ S (S N)]
+;
+
+rec ev_two : Ev [⊢ S (S z)] =
+SEv ZEv;
+
+inductive Od : [⊢ nat] → ctype =
+  | SZOd : Od [⊢ S z]
+  | SOd :  Od [⊢ N] → Od [⊢ S (S N)]
+;
+
+
+
+% New object- num, and its' properties
+
+LF num : nat → type =
+   | num_z : num z
+   | num_s : num N → num (S N)
+;
+
+rec all_num : {N : [⊢ nat]} [⊢ num N] =
+/ total n (all_num n) /
+mlam N ⇒ case [⊢ N] of
+  | [⊢ z] ⇒ [⊢ num_z]
+  | [⊢ S M] ⇒ let [⊢ num_m ] = all_num [⊢ M] in
+	      [⊢ num_s num_m]
+;
+
+rec all_all_num : {N : [ ⊢ nat]} [⊢ num N] → [⊢ num N] =
+/ total m (all_all_num n m) /
+mlam n ⇒ fn m ⇒ m
+; 
+
+rec again_all_num : {N : [⊢ nat]} {M : [⊢ nat]} [⊢ num M] → [⊢ num N] =
+/ total n (again_all_num n m u) /
+mlam n,m ⇒ fn U ⇒ all_num [⊢ n]
+;
+
+
+
+% ctx schema declaration.
+
+schema ctx = nat;
+
+
+
+% nat addition operation, and its' properties 
+
+plus : nat -> nat -> nat -> type.
+p_z : {N: nat} plus z N N.
+p_s : plus N M K -> plus (S N) M (S K).
+
+rec two : [⊢ plus (S z) (S z) (S (S z))] =
+[⊢ p_s (p_z (S z))];
+
+rec two_ctx : {g:ctx} [g ⊢ plus (S z) (S z) (S (S z))] =
+/ total g (two_ctx g) /
+mlam g ⇒
+    [g ⊢ p_s (p_z (S z))];
+
+rec two_imp_ctx : (g:ctx) [g ⊢ plus (S z) (S z) (S (S z))] =
+[_ ⊢ p_s (p_z (S z))];
+
+
+rec plusz_sym : {N : [⊢ nat]} [⊢ plus z N N] → [⊢ plus N z N] =
+/ total n (plusz_sym n p) /
+mlam N ⇒ fn p ⇒ case [⊢ N] of
+  | [⊢ z] ⇒ p
+  | [⊢ S M] ⇒ let [⊢ p_zM] = plusz_sym [⊢ M][⊢ p_z M] in 
+	      [⊢ p_s p_zM]
+;
+
+rec plusz2_sym : {N : [⊢ nat]} [⊢ plus N z N] → [⊢ plus z N N] =
+/ total n (plusz2_sym n p) /
+mlam N ⇒ fn p ⇒ [⊢ p_z N]
+;
+
+
+
+% Ordering of nat.
+
+inductive Le : [⊢ nat] → [⊢ nat] → ctype =
+  | zLe : Le [⊢ z] [⊢ S z]
+  | SLe : LE [⊢ N] [⊢ M] → Le [⊢ N] [⊢ S M]
+
+and inductive LE : {M : [⊢ nat]} {N : [⊢ nat]} ctype =
+  | zLE : LE [⊢ z] [⊢ N]
+  | SLE : Le [⊢ N] [⊢ M] → LE [⊢ S N] [⊢ M]
+;
+
+inductive lessEq : [⊢ nat] → [⊢ nat] → [⊢ nat] → ctype =
+  | zle : lessEq [⊢ z] [⊢ N] [⊢ z]
+  | lez : lessEq [⊢ N] [⊢ z] [⊢ z]
+  | sle : lessEq [⊢ N] [⊢ M] [⊢ M] → lessEq [⊢ S N] [⊢ S M] [⊢ S M]
+  | les : lessEq [⊢ N] [⊢ M] [⊢ N] → lessEq [⊢ S N] [⊢ S M] [⊢ S N]
+;
+
+rec oneLEtwo : lessEq [⊢ S z] [⊢ S (S z)] [⊢ S z] =
+les zle;
+
+%{
+
+rec trans1Le : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ N1] [⊢ S N2] =
+/ total a (trans1Le n m a) /
+mlam N1, N2 ⇒ fn a ⇒ case [⊢ N1] of
+  | [⊢ z] ⇒ SLe zLE 
+  | [⊢ S N] ⇒ let SLe lENM = a in
+	      let SLE lenm = lENM in
+	      let d = trans1Le [⊢ N] [⊢ _] lenm in
+	      SLe (SLE d)
+;
+
+rec trans2Le : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ S N1] [⊢ S N2] =
+/ total a (trans2Le n m a) /
+mlam N1, N2 ⇒ fn a ⇒ SLe (SLE a)	       
+;
+
+
+rec transLe : {N1 : [⊢ nat]} {N2 : [⊢ nat]} {N3 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ N2] [⊢ N3] → Le [⊢ N1] [⊢ N3] =
+/ total a (transLe n m q a b) /
+mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
+  | zLe ⇒ let SLe lenm = b in
+	   let SLE lemc = lenm in
+	   trans1Le [⊢ N1] [⊢ _] lemc
+  | SLe lENM ⇒ (case [⊢ N1] of
+		 | [⊢ z] ⇒ let SLe lEMP = b in
+			     SLe zLE
+		 | [⊢ S N] ⇒
+		       let SLE lenm = lENM in
+	               let SLe lEMP = b in
+	               let SLE lemp = lEMP in
+	               let d = transLe [⊢ _] [⊢ _] [⊢ _] lenm lemp in
+	               trans2Le [⊢ _] [⊢ _] d)  
+;
+
+rec sLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} LE [⊢ N1] [⊢ N2] → LE [⊢ S N1] [⊢ S N2] = / total a (sLE n m a) /
+mlam N1, N2 ⇒ fn a ⇒ SLE (SLe a)
+;
+
+rec leLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → LE [⊢ N1] [⊢ N2] = / total a (leLE n m a) /
+mlam N1, N2 ⇒ fn a ⇒ case a of
+  | zLe ⇒ zLE
+  | SLe lENM ⇒ (case [⊢ N1] of
+		 | [⊢ z] ⇒ zLE
+		 | [⊢ S N] ⇒ let SLE lenm = lENM in
+			       let d = leLE [⊢ _] [⊢ _] lenm in 
+                               sLE [⊢ _] [⊢ _] d)
+;
+
+rec lemma2 : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ N1] [⊢ S N2] =
+/ total a (lemma2 n m a) /
+mlam N1, N2 ⇒ fn a ⇒ case a of
+  | zLe ⇒ SLe zLE
+  | SLe lENM ⇒ (case [⊢ N1] of
+		 | [⊢ z] ⇒ SLe zLE 
+		 | [⊢ S N] ⇒ let SLE lenm = lENM in
+			       let d = lemma2 [⊢ _] [⊢ _] lenm in 
+                               trans2Le [⊢ _] [⊢ _] d)
+;
+
+rec lemma3 : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ z] [⊢ N1] → LE [⊢ N1] [⊢ N2] → Le [⊢ z] [⊢ N2] =
+/ total a (lemma3 n m a b) /
+mlam N1, N2 ⇒ fn a, b ⇒ case a of
+  | zLe ⇒ let SLE lenm = b in
+	  (case lenm of
+	    | zLe ⇒ SLe zLE
+	    | SLe leNM ⇒ SLe zLE)
+  | SLe lENM ⇒ let SLE lenm = b in
+	       (case lenm of
+	    | zLe ⇒ SLe zLE
+	    | SLe leNM ⇒ SLe zLE)
+;
+
+
+rec lemma1 : {N1 : [⊢ nat]} {N2 : [⊢ nat]} {N3 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → LE [⊢ N2] [⊢ N3] → Le [⊢ N1] [⊢ N3] =
+/ total a (lemma1 n m p a b) /
+mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
+  | zLe ⇒ let SLE lenm = b in
+	  lenm
+  | SLe lENM ⇒ (case [⊢ N1] of
+		 | [⊢ z] ⇒ lemma3 [⊢ _] [⊢ _] a b
+		 | [⊢ S N] ⇒ let SLE lenm = b in
+	                     let SLE leab = lENM in
+			     (case leab of
+			       | zLe ⇒ ?
+			       | SLe lEAB ⇒
+			     let d = lemma1 [⊢ _] [⊢ _] [⊢ _] leab lEAB in
+			     trans2Le [⊢ _] [⊢ _] d))
+			     
+; 
+
+
+rec transLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} {N3 : [⊢ nat]} LE [⊢ N1] [⊢ N2] → LE [⊢ N2] [⊢ N3] → LE [⊢ N1] [⊢ N3] =
+/ total n (transLE n m q a b) /
+mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
+  | zLE ⇒ zLE
+  | SLE lenm ⇒ let lEBC = leLE [⊢ _] [⊢ _] lenm in
+	        let d = transle [⊢ _] [⊢ _] [⊢ _] 
+	        
+;
+}%
+
+%{
+rec plus_sym : {N : [⊢ nat]} {M : [⊢ nat]} [⊢ plus N M K] →
+	       [⊢ plus M N K] =
+/ total n (plus_sym n m p) /
+mlam N,M ⇒ fn p ⇒ case [⊢ N] of
+  | [⊢ z] ⇒ [⊢ plusz_sym M p]
+  | [⊢ S L] ⇒ let [⊢ p_s O] = p in
+	      plus_sym _ _ (
+;
+
+
+rec ev_sym : {N : [⊢ nat]} {P : [⊢ plus z N K]} Ev [⊢ K] → Ev [⊢ N] =
+/ total p (ev_sym n p e) /
+mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
+  | ZEv ⇒ let p_z = P in
+	   e
+  | SEv e' ⇒ e
+;  
+
+	        
+						
+	    
+}%
+
+% Box
+
+% B1
+--mquery 1 * * [⊢ even z].
+% [ |- even_z]
+
+% B2
+--mquery 1 * * [⊢ plus z z z].
+% [ |- p_z z]
+
+% B3
+--mquery 1 * * [M:nat, D:nat, Q:nat  ⊢ plus z D D].
+% [M : nat, D : nat, Q : nat |- p_z D]
+
+% B4
+--mquery 4 * 1 [⊢ plus (S z) (S z) (S (S z))].
+% [ |- p_s (p_z S z)]
+% two
+% two_ctx []
+% two_imp_ctx
+
+
+% B5
+--mquery 3 * 1 [D:nat ⊢ plus (S z) (S z) (S (S z))].
+% [D : nat |- p_s (p_z S z)]
+% two_ctx [D : nat]
+% two_imp_ctx
+
+
+% B6
+--mquery 5 * 1  [⊢ num (S (S (S z)))].
+% [ |- num_s (num_s (num_s num_z))]
+% all_num [ |- S (S (S z))]
+% all_all_num [ |- S (S (S z))] [ |- num_s (num_s (num_s num_z))]
+% all_all_num [ |- S (S (S z))] (all_num [ |- S (S (S z))])
+%No solution found: Maximum depth reached! -- Current Depth 2 , Maximum Depth allowed 1 
+
+
+
+% Atomic
+
+% A1
+--mquery 2 * * Ev [⊢ S (S z)].
+% SEv ZEv
+% ev_two
+
+% A2
+--mquery 1 * * LE [⊢ z] [⊢ z].
+% zLE
+
+% A3
+--mquery 1 * * lessEq [⊢ S (S (S z))] [⊢ S (S z)] [⊢ S (S z)].
+% sle (sle lez)
+
+% A4 
+--mquery 1 * * Ev [⊢ S (S (S (S z)))].
+% SEv (SEv ZEv)
+
+% A5
+--mquery 2 * * lessEq [⊢ S z] [⊢ S (S z)] [⊢ S z].
+% les (zle)
+% oneLEtwo
+
+% A6
+--mquery 1 * * Le [⊢ z] [⊢ S (S z)].
+% SLe (zLE)
+% 
+
+
+
+% Forall
+
+% F1
+--mquery 1 * * {N: [⊢ nat]} {N2: [⊢ nat]} {N3: [⊢ nat]} [⊢ even z].
+%  mlam N => mlam N2 => mlam N3 => [ |- even_z]
+
+% F2
+--mquery 2 * * {E: [⊢ even z]} [⊢ even z].
+%  mlam E => [ |- E]
+%  mlam E => [ |- even_z]
+
+% F3
+--mquery 1 * * {N : [⊢ nat]} {E: [⊢ even N]} [⊢ even z].
+% mlam N => mlam E => [ |- even_z]
+
+% F4
+--mquery 4 * * {N : [⊢ nat]} [⊢ num N].
+% mlam N => all_num [ |- N]
+% mlam N => all_all_num [ |- N] (all_num [ |- N])
+% mlam N => all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N]))
+% mlam N => all_all_num [ |- N]
+%    (all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N])))
+
+% F5
+--mquery 1 * * {D : [⊢ nat]} [⊢ plus z D D].  
+% mlam D => [ |- p_z D]
+
+% F6
+--mquery 4 * * {E: [⊢ even z]} [⊢ even z] → [⊢ even z].
+% mlam E => fn x2 => let [ |- X] = x2 in [ |- X]
+% mlam E => fn x2 => let [ |- X] = x2 in [ |- E]
+% mlam E => fn x2 => let [ |- X] = x2 in [ |- even_z]
+% mlam E => fn z6 => let [ |- X7] = z6 in z6
+
+
+
+% F7
+--mquery 5 * * {N : [⊢ nat]} [⊢ num N] → [⊢ num N].
+% mlam N => fn z6 => let [ |- X] = y7 in [ |- X] 
+% mlam N => fn z6 => let [ |- X] = z6 in z6
+% mlam N => fn z6 => let [ |- X] = z6 in all_num [ |- N]
+% mlam N => fn z6 => let [ |- X] = z6 in
+%    all_all_num [ |- N] [⊢ X]
+% mlam N => fn z6 => let [ |- X] = z6 in
+%    all_all_num [ |- N] (all_num [ |- N])
+
+
+
+% F8
+--mquery 1 * * {M : [⊢ nat]} {N : [⊢ nat]} [⊢ num N].
+% mlam M => mlam N => all_num [ |- N]
+
+% F9
+--mquery 1 * * {N : [⊢ nat]} [⊢ even N] → [⊢ num N] → [⊢ even (S (S N))].
+% mlam N => fn z7 => fn x7 =>
+%   let [ |- X28] = x7 in let [ |- Z28] = z7 in [ |- even_ss Z28]
+
+% F10
+--mquery 1 * * {N : [⊢ nat]} ([⊢ num N] → [⊢ even N]) → [⊢ even (S (S N))].
+% Query error: Wrong number of solutions -- expected 1 in * tries, but found 0
+
+
+
+
+%%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%
+%-------------------|------|----------------------
+%  Sig              |      |
+%  ctx match        |      |
+%-------------------|------|----------------------
+%  ctx do not match |      |
+%-------------------|------|-----------------------
+%  Gamma            |      |
+%  ctx match        |      |
+%-------------------|------|-----------------------------
+%  ctx do not match |      |
+%-------------------|------|-------------------------------------
+%  Theorems         |      |
+%  cM               |      |
+%  cDNM             |      |
+
+
+
+% -mctx match, dctx match, get answer from multiple sources, size of ctx, number of subgoals of focused clause
+% note any ctx match means ctx1 = ctx2 or ctx1 < ctx2 or ctx2 < ctx1 or ctx1 n ctx2 =\= {} or ctx1 n ctx2 = {}, 5 cases!!!

--- a/examples/aps/numbers.bel
+++ b/examples/aps/numbers.bel
@@ -8,7 +8,7 @@ LF nat : type =
 
 % Even/Odd Properties of nat
 
-LF even : nat → type = 
+LF even : nat → type =
   | even_z : even z
   | even_ss : even N → even (S (S N))
 ;
@@ -54,7 +54,7 @@ mlam N ⇒ case [⊢ N] of
 rec all_all_num : {N : [ ⊢ nat]} [⊢ num N] → [⊢ num N] =
 / total m (all_all_num n m) /
 mlam n ⇒ fn m ⇒ m
-; 
+;
 
 rec again_all_num : {N : [⊢ nat]} {M : [⊢ nat]} [⊢ num M] → [⊢ num N] =
 / total n (again_all_num n m u) /
@@ -69,7 +69,7 @@ schema ctx = nat;
 
 
 
-% nat addition operation, and its properties 
+% nat addition operation, and its properties
 
 plus : nat -> nat -> nat -> type.
 p_z : {N: nat} plus z N N.
@@ -91,7 +91,7 @@ rec plusz_sym : {N : [⊢ nat]} [⊢ plus z N N] → [⊢ plus N z N] =
 / total n (plusz_sym n p) /
 mlam N ⇒ fn p ⇒ case [⊢ N] of
   | [⊢ z] ⇒ p
-  | [⊢ S M] ⇒ let [⊢ p_zM] = plusz_sym [⊢ M][⊢ p_z M] in 
+  | [⊢ S M] ⇒ let [⊢ p_zM] = plusz_sym [⊢ M][⊢ p_z M] in
 	      [⊢ p_s p_zM]
 ;
 
@@ -128,7 +128,7 @@ les zle;
 rec trans1Le : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ N1] [⊢ S N2] =
 / total a (trans1Le n m a) /
 mlam N1, N2 ⇒ fn a ⇒ case [⊢ N1] of
-  | [⊢ z] ⇒ SLe zLE 
+  | [⊢ z] ⇒ SLe zLE
   | [⊢ S N] ⇒ let SLe lENM = a in
 	      let SLE lenm = lENM in
 	      let d = trans1Le [⊢ N] [⊢ _] lenm in
@@ -137,7 +137,7 @@ mlam N1, N2 ⇒ fn a ⇒ case [⊢ N1] of
 
 rec trans2Le : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ S N1] [⊢ S N2] =
 / total a (trans2Le n m a) /
-mlam N1, N2 ⇒ fn a ⇒ SLe (SLE a)	       
+mlam N1, N2 ⇒ fn a ⇒ SLe (SLE a)
 ;
 
 
@@ -155,7 +155,7 @@ mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
 	               let SLe lEMP = b in
 	               let SLE lemp = lEMP in
 	               let d = transLe [⊢ _] [⊢ _] [⊢ _] lenm lemp in
-	               trans2Le [⊢ _] [⊢ _] d)  
+	               trans2Le [⊢ _] [⊢ _] d)
 ;
 
 rec sLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} LE [⊢ N1] [⊢ N2] → LE [⊢ S N1] [⊢ S N2] = / total a (sLE n m a) /
@@ -168,7 +168,7 @@ mlam N1, N2 ⇒ fn a ⇒ case a of
   | SLe lENM ⇒ (case [⊢ N1] of
 		 | [⊢ z] ⇒ zLE
 		 | [⊢ S N] ⇒ let SLE lenm = lENM in
-			       let d = leLE [⊢ _] [⊢ _] lenm in 
+			       let d = leLE [⊢ _] [⊢ _] lenm in
                                sLE [⊢ _] [⊢ _] d)
 ;
 
@@ -177,9 +177,9 @@ rec lemma2 : {N1 : [⊢ nat]} {N2 : [⊢ nat]} Le [⊢ N1] [⊢ N2] → Le [⊢ 
 mlam N1, N2 ⇒ fn a ⇒ case a of
   | zLe ⇒ SLe zLE
   | SLe lENM ⇒ (case [⊢ N1] of
-		 | [⊢ z] ⇒ SLe zLE 
+		 | [⊢ z] ⇒ SLe zLE
 		 | [⊢ S N] ⇒ let SLE lenm = lENM in
-			       let d = lemma2 [⊢ _] [⊢ _] lenm in 
+			       let d = lemma2 [⊢ _] [⊢ _] lenm in
                                trans2Le [⊢ _] [⊢ _] d)
 ;
 
@@ -211,8 +211,8 @@ mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
 			       | SLe lEAB ⇒
 			     let d = lemma1 [⊢ _] [⊢ _] [⊢ _] leab lEAB in
 			     trans2Le [⊢ _] [⊢ _] d))
-			     
-; 
+
+;
 
 
 rec transLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} {N3 : [⊢ nat]} LE [⊢ N1] [⊢ N2] → LE [⊢ N2] [⊢ N3] → LE [⊢ N1] [⊢ N3] =
@@ -220,8 +220,8 @@ rec transLE : {N1 : [⊢ nat]} {N2 : [⊢ nat]} {N3 : [⊢ nat]} LE [⊢ N1] [�
 mlam N1, N2, N3 ⇒ fn a,b ⇒ case a of
   | zLE ⇒ zLE
   | SLE lenm ⇒ let lEBC = leLE [⊢ _] [⊢ _] lenm in
-	        let d = transle [⊢ _] [⊢ _] [⊢ _] 
-	        
+	        let d = transle [⊢ _] [⊢ _] [⊢ _]
+
 ;
 }%
 
@@ -242,13 +242,12 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
   | ZEv ⇒ let p_z = P in
 	   e
   | SEv e' ⇒ e
-;  
+;
 
-	        
-						
-	    
+
+
+
 }%
-%{
 
 % Box
 
@@ -285,7 +284,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % all_num [ |- S (S (S z))]
 % all_all_num [ |- S (S (S z))] [ |- num_s (num_s (num_s num_z))]
 % all_all_num [ |- S (S (S z))] (all_num [ |- S (S (S z))])
-% No solution found: Maximum depth reached! -- Current Depth 2 , Maximum Depth allowed 1 
+% No solution found: Maximum depth reached! -- Current Depth 2 , Maximum Depth allowed 1
 
 % B7
 --mquery 1 * * [⊢ even (S (S (S (S z))))].
@@ -303,15 +302,11 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * LE [⊢ z] [⊢ z].
 % zLE
 
-}%
-
 % A3
 --mquery 1 * * lessEq [⊢ S (S (S z))] [⊢ S (S z)] [⊢ S (S z)].
 % sle (sle lez)
 
-%{
-
-% A4 
+% A4
 --mquery 1 * * Ev [⊢ S (S (S (S z)))].
 % SEv (SEv ZEv)
 
@@ -324,7 +319,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 % A6
 --mquery 1 * * Le [⊢ z] [⊢ S (S z)].
 % SLe (zLE)
-% 
+%
 
 
 
@@ -352,7 +347,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 %    (all_all_num [ |- N] (all_all_num [ |- N] (all_num [ |- N])))
 
 % F5
---mquery 1 * * {D : [⊢ nat]} [⊢ plus z D D].  
+--mquery 1 * * {D : [⊢ nat]} [⊢ plus z D D].
 % mlam D => [ |- p_z D]
 
 % F6
@@ -365,7 +360,7 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 
 % F7
 --mquery 4 * * {N : [⊢ nat]} [⊢ num N] → [⊢ num N].
-% mlam N => fn z6 => let [ |- X] = z6 in [ |- X] 
+% mlam N => fn z6 => let [ |- X] = z6 in [ |- X]
 % mlam N => fn z6 => let [ |- X] = z6 in all_num [ |- N]
 % mlam N => fn z6 => let [ |- X] = z6 in
 %    all_all_num [ |- N] [⊢ X]
@@ -391,16 +386,11 @@ mlam N ⇒ mlam P ⇒ fn e ⇒ case e of
 --mquery 1 * * [⊢ even (S z)] → [⊢ even (S (S (S z)))].
 % fn x8 => let [ |- Y32] = x8 in [ |- even_ss Y32]
 
-
-
 --mquery 1 * * [⊢ num N].
-
-
-}%
 
 --mquery 1 * * {N : [⊢ nat]} ({M:[⊢ nat]} [⊢ num M] → [⊢ even M]) → [⊢ even (S (S N))].
 
-% --query 2 2 D : even N. 
+% --query 2 2 D : even N.
 
 
 %%%%%%%%            | Base | Box | PiBox | Implies |%%%%%%%%

--- a/examples/aps/tasks.txt
+++ b/examples/aps/tasks.txt
@@ -1,10 +1,3 @@
-- Extend solve to bounded depth-first search
-
-- Similar to solve, design solve for inductive types
-  --> Extend the data type for comp_goals and add data type for computation-level clauses  
-  --> Compile computation-level types into computation goals and clauses
-  --> Do proof search over the computation goals and clauses
-
 - Build a bridge between Harpoon and msolve(logic.ml).
   Note: * Harpoon will have a meta-context cD and a computation-level type T (typically Box or Inductive) it tries to prove
         * msolve and sgnMQuery work on the computation-level type Pibox cD . T
@@ -16,4 +9,15 @@
       to obtain cD together with a computation-level type T (typically Box or Inductive)
  
 
+- Introduce automated split in proof-loop
+  --> add in another argument to mquery in which the user will specify the var. to split on
+  --> generate induction hyp. if there is one (try to use the split tactic from Harpoon)
 
+
+- Introduce a 'blurring' phase in the loop
+  --> this will involve focusing on assumptions in which the heads don't unify with the goal
+  --> once we have focused on the head of such an assumption, we add that atomic type to either cD or cG (depending on the type) and continue again with focusing
+                              L
+                 cD ; cG, R' ===> R
+	      ----------------------- blur
+		 cD ; cG > R' ===> R

--- a/examples/aps/tc_1.bel
+++ b/examples/aps/tc_1.bel
@@ -67,7 +67,7 @@ r_reach: reach B C -> edge A B -> reach A C.
 %       in this example our 1. subgoal will be edge A B and our 2. subgoal reach B C.
 %       This is important, when we use depth first search
 
---mquery 1 * * [ |- reach a d].
+--mquery 2 * * [ |- reach a d].
 % succeeds, finding the first solution, but in fact there are 2 expected solutions.
 
 --mquery 2 * * [ |- reach a d].

--- a/examples/aps/tc_1.bel
+++ b/examples/aps/tc_1.bel
@@ -14,10 +14,11 @@ le : nat -> nat -> type.
 le_z : le zero N.
 le_s : le N M -> le (succ N) (succ M).
 
+--mquery 1 * 4 {N: [⊢ nat]} {D: [⊢ even N]} [⊢ odd (succ N)].
 
 --mquery 1 * 4 [ |- even (succ (succ zero))].
 
-%% --mquery 0 * 2 [ |- even (succ (succ (succ zero)))].
+--mquery 1 * 2 [ |- even (succ (succ (succ zero)))].
 --mquery 1 * * [ |- odd (succ (succ (succ zero)))].
 
 --mquery 1 * 7 [ |- le (succ (succ zero)) (succ (succ (succ (succ zero))))].
@@ -42,12 +43,10 @@ rec odd_even : [ ⊢ odd N] → [ ⊢ even (succ N)] = fn d ⇒ case d of
 
 
 
-% 
-% --mquery  1 * * {g:ctx}{N:[g |- nat]}{D : [g |- even N]} [g |- even (succ (succ N))].
-%   ERROR: does not produce any solution but should produce as an answer [g |- ev_s D]
 %
-% --mquery  1 * * {g:ctx}{N:[ |- nat]} {D : [g |- even N[]]} [g |- even (succ (succ N[]))].
-%   ERROR: does not produce a solution, but should produce as an answer [g |- ev_s D]
+--mquery  1 * * {g:ctx}{N:[g |- nat]}{D : [g |- even N]} [g |- even (succ (succ N))].
+
+--mquery  1 * * {g:ctx}{N:[ |- nat]} {D : [g |- even N[]]} [g |- even (succ (succ N[]))].
 
 node:type.
 a:node.

--- a/examples/aps/tc_1.bel
+++ b/examples/aps/tc_1.bel
@@ -30,7 +30,7 @@ le_s : le N M -> le (succ N) (succ M).
 --mquery 1 * * {N1:[ ⊢ nat]}{D : [ ⊢ odd N1]} {F:[ ⊢ even (succ N1)]}
 	   [ |- even (succ (succ (succ N1)))].
 
-% --mquery 2 2 D :  even (succ N)
+--mquery 2 2 * [⊢ even (succ N)].
 
 --mquery 1 * 3 {N: [ |- nat]}{D: [|- even N]} [|- even (succ (succ zero))].
 
@@ -92,9 +92,3 @@ rec size : [ ⊢ tree] → [ ⊢ nat] = fn t ⇒ case t of
 			  let [ ⊢ N2] = size [ ⊢ R] in
 			  plus ? (plus [ ⊢ N1] ?)
 ;
-
-
-% Bi-directional typing
-% -- checking an expression against a type (\x.M, [ ⊢ ....],  )
-% -- synthesizing a type for an expression 
-% 

--- a/examples/aps/tc_1.bel
+++ b/examples/aps/tc_1.bel
@@ -25,7 +25,7 @@ le_s : le N M -> le (succ N) (succ M).
 
 --mquery 1 * 2 {N:[ |- nat]}{D:[ |- even N]} [ |- even (succ (succ N))].
 
---mquery 0 * 5 {N:[ |- nat]}[ |- even (succ (succ N))].
+--mquery 0 * 1 {N:[ |- nat]}[ |- even (succ (succ N))].
 
 --mquery 1 * * {N1:[ ⊢ nat]}{D : [ ⊢ odd N1]} {F:[ ⊢ even (succ N1)]}
 	   [ |- even (succ (succ (succ N1)))].

--- a/examples/aps/tc_2.bel
+++ b/examples/aps/tc_2.bel
@@ -7,6 +7,6 @@ inductive Even : [ |- nat] -> ctype =
 | Ev_z : Even [ |- z]
 | Ev_ss: Even [ |- N] -> Even [ |- succ (succ N)]	;
 
-% 
-% --mquery 1 *  Even [ |- succ (succ z)].
+
+ --mquery 1 *  * Even [ |- succ (succ z)].
 

--- a/examples/mini-ml/tps-log-prog.bel
+++ b/examples/mini-ml/tps-log-prog.bel
@@ -185,7 +185,7 @@ od_sz: odd (suc z).
 od_s : odd N -> odd (suc (suc N)).
 
 --query 2 2 D : even (suc N).             % does the exist a solution for D and N st. D : [even (suc N)] 
---mquery 1 *  [ |- even (suc (suc z))].    
+--mquery 1 *  * [ |- even (suc (suc z))].    
 
 
 

--- a/src/core/abstract.ml
+++ b/src/core/abstract.ml
@@ -354,7 +354,7 @@ let rec mctxToCtx =
   | I.Dec (cQ', I.Decl (x, I.CTyp (Some w), dep)) ->
      I.Dec (mctxToCtx cQ', CtxV (x, w, dep))
   | I.Dec (cQ', I.Decl (n, ityp, dep)) ->
-     I.Dec (mctxToCtx cQ', FDecl (FV n, Pure (MetaTyp (ityp, dep))))   
+     I.Dec (mctxToCtx cQ', FDecl (FV n, Pure (MetaTyp (ityp, dep))))
 
 let rec ctxToMCtx_pattern names =
   function
@@ -1596,7 +1596,7 @@ let abstrCompTypcD cD tau =
   let l' = lengthCollection cQ in
   let p = prefixCompTyp tau' in (* p = number of explicitely declared mvars *)
   (* extend cQ with any variables found in tau' *)
-  let (cQ, tau1) = collectCompTyp (l' + p) cQ tau' in 
+  let (cQ, tau1) = collectCompTyp (l' + p) cQ tau' in
   let k = lengthCollection cQ in
   let l = (k - l') in
   (* l: count of variables *excluding* leading context variables *)
@@ -1604,14 +1604,14 @@ let abstrCompTypcD cD tau =
   (* let cQ' = abstractMVarCtx cQ (l-1) in *)
   let tau' = abstractMVarCompTyp cQ' (l, 0) tau1 in
   let cD' = ctxToMCtx (fun _ -> I.Maybe) cQ' in
-  
+
   let tau'' = raiseCompTyp cD' tau' in
   (* We can't just subtract l' because l' counts also implicit context quantifications.
      Instead we drop all explicit context contexts from cD' and then
      take the length in order to get the correct count of implicit
      parameters. *)
   (tau'', Context.length (dropExplicitCTyp cD'))
- 
+
 
 let abstrCodataTyp cD tau tau' =
   let rec split =

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -482,8 +482,6 @@ module Convert = struct
        let dctx_hat = Context.dctxToHat cPsi in
        let plicity = get_plicity dep in
        let mfront = LF.ClObj (dctx_hat, LF.MObj tM) in
-       (* let mf = Whnf.cnormMFt mfront ms' in *)
-       (* let ctyp' = Whnf.cnormMTyp (ctyp, ms') in *)
        (LF.MDot (mfront, ms'),
         (fun s ->
           fS' (Comp.MApp (noLoc, s, (noLoc, mfront), ctyp, plicity))))
@@ -496,7 +494,6 @@ module Convert = struct
        let plicity = get_plicity dep in
        let mfront =
          LF.ClObj (dctx_hat, LF.PObj hd) in
-       (* let mf = Whnf.cnormMFt mfront ms' in *)
        (LF.MDot (mfront, ms'),
         (fun s ->
           fS' (Comp.MApp (noLoc, s, (noLoc, mfront), ctyp, plicity))))
@@ -1373,7 +1370,7 @@ module Solver = struct
      * In that case, it will call matchSigma to figure out the
        appropriate projection to use on the variable, if any.
      *)
-     and matchDelta (cD' : LF.mctx) =
+    and matchDelta (cD' : LF.mctx) =
       let rec loop cD' k =
         match cD' with
         | LF.Empty -> matchDProg dPool
@@ -1442,7 +1439,7 @@ module Solver = struct
        I.iterSClauses (fun w -> matchSgnClause w sc) cidTyp
 
     (* matchSgnClause (c, sCl) sc = ()
-       Try to unify the LF type of sCl with A[s]. If unification succeeds,
+       Try to unify the head of sCl with A[s]. If unification succeeds,
        attempt to solve the subgoals of sCl.
      *)
     and matchSgnClause (cidTerm, sCl) sc =
@@ -1475,7 +1472,7 @@ module Solver = struct
 
     in
     (* ^ end of the gigantic let of all the helpers for matchAtom;
-         Now here's the actual body of matchAtom: *)
+      Now here's the actual body of matchAtom: *)
     matchDelta cD
 
   (* spineFromRevList : LF.normal list -> LF.spine
@@ -1687,7 +1684,7 @@ module CSolver = struct
        let hd' = Whnf.cnormCTyp (hd, ms) in
        let sg' = normSubGoals (sg, ms) cD in
        Full (cPool'', ({cHead = hd'; cMVars = mV; cSubGoals = sg'}, _k, _s))
-   
+
    (*
   (* mctx -> ctyp_decl *)
   let least_cases cD =
@@ -1729,8 +1726,8 @@ module CSolver = struct
       | LF.MDot (mf, ms') -> rev ms' (LF.MDot (mf, ms_ret))
     in
     rev ms (LF.MShift k)
-    
-    
+
+
   let rec cgSolve' (cD: LF.mctx) (cG: Comp.gctx) (cPool: cPool)
             (mq:mquery) (sc: Comp.exp_chk -> unit) (currDepth: bound) (maxDepth: bound) =
 
@@ -1824,9 +1821,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
-        (* printf "solve gamma SG \n";
+        (*printf "solve gamma SG \n";
         let cg = normCompGoal (cg', ms) in
-        Printer.printState cD cG cg ms; *)
+        Printer.printState cD cG cg ms;*)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveSubGoals cD cG cPool (sg', k) ms mV
@@ -1844,9 +1841,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
-       (* printf "solve sig SG \n";
+       (*printf "solve sig SG \n";
        let cg = normCompGoal (cg', ms) in
-       Printer.printState cD cG cg ms; *)
+       Printer.printState cD cG cg ms;*)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveCClauseSubGoals cD cG cPool cid sg' ms mV
@@ -1863,9 +1860,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
-       (* printf "solve thm SG \n";
+       (*printf "solve thm SG \n";
        let cg = normCompGoal (cg',ms) in
-       Printer.printState cD cG cg ms; *)
+       Printer.printState cD cG cg ms;*)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveTheoremSubGoals cD cG cPool cid sg' ms mV
@@ -1882,11 +1879,6 @@ module CSolver = struct
       then
         (let (ms', fS) = C.mctxToMSub cD (sCCl.cMVars, LF.MShift 0) (fun s -> s) in
          let ms'' = rev_ms ms' (Context.length (sCCl.cMVars)) in
-        (* printf "focus Thm NEW MS \n";
-         Printer.printState cD cG cg ms';
-         let ms''' = Whnf.cnormMSub ms' in
-         printf "focus Thm normedd MS \n";
-         Printer.printState cD cG cg ms'''; *)
          let tau = if isBox cg then C.boxToTypBox cg else C.atomicToBase cg in
         (try
            Solver.trail
@@ -2031,10 +2023,9 @@ module CSolver = struct
           *)
 
   and focus cD cG cPool cg ms sc currDepth maxDepth =
-   (*  printf "FOCUS \n";
-    (* let ms = Whnf.cnormMSub ms in
-    let cg' = normCompGoal (cg, ms) in *)
-    Printer.printState cD cG cg' ms; *)
+    (*printf "FOCUS \n";
+    let cg' = normCompGoal (cg, ms) in
+    Printer.printState cD cG cg' ms;*)
     match cg with
     | Box (cPsi, g, Some M) ->
        (* If our goal is of box type, we first try to find the
@@ -2238,7 +2229,7 @@ module CSolver = struct
 
      (* First we break our goal down into an atomic one *)
   and uniform_right cD cG cPool cg ms sc currDepth maxDepth =
-    (* printf "UNIFORM RIGHT \n";
+    (*printf "UNIFORM RIGHT \n";
     Printer.printState cD cG cg ms;*)
     match cg with
     | Box (_) | Atomic (_) ->

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -1672,12 +1672,12 @@ module CSolver = struct
        let aS' = normAtomicSpine ms aS in
        Atomic (cid, aS')
 
-  let rec normSubGoals ms sg cD =
+  let rec normSubGoals (sg, ms) cD =
     match sg with
     | Proved -> sg
     | Solve (sg', cg) ->
        let cg' = normCompGoal (cg, ms) in
-       Solve (normSubGoals ms sg' cD, cg')
+       Solve (normSubGoals (sg', ms) cD, cg')
 
   let rec cnormCPool (cPool, ms) cD =
     match cPool with
@@ -1685,9 +1685,9 @@ module CSolver = struct
     | Full (cPool', ({cHead = hd; cMVars = mV; cSubGoals = sg}, _k, _s)) ->
        let cPool'' = cnormCPool (cPool', ms) cD in
        let hd' = Whnf.cnormCTyp (hd, ms) in
-       let sg' = normSubGoals ms sg cD in
+       let sg' = normSubGoals (sg, ms) cD in
        Full (cPool'', ({cHead = hd'; cMVars = mV; cSubGoals = sg'}, _k, _s))
-
+   
    (*
   (* mctx -> ctyp_decl *)
   let least_cases cD =
@@ -1821,7 +1821,7 @@ module CSolver = struct
     | Proved ->
        let e' = (Comp.Var (noLoc, k)) in
        let e = fS e' in
-       let e = Whnf.cnormExp' (e,ms) in
+       let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
         (* printf "solve gamma SG \n";
@@ -1841,7 +1841,7 @@ module CSolver = struct
     | Proved ->
        let e' = (Comp.DataConst (noLoc, cid)) in
        let e = fS e' in
-       let e = Whnf.cnormExp' (e,ms) in
+       let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
        (* printf "solve sig SG \n";
@@ -1860,7 +1860,7 @@ module CSolver = struct
     | Proved ->
        let e' = (Comp.Const (noLoc, cid)) in
        let e = fS e' in
-       let e = Whnf.cnormExp' (e,ms) in
+       let e = Whnf.cnormExp' (e, LF.MShift 0) in
        sc e
     | Solve (sg', cg') ->
        (* printf "solve thm SG \n";

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -422,11 +422,11 @@ module Convert = struct
     | [] -> S.id
     | (x, tN) :: xs -> LF.Dot (LF.Obj tN, solToSub xs)
 
-(*  let rec solToMSub xs =
+  let rec solToMSub xs =
     match xs with
     | [] -> LF.MShift 0
     | (x, tN) :: xs ->
-       LF.MDot (tN, solToMSub xs) *)
+       LF.MDot (tN, solToMSub xs) 
 
 (*
   comptypToMQuery (tau,i) = comp_goal  
@@ -1331,8 +1331,22 @@ module CSolver = struct
        List.rev (cg1 :: xs)
     | Box (_) -> []
     | Forall (_) -> [cg]
-      
 
+  (* Convert a (normal) term into an exp_chk for type checking purposes *) 
+  let tmToExCk tM cPsi =
+    match tM with
+    | LF.Lam (loc, name, tM') ->
+       raise NotImplementedYet
+    | LF.Root (loc, hd, spine, pl) ->
+       raise NotImplementedYet
+    | LF.LFHole (loc, t, name) ->
+       raise NotImplementedYet
+    | LF.Clo (tM', s) ->
+       raise NotImplementedYet
+    | LF.Tuple (loc, tuple) ->
+       raise NotImplementedYet
+       
+      
 
   (* Solver function for a goal of computation type *)
   let rec cgSolve (cG : comp_goal list) cD mq sc =
@@ -1374,7 +1388,8 @@ module CSolver = struct
       let hd = getcgHead c_g in 
       match subG with
       | [] ->
-         (match hd with
+         ( (* In this case we are finished; no subgoals remain. *)
+           match hd with
           | Box (cPsi, _) -> 
             (* check that the hd matches the goal in sc func
 
@@ -1386,6 +1401,7 @@ module CSolver = struct
              ())
       | x :: xs ->
          cgSolve cG cD (x, ms) sc
+         (* TODO:: sc function for solveImpSubGoals as in gsolve *)
  (*          (fun cD (cPsi, tM) ->
              solveImpSubGoals c_g xs cD ms
                (fun cD' (v, tS) -> sc cD' (v, tM :: tS))
@@ -1425,11 +1441,7 @@ module CSolver = struct
       
     in
     (*         
-     (* Try to unify the LF type of sCCl with A[s].
-       TODO:: We will probably be checking if all the preConds are met- 
-              therefore allowing us to deduce the conclusion, adding it
-              to dPool??
-     *)                                      
+     (* Try to find solution in the computation signatures. *)                                      
     let matchSgnCClause (cidTerm, sCCl) sc =
       let (s', fS) =
         C.dctxToSub cD cPsi (sCCl.cEVars, shiftSub (Context.dctxLength cPsi))
@@ -1662,21 +1674,23 @@ module Frontend = struct
     | (Box(cPsi, g) , ms) -> *)
 
     (* Type checking function. *)
-(*    let check cD cPsi (e : Comp.exp_chk) ms =
+    let check cD cPsi (e : Comp.exp_chk) ms =
       (* check mcid cD cG (total_decs : total_dec list) ?cIH:(cIH = Syntax.Int.LF.Empty) e ttau  *)
-     let x = name in 
-      let mcid = Store.Comp.index_of_name_opt x in 
-      Check.Comp.check mcid cD LF.Empty [] e (sgnMQuery.skinnyCompTyp, ms)
+      (* Does the term have a cid?? *)
+      Check.Comp.check None cD LF.Empty [] e (sgnMQuery.skinnyCompTyp, ms)
     in
- *) 
+   
     
     let scInit cD (cPsi, tM) =
       incr solutions;
 
        (* Rebuild the substitution and type check the proof term. *)
-(*      if !Options.checkProofs
-      then check cD cPsi tM (Convert.solToMSub sgnMQuery.instMMVars); (* !querySub *)
- *) 
+      if !Options.checkProofs
+      then
+        let e = CSolver.tmToExCk tM cPsi in
+        check cD cPsi e (Convert.solToMSub sgnMQuery.instMMVars);
+    
+ 
           begin
             fprintf std_formatter  "@[<v>---------- Solution %d ----------@,[%a |- %a]@]" 
               (*              "@[<hov 2>@[%a@] |-@ @[%a@]@]" *)

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -686,9 +686,11 @@ module Index = struct
   let iterAllSClauses f =
     Hashtbl.iter (fun k v -> DynArray.iter f v) types
 
+  (* bp : currently unused     
   let iterSCClauses f cidTyp =
     DynArray.iter f (Hashtbl.find compTypes cidTyp)
-
+   *)
+    
   let iterAllSCClauses f =
     Hashtbl.iter (fun k v -> DynArray.iter f v) compTypes
 
@@ -1240,11 +1242,11 @@ module Solver = struct
         U.unifyTyp cD cPsi (tA, s) (sCCl.lfTyp, s');
       with
       | U.Failure _ -> ()
+ *)
     in
- *)    
     (* ^ end of the gigantic let of all the helpers for matchAtom;
          Now here's the actual body of matchAtom: *)
-
+    matchDelta cD
 
   (* spineFromRevList : LF.normal list -> LF.spine
      build an LF.spine out of a list of LF.normal, reversing the order of the elements*)

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -948,7 +948,7 @@ module Printer = struct
     P.fmt_ppr_cmp_gctx cD P.l0 ppf cG 
 
   let fmt_ppr_mctx ppf cD = 
-    P.fmt_ppr_lf_mctx P.l0 ppf cD    *)
+    P.fmt_ppr_lf_mctx P.l0 ppf cD *)   
      
   let fmt_ppr_typ cD cPsi ppf sA =
     P.fmt_ppr_lf_typ cD cPsi P.l0 ppf (Whnf.normTyp sA)
@@ -1853,9 +1853,9 @@ module CSolver = struct
        let e = fS e' in
        sc e
     | Solve (sg', cg) ->
- (*   printf "solve sig SG \n";
+  (*  printf "solve sig SG \n";
     let cg'= normCompGoal ms' cg in 
-    Printer.printState cD cG (cg') ms';  *)
+    Printer.printState cD cG (cg') ms'; *) 
        cgSolve' cD cG cPool (cg, ms')
          (fun e ->
            solveCClauseSubGoals cD cG cPool cid sg' ms ms' mV
@@ -1882,9 +1882,8 @@ module CSolver = struct
          
   (* We focus on one of the computation-type theorems *)
   and focusT cD cG cPool cg ms sc currDepth maxDepth =
-  (*  printf "focus Theorem \n";
-    let cg'= normCompGoal ms cg in 
-    Printer.printState cD cG cg' ms; *) 
+    (*  printf "focus Theorem \n";
+    Printer.printState cD cG cg ms; *) 
     let mS (cid, sCCl) =
       if (* Check to see if the comp goal is the head of the assumption *)
          matchHead cD sCCl.cHead cg;
@@ -1910,12 +1909,11 @@ module CSolver = struct
   (* Focus on the clause in the static Comp signature with head matching
      type constant c. *)
   and focusS cidTyp cD cG cPool cg ms sc currDepth maxDepth =
-  (*  printf "focus Sig \n";
-    let cg'= normCompGoal ms cg in 
-    Printer.printState cD cG cg' ms; *)
+    (*  printf "focus Sig \n"; 
+    Printer.printState cD cG cg ms; *)
     let matchSgnCClause (cidTerm, sCCl) sc =
       let (ms'', fS) = C.mctxToMSub cD (sCCl.cMVars, ms) (fun s -> s) in
-      let tau =  C.atomicToBase cg in
+      let tau = C.atomicToBase cg in
       let ms'= rev_ms ms'' ms (Context.length sCCl.cMVars) in  
       (try
          Solver.trail
@@ -1945,9 +1943,8 @@ module CSolver = struct
 
   (* We focus on one of the computation assumptions in cPool/Gamma *)
   and focusG cD cG cPool cPool_all cg ms sc currDepth maxDepth =
-  (*  printf "focus Gamma \n";
-    let cg'= normCompGoal ms cg in 
-    Printer.printState cD cG cg' ms; *) 
+    (*  printf "focus Gamma \n"; 
+    Printer.printState cD cG cg ms; *)
     match cPool with
     | Emp -> ()
     | Full (cPool', ({cHead = hd; cMVars; cSubGoals = sg}, k', _s)) ->
@@ -1976,45 +1973,42 @@ module CSolver = struct
       
         
   and focus cD cG cPool cg ms sc currDepth maxDepth =
-  (*  printf "FOCUS \n";
-    let cg'= normCompGoal ms cg in 
-    Printer.printState cD cG (cg') ms;  *)
+    (*  printf "FOCUS \n"; *)
+    let cg = normCompGoal ms cg in 
+  (*  Printer.printState cD cG (cg') ms;  *)
     match cg with
     | Box (cPsi, g, Some M) ->
        (* If our goal is of box type, we first try to find the  
           proof term in the LF level, otherwise we focus on 
           an assumption in our computation context cG          *)
-
-       let cg'= normCompGoal ms cg in
-       let Box (_,g',_) = cg' in
-       let Atom tA = g' in
+       let Atom tA = g in
           (* note, we take the goal's type because the main check
              is checking the meta_obj against meta_typ of the goal *)
           let cltyp = LF.MTyp tA in
           let sc' =
-            (fun (cPsi, tM) ->
-              let dctx_hat = Context.dctxToHat cPsi in 
+            (fun (cPsi', tM) ->
+              let dctx_hat = Context.dctxToHat cPsi' in 
               let mfront = LF.ClObj (dctx_hat, LF.MObj tM) in
               let meta_obj = (noLoc, mfront) in
-              let meta_typ = LF.ClTyp (cltyp, cPsi) in
+              let meta_typ = LF.ClTyp (cltyp, cPsi') in
               sc (Comp.Box(noLoc, meta_obj, meta_typ)))
           in
-          Solver.solve cD cPsi (g', S.id) sc';
+          Solver.solve cD cPsi (g, S.id) sc';
           focusG cD cG cPool cPool cg ms sc currDepth maxDepth;
           focusT cD cG cPool cg ms sc currDepth maxDepth; 
-    | Box (_cPsi, _g, Some P) ->
-       let Atom tA = _g in
+    | Box (cPsi, g, Some P) ->
+       let Atom tA = g in
        let cltyp = LF.PTyp tA in
        let sc' =
-         (fun (cPsi, tM) ->
+         (fun (cPsi', tM) ->
            let LF.Root (_,hd,_,_) = tM in
-           let dctx_hat = Context.dctxToHat cPsi in 
+           let dctx_hat = Context.dctxToHat cPsi' in 
            let mfront = LF.ClObj (dctx_hat, LF.PObj hd) in
            let meta_obj = (noLoc, mfront) in
-           let meta_typ = LF.ClTyp (cltyp, cPsi) in
+           let meta_typ = LF.ClTyp (cltyp, cPsi') in
            sc (Comp.Box(noLoc, meta_obj, meta_typ)))
        in
-       Solver.solve cD _cPsi (_g, S.id) sc';
+       Solver.solve cD cPsi (g, S.id) sc';
        focusG cD cG cPool cPool cg ms sc currDepth maxDepth;
        focusT cD cG cPool cg ms sc currDepth maxDepth;
     | Atomic (name, spine) ->
@@ -2130,7 +2124,7 @@ module CSolver = struct
        let cPool'' = cnormCPool (cPool', LF.MShift 1) cD' in
        let cPool_ret' = prependToCPool (boxME cP) cPool_ret in
        let cPool_ret'' = cnormCPool (cPool_ret', LF.MShift 1) cD' in
-       let cg' = normCompGoal (LF.MShift 1) cg in
+       let cg' = normCompGoal (LF.MShift 1) cg in 
        uniform_left cD' cG' cPool'' cPool_ret'' cg' ms' sc' currDepth maxDepth
     | Full (cPool', x) ->
        (* Otherwise we leave the assumption in cG *)

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -1391,12 +1391,12 @@ module CSolver = struct
       | [] ->
          ( (* In this case we are finished; no subgoals remain. *)
            match hd with
-          | Box (cPsi, _) -> 
-            (* check that the hd matches the goal in sc func
-
-              let tm = ? in 
-              sc cD (cPsi, tm) *) 
-             ()
+           | Box (cPsi, g) ->
+              let root x = LF.Root (Syntax.Loc.ghost, x, LF.Nil, `explicit)
+              in
+              let mvar k = LF.MVar (LF.Offset k, LF.Shift 0) in
+              let tm = root (mvar 0) in 
+              sc cD (cPsi, tm)  
           | _ ->
              (* For goals of ind type *)
              ())
@@ -1498,11 +1498,15 @@ module CSolver = struct
        let (cG', cD') = filter_cG cG cD ms in
        (* Finally we try to solve the goal via focusing- 
           either on the LF level or Comp level *)
+  (*     let sc' = (fun (u, tM) -> sc cD' (u, tM)) in *)
        focus cG' cD' cg ms sc
     | Forall (tdecl, cg') ->
        (* In this case we gain an assumption in the meta-context *)
        let cD' = Whnf.extend_mctx cD (tdecl,ms) in
-       cgSolve cG cD' (cg', ms) sc
+       let sc' =
+         (fun d (u, tM) ->
+           sc cD' (u, tM)) in
+       cgSolve cG cD' (cg', ms) sc'
     | Implies (cg1, cg2) ->
        (* We gain a computation assumption *)
        

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -1824,9 +1824,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e,ms) in
        sc e
     | Solve (sg', cg') ->
-       (* printf "solve gamma SG \n"; *)
-       let cg' = normCompGoal (cg', ms) in
-       (* Printer.printState cD cG cg' ms; *)
+        (* printf "solve gamma SG \n";
+        let cg = normCompGoal (cg', ms) in
+        Printer.printState cD cG cg ms; *)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveSubGoals cD cG cPool (sg', k) ms mV
@@ -1844,10 +1844,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e,ms) in
        sc e
     | Solve (sg', cg') ->
-       (* printf "solve sig SG \n"; *)
-      let cg' = normCompGoal (cg', ms) in
-      (* let ms = Whnf.cnormMSub ms in *)
-       (*Printer.printState cD cG (cg') ms;*)
+       (* printf "solve sig SG \n";
+       let cg = normCompGoal (cg', ms) in
+       Printer.printState cD cG cg ms; *)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveCClauseSubGoals cD cG cPool cid sg' ms mV
@@ -1864,8 +1863,9 @@ module CSolver = struct
        let e = Whnf.cnormExp' (e,ms) in
        sc e
     | Solve (sg', cg') ->
-       let cg'= normCompGoal (cg',ms) in
-      (* Printer.printState cD cG cg' ms; *)
+       (* printf "solve thm SG \n";
+       let cg = normCompGoal (cg',ms) in
+       Printer.printState cD cG cg ms; *)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveTheoremSubGoals cD cG cPool cid sg' ms mV
@@ -2033,8 +2033,8 @@ module CSolver = struct
   and focus cD cG cPool cg ms sc currDepth maxDepth =
    (*  printf "FOCUS \n";
     (* let ms = Whnf.cnormMSub ms in
-    let cg = normCompGoal (cg, ms) in *)
-    Printer.printState cD cG cg ms; *)
+    let cg' = normCompGoal (cg, ms) in *)
+    Printer.printState cD cG cg' ms; *)
     match cg with
     | Box (cPsi, g, Some M) ->
        (* If our goal is of box type, we first try to find the

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -1564,8 +1564,8 @@ module CSolver = struct
 
   let checkDepth x y =
       match (x, y) with
-      | (Some i, Some j) -> i >= j
-      | (Some i, None) -> true
+      | (Some i, Some j) -> i > j
+      | (Some i, None) -> false
       | (None, _) -> false
 
     (* Abort mquery. *)
@@ -1940,10 +1940,6 @@ module CSolver = struct
          matchHead cD sCCl.cHead cg;
       then (* If so, since there are no subgoals, return the assumption *)
         (let ms' = C.mctxToMSub cD (sCCl.cMVars, ms) in
-         fprintf std_formatter "\n ms' = \n %a \n"
-           (Pretty.Int.DefaultPrinter.fmt_ppr_lf_msub cD Pretty.Int.DefaultPrinter.l0) ms';
-         fprintf std_formatter "\n ms = \n %a \n"
-          (Pretty.Int.DefaultPrinter.fmt_ppr_lf_msub cD Pretty.Int.DefaultPrinter.l0) ms;
          let tau = if isBox cg then C.boxToTypBox cg else C.atomicToBase cg in
          let sg = normSubGoals ms' sCCl.cSubGoals in
         (try

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -595,6 +595,8 @@ module Index = struct
 
   let compTypes = Hashtbl.create 0      (* compTypConst Hashtbl.t      *)
 
+(*  let compCoTypes = Hashtbl.create 0 *)
+
   type inst = (Id.name *  LF.normal)    (* I ::= (x, Y[s]) where Y is an MVar        *)
   type minst = (Id.name * LF.mfront)    (* I ::= (x, mf)   where mf is (Psihat.term) *)            
                                         (* where mf contains an MMVar *)
@@ -641,6 +643,10 @@ module Index = struct
     Hashtbl.add compTypes cidTyp (DynArray.create ());
     Hashtbl.find compTypes cidTyp
 
+(*  let addCompCoTyp cidTyp =
+    Hashtbl.add compCoTypes cidTyp (DynArray.create ());
+    Hashtbl.find compCoTypes cidTyp *)
+
   (* addSgnClause tC, sCl = ()
      Add a new sgnClause, sCl, to the DynArray tC.
   *)
@@ -683,48 +689,43 @@ module Index = struct
       ; instMMVars = xs
       }    
     
-  (* compileSgnClause c = (c, sCl)
-     Retrieve LF.typ for term constant c, clausify it into sCl and
-     return an sgnClause (c, sCl).
-  *)
+  (* compile _ Clause c = (c, sCl)
+     Retrieve type for term constant c, clausify it, and
+     return the respective clause (c, sCl).
+   *)
+    
+  (* LF Constants  *)
   let compileSgnClause cidTerm =
     let termEntry = Cid.Term.get cidTerm in
     let tM = termEntry.Cid.Term.Entry.typ in
     (cidTerm, Convert.typToClause tM)
 
-
-    
-  (* compileSgnCClause c = (c, sCCl)
-     Retrieve Comp.typ for term constant c, clausify it into sCCl and
-     return an sgnCClause (c, sCCl). 
-   *)
-    
-  (* Computation Type Theorems  *)
+  (* Computation Theorem Constants  *)
   let compileSgnCClause cidTerm =
     let termEntry = Cid.Comp.get cidTerm in
     let tau = termEntry.Cid.Comp.Entry.typ in
     (cidTerm, Convert.comptypToCClause tau)
     
-  (* Inductive Types *)
-  let compileSgnIClause cidTerm =
+  (* Inductive Constants *)
+  let compileSgnConstClause cidTerm =
     let termEntry = Cid.CompConst.get cidTerm in
     let tau = termEntry.Cid.CompConst.Entry.typ in
-    (cidTerm, Convert.comptypToCClause tau)
+    (cidTerm, Convert.comptypToCClause tau)    
 
 (*  let compileSgnTDClause cidTerm =
     let termEntry = Cid.CompTypDef.get cidTerm in
     let tau = termEntry.Cid.CompTypDef.Entry.typ in
-    (cidTerm, Convert.comptypToCClause tau)  *)
+    (cidTerm, Convert.comptypToCClause tau)  
 
 (*  let compileCoClause cidTerm =
     let termEntry = Cid.CompCotyp.get cidTerm in
     let tau = termEntry.Cid.CompCotyp.Entry.typ in
-    (cidTerm, Convert.comptypToCClause tau) *)
+    (cidTerm, Convert.comptypToCClause tau)  *)
 
-(*  let compileCTClause cidTerm =
+  let compileCTClause cidTerm =
     let termEntry = Cid.CompDest.get cidTerm in
     let tau = termEntry.Cid.CompDest.Entry.return_type in
-    (cidTerm, Convert.comptypToCClause tau)   *)
+    (cidTerm, Convert.comptypToCClause tau)    *)
 
     
 
@@ -734,8 +735,17 @@ module Index = struct
   let termName cidTerm =
     (Cid.Term.get cidTerm).Cid.Term.Entry.name
 
-  let compTermName cidTerm =
+  let compName cidTerm =
     (Cid.Comp.get cidTerm).Cid.Comp.Entry.name
+
+  let compConstName cidTerm =
+    (Cid.CompConst.get cidTerm).Cid.CompConst.Entry.name 
+
+(*  let typName cidTerm =
+    (Cid.Typ.get cidTerm).Cid.Typ.Entry.name *)
+
+(*  let compTypName cidTerm =
+    (Cid.Comp.get cidTerm).Cid.Comp.Entry.name *)
 
   (* storeTypConst c = ()
      Add a new entry in `types' for type constant c and fill the DynArray
@@ -766,6 +776,7 @@ module Index = struct
    *)
     
   let storeCompTypConst (cidTyp, typEntry) =
+    (* TODO:: Typ or CompTyp?? *)
     let typConstr = !(typEntry.Cid.Typ.Entry.constructors) in  
     let typConst = addCompTyp cidTyp in
     let regSgnCClause cidTerm =
@@ -780,11 +791,11 @@ module Index = struct
     in
     revIter regSgnCClause typConstr
 
-  let storeCompTypIConst (cidTyp, typEntry) =
-    let typConstr = !(typEntry.Cid.Typ.Entry.constructors) in  
-    let typConst = addCompTyp cidTyp in
+(*  let storeCompCoTypConst (cidTyp, typEntry) =
+    let typConstr = !(typEntry.Cid.CompCotyp.Entry.destructors) in  
+    let typConst = addCompCoTyp cidTyp in
     let regSgnCClause cidTerm =
-      addSgnCClause typConst (compileSgnIClause cidTyp)
+      addSgnCClause typConst (compileSgnCClause cidTyp)
     in
     let rec revIter f =
       function
@@ -793,7 +804,23 @@ module Index = struct
          revIter f l';
          f h
     in
-    revIter regSgnCClause typConstr
+    revIter regSgnCClause typConstr   *)
+
+  let storeCompConst (cidTyp, typEntry) =
+    (* TODO:: Typ or CompTyp?? *)
+    let typConstr = !(typEntry.Cid.CompTyp.Entry.constructors) in  
+    let typConst = addCompTyp cidTyp in
+    let regSgnCClause cidTerm =
+      addSgnCClause typConst (compileSgnConstClause cidTyp)
+    in
+    let rec revIter f =
+      function
+      | [] -> ()
+      | h :: l' ->
+         revIter f l';
+         f h
+    in
+    revIter regSgnCClause typConstr 
 
 (*  let storeCompTypTDConst (cidTyp, typEntry) =
     let typConstr = !(typEntry.Cid.Typ.Entry.constructors) in  
@@ -866,25 +893,20 @@ module Index = struct
     | _ -> ()
 
   (* robThirdStore () = ()
-     Store all Inductive comptype constants in the `compTypes' table.
+     Store all ? comptype constants in the `compTypes' table.
   *)
   let robThirdStore () =
     try
-      List.iter storeCompTypIConst (Cid.Typ.current_entries ())
+      List.iter storeCompConst (Cid.CompTyp.current_entries ())
     with
-    | _ -> ()
+    | _ -> ()   
 
-(*  let robFourthStore () =
-    try
-      List.iter storeCompTypTDConst (Cid.Typ.current_entries ())
-    with
-    | _ -> ()
 
-    let robFifthStore () =
-    try
-      List.iter storeCompTypCTConst (Cid.Typ.current_entries ())
-    with
-    | _ -> ()  *)
+  let robAll () =
+    robStore ();
+    robSecondStore ();
+    robThirdStore () 
+    
  
   (* iterSClauses f c = ()
      Iterate over all signature clauses associated with c.
@@ -921,7 +943,7 @@ module Index = struct
     querySub := s;
     robStore ();
     robSecondStore ();
-    robThirdStore ();
+ (*   robThirdStore ();*)
     let bchatter = !Options.chatter in
     Options.chatter := 0;
     let sgnQ =
@@ -1027,7 +1049,7 @@ module Printer = struct
          (fmt_ppr_cmp_typ cD) (typ)
     | Atomic (cid, aSpine) ->
        fprintf ppf "%a %a"
-         Id.print (compTermName cid)
+         Id.print (compName cid)
          (fmt_ppr_atomic_spine cD) aSpine
     | Forall (ctdec, cg') ->
        fprintf ppf "(∀%a. %a)"
@@ -1118,9 +1140,16 @@ module Printer = struct
   (** Prints a Computation Type clause *)
   let fmt_ppr_sgn_cclause ppf (cidTerm, sCCl) =
     fprintf ppf "@[<v 2>@[%a@] : @[%a@]@,%a@]"
-      Id.print (compTermName cidTerm)
+      Id.print (compName cidTerm)
       (fmt_ppr_preconds sCCl.cMVars) (sCCl.cSubGoals)
       (fmt_ppr_cmp_typ sCCl.cMVars) (sCCl.cHead)
+
+   (** Prints a Computation Constant clause *)
+  let fmt_ppr_sgn_constclause ppf (cidTerm, sCCl) =
+    fprintf ppf "@[<v 2>@[%a@] : @[%a@]@,%a@]"
+      Id.print (compConstName cidTerm)
+      (fmt_ppr_preconds sCCl.cMVars) (sCCl.cSubGoals)
+      (fmt_ppr_cmp_typ sCCl.cMVars) (sCCl.cHead)     
      
 
   let fmt_ppr_bound ppf =
@@ -1176,6 +1205,18 @@ module Printer = struct
       (fun w ->
         fprintf std_formatter "%a@."
           fmt_ppr_sgn_cclause w)
+    
+  let printCompConstSignature () =
+    iterAllSCClauses
+      (fun w ->
+        fprintf std_formatter "%a@."
+          fmt_ppr_sgn_constclause w)  
+
+  let printAllSig () =
+    printSignature ();
+    printCompSignature ();
+    printCompConstSignature () 
+    
 end
 
 module Solver = struct
@@ -2309,15 +2350,11 @@ let runLogic () =
   if !Options.enableLogic
   then
     begin
-      (* Transform LF signature into clauses. *)
-      Index.robStore ();
-      (* Transform Comp signatures into clauses. *)
-      Index.robSecondStore ();
-      Index.robThirdStore ();
+      (* Transform signature into clauses. *)
+      Index.robAll ();
       (* Optional: Print signature clauses. *)
       if !Options.chatter >= 4
-      then (Printer.printSignature ();
-            Printer.printCompSignature ());
+      then Printer.printAllSig ();
       (* Solve! *)
       Index.iterQueries Frontend.solve;
       Index.iterMQueries Frontend.msolve;      
@@ -2331,9 +2368,7 @@ let runLogicOn n (tA, i) cD e t  =
 
 let prepare () =
   Index.clearIndex ();
-  Index.robStore ();
-  Index.robSecondStore ();
-  Index.robThirdStore ()
+  Index.robAll ();
 
 (*
 

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -24,7 +24,7 @@ module Options = struct
        3 => + Solutions and proof terms.
        4 => + LF signature & Comp Sig.
   *)
-  let chatter = ref 3
+  let chatter = ref 4
 
   (* Ask before giving more solutions (à la Prolog). *)
   let askSolution = ref false
@@ -2501,7 +2501,7 @@ let runLogic () =
       (* Transform signature into clauses. *)
       Index.robAll ();
       (* Optional: Print signature clauses. *)
-      if !Options.chatter >= 4
+      if !Options.chatter >= 5
       then Printer.printAllSig ();
       (* Solve! *)
       Index.iterQueries Frontend.solve;

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -422,12 +422,12 @@ module Convert = struct
     | [] -> S.id
     | (x, tN) :: xs -> LF.Dot (LF.Obj tN, solToSub xs)
 
-  let rec solToMSub xs =
+(*  let rec solToMSub xs =
     match xs with
     | [] -> LF.MShift 0
     | (x, tN) :: xs ->
        LF.MDot (tN, solToMSub xs) 
-
+ *)
 (*
   comptypToMQuery (tau,i) = comp_goal  
 
@@ -1331,7 +1331,7 @@ module CSolver = struct
        List.rev (cg1 :: xs)
     | Box (_) -> []
     | Forall (_) -> [cg]
-
+(*
   (* Convert a (normal) term into an exp_chk for type checking purposes *) 
   let tmToExCk tM cPsi =
     match tM with
@@ -1345,6 +1345,7 @@ module CSolver = struct
        raise NotImplementedYet
     | LF.Tuple (loc, tuple) ->
        raise NotImplementedYet
+ *)      
        
       
 
@@ -1674,22 +1675,22 @@ module Frontend = struct
     | (Box(cPsi, g) , ms) -> *)
 
     (* Type checking function. *)
-    let check cD cPsi (e : Comp.exp_chk) ms =
+(*    let check cD cPsi (e : Comp.exp_chk) ms =
       (* check mcid cD cG (total_decs : total_dec list) ?cIH:(cIH = Syntax.Int.LF.Empty) e ttau  *)
       (* Does the term have a cid?? *)
       Check.Comp.check None cD LF.Empty [] e (sgnMQuery.skinnyCompTyp, ms)
     in
-   
+*)   
     
     let scInit cD (cPsi, tM) =
       incr solutions;
 
        (* Rebuild the substitution and type check the proof term. *)
-      if !Options.checkProofs
+(*      if !Options.checkProofs
       then
         let e = CSolver.tmToExCk tM cPsi in
         check cD cPsi e (Convert.solToMSub sgnMQuery.instMMVars);
-    
+ *)    
  
           begin
             fprintf std_formatter  "@[<v>---------- Solution %d ----------@,[%a |- %a]@]" 

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -73,7 +73,6 @@ type goal =                             (* Goals            *)
   | Atom of LF.typ                      (* g ::= A          *)
   | Impl of (res * LF.typ_decl) * goal  (*     | r => g'    *)
   | All of LF.typ_decl * goal           (*     | ∀x:A. g'   *)
-  | Comp of Comp.typ                    (*     | [ g' ]     *)
 
 and res =                               (* Residual Goals   *)
   | Head of LF.typ                      (* r ::= A          *)
@@ -299,7 +298,7 @@ module Convert = struct
     | LF.PiTyp ((LF.TypDecl (x, tA) as tdec, LF.No), tB) ->
        Impl ((typToRes tA (cS, dS, dR), tdec), typToGoal tB (cS, dS, dR + 1))
     | LF.Atom _ ->
-       Atom (Shift.shiftAtom tM (-cS, -dS, dR))
+       Atom (Shift.shiftAtom tA (-cS, -dS, dR))
 
   and typToRes tM (cS, dS, dR) =
     match tM with
@@ -1167,7 +1166,7 @@ module Printer = struct
 
  (* Prints the current state of proof loop
     (used for debugging) *)
-
+(*
   let printState cD cG cg ms =
     let fmt_ppr_gctx cD ppf cG =
       P.fmt_ppr_cmp_gctx cD P.l0 ppf cG
@@ -1184,7 +1183,7 @@ module Printer = struct
         (fmt_ppr_gctx cD) cG
         (fmt_ppr_cmp_goal cD) (cg,S.id)
         (Pretty.Int.DefaultPrinter.fmt_ppr_lf_msub cD Pretty.Int.DefaultPrinter.l0) ms
-
+*)
 end
 
 module Solver = struct
@@ -1860,7 +1859,7 @@ module CSolver = struct
        (* printf "solve sig SG \n"; *)
       (* let cg' = normCompGoal (cg', ms) in
        let ms = Whnf.cnormMSub ms in *)
-       Printer.printState cD cG (cg') ms;
+       (*Printer.printState cD cG (cg') ms;*)
        cgSolve' cD cG cPool (cg', ms)
          (fun e ->
            solveCClauseSubGoals cD cG cPool cid sg' ms mV
@@ -2435,8 +2434,6 @@ module Frontend = struct
     (* Success continuation function *)
     let scInit e =
       incr solutions;
-      fprintf std_formatter "\n FINAL check e = \n %a \n"
-          (P.fmt_ppr_cmp_exp_chk LF.Empty LF.Empty) e;
 
        (* Rebuild the substitution and type check the proof term. *)
       if !Options.checkProofs
@@ -2519,8 +2516,6 @@ let prepare () =
   Index.robAll ();
 
 (*
-
-
 let runLogicOn n (cD, cPsi, tA, i) e t  =
   Index.singleQuery (n, (tA, i), e, t) Frontend.solve
  *)

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -105,7 +105,7 @@ type clause =                    (* Horn Clause ::= eV |- A :- cG   *)
 
  *)
 
-type comp_goal =                                (* Comp Goal cg :=     x  *)
+type comp_goal =                                (* Comp Goal cg :=       *)
   | Box of LF.dctx  * goal * lfTyp option       (*     | Box (cPsi , g)  *)
   | Implies of (comp_res * Comp.ctyp_decl)      (*     | r -> cg'        *)
                * comp_goal  
@@ -392,6 +392,7 @@ module Convert = struct
   let comptypToCClause tau =
     comptypToCClause' LF.Empty tau Proved
 
+  (* Converts a box comp goal to a Comp.TypBox *)
   let boxToTypBox box =
     match box with
     | Box (cPsi, Atom tA, Some M) ->
@@ -403,6 +404,7 @@ module Convert = struct
        let ctyp = LF.ClTyp (LF.PTyp tA, cPsi) in
        Comp.TypBox (loc, ctyp)
 
+  (* Converts an atomic comp goal to a Comp.TypBase *) 
   let atomicToBase atomic =
     let rec asToS aS =
       match aS with
@@ -519,33 +521,8 @@ module Convert = struct
     | [] -> LF.MShift 0
     | (x, tN) :: xs ->
        LF.MDot (tN, solToMSub xs)
-(*
-  let typToExp tau =
-    match tau with
-    | Comp.TypBox (loc, meta_typ) ->
-       Comp.Box (loc, meta_obj, meta_typ)
-    | Comp.TypBase (loc, cid, meta_spine) -> *)
        
- (*      
-  let tauToSyn hd =
-    match hd with
-    | Comp.TypArr (loc, tau1, tau2) ->
-       
-        
-    let {cHead = hd; cMVars; cSubGoals = sg} = cc in
-    let body = typToExp hd in
-    let name = Id.mk_name Id.NoName in
-    let loc = Syntax.Loc.ghost in 
-    let rec sgToBody sg body =
-      match sg with 
-      | Proved -> body
-      | Solve (sg', cg) ->
-         sgToBody sg' (Comp.Fn (loc, name, body))
-    in
-    sgToBody sg body  *)
-       
-                                      
-       
+                                     
  
 (*
   comptypToMQuery (tau,i) = comp_goal  

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -2434,7 +2434,10 @@ module Frontend = struct
     (* Success continuation function *)
     let scInit e =
       incr solutions;
-
+      (*
+      fprintf std_formatter "\n FINAL check e = \n %a \n"
+        (P.fmt_ppr_cmp_exp_chk LF.Empty LF.Empty) e;  *)
+      
        (* Rebuild the substitution and type check the proof term. *)
       if !Options.checkProofs
       then
@@ -2498,7 +2501,7 @@ let runLogic () =
       (* Transform signature into clauses. *)
       Index.robAll ();
       (* Optional: Print signature clauses. *)
-      if !Options.chatter >= 5
+      if !Options.chatter >= 4
       then Printer.printAllSig ();
       (* Solve! *)
       Index.iterQueries Frontend.solve;

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -24,7 +24,7 @@ module Options = struct
        3 => + Solutions and proof terms.
        4 => + LF signature & Comp Sig.
   *)
-  let chatter = ref 4
+  let chatter = ref 3
 
   (* Ask before giving more solutions (à la Prolog). *)
   let askSolution = ref false

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -799,9 +799,16 @@ module Index = struct
        t = expected number of tries to find soln.
   *)
   let storeMQuery ((tau, i), e, t, d) =
-    (*  TO BE IMPLEMENTED AND FINISHED *)
+    let rec get_minst xs =
+      match xs with
+      | [] -> []
+      | (a,(loc,b)) :: ys ->
+         let ys' = get_minst ys in
+         (a,b) :: ys'
+    in
     let (mq, tau', ms, xs) = (Convert.comptypToMQuery (tau, i)) in
-    addSgnMQuery (tau', mq, [], e, t, d)
+    let xs' = get_minst xs in
+    addSgnMQuery (tau', mq, xs', e, t, d)
 
 
   (* robStore () = ()
@@ -1134,8 +1141,8 @@ module Printer = struct
 
  (* Prints the current state of proof loop
     (used for debugging) *)
-(*
-   let printState cD cG cg ms =
+
+  (* let printState cD cG cg ms =
     let fmt_ppr_gctx cD ppf cG =
       P.fmt_ppr_cmp_gctx cD P.l0 ppf cG
     in
@@ -1875,7 +1882,7 @@ module CSolver = struct
       then
         (let (ms', fS) = C.mctxToMSub cD (sCCl.cMVars, LF.MShift 0) (fun s -> s) in
          let ms'' = rev_ms ms' (Context.length (sCCl.cMVars)) in
-      (*  printf "focus Thm NEW MS \n";
+        (* printf "focus Thm NEW MS \n";
          Printer.printState cD cG cg ms';
          let ms''' = Whnf.cnormMSub ms' in
          printf "focus Thm normedd MS \n";
@@ -1903,12 +1910,8 @@ module CSolver = struct
      Printer.printState cD cG cg ms; *)
     let matchSig (cidTerm, sCCl) sc =
       let (ms', fS) = C.mctxToMSub cD (sCCl.cMVars, LF.MShift 0) (fun s -> s) in
-      let ms'' = rev_ms ms' (Context.length ((sCCl.cMVars))) in
-      (* printf "focus Sig NEW MS \n";
-      Printer.printState cD cG cg ms'; *)
+      let ms'' = rev_ms ms' (Context.length (sCCl.cMVars)) in
       let tau = C.atomicToBase cg in
-      (* printf "focus Sig match with assump head: \n";
-      Printer.fmt_ppr_cmp_typ cD std_formatter sCCl.cHead; *)
       (try
          Solver.trail
            begin fun () ->
@@ -2451,9 +2454,9 @@ module Frontend = struct
          if !Options.chatter >= 1
            then P.printMQuery sgnMQuery;
          try
-             CSolver.cgSolve LF.Empty LF.Empty sgnMQuery.mquery scInit sgnMQuery.depth;
-             (* Check solution bounds. *)
-             checkSolutions sgnMQuery.mexpected sgnMQuery.mtries !solutions
+           CSolver.cgSolve LF.Empty LF.Empty sgnMQuery.mquery scInit sgnMQuery.depth;
+           (* Check solution bounds. *)
+           checkSolutions sgnMQuery.mexpected sgnMQuery.mtries !solutions
            with
            | Done -> printf "Done.\n"
            | AbortQuery s -> printf "%s\n" s

--- a/src/core/logic.ml
+++ b/src/core/logic.ml
@@ -1150,7 +1150,7 @@ module Printer = struct
         (fmt_ppr_mctx) cD
         (fmt_ppr_gctx cD) cG
         (fmt_ppr_cmp_goal cD) (cg,S.id)
-        (Pretty.Int.DefaultPrinter.fmt_ppr_lf_msub cD Pretty.Int.DefaultPrinter.l0) ms *) 
+        (Pretty.Int.DefaultPrinter.fmt_ppr_lf_msub cD Pretty.Int.DefaultPrinter.l0) ms *)
 
 end
 
@@ -1711,7 +1711,7 @@ module CSolver = struct
        find_max cD' cltyp_d k lst
     *)
 
-  (* rev_ms ms k = 
+  (* rev_ms ms k =
        reverses ms with first sub MShift k
  *)
 

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -10,6 +10,7 @@ module Options : sig
 end
 
 module Convert : sig
+  val comptypToCompGoal : Comp.typ -> comp_goal 
   val typToQuery : LF.mctx -> LF.dctx -> LF.typ * Id.offset
                    -> query * LF.typ * LF.sub * (Id.name * LF.normal) list
   val comptypToMQuery : Comp.typ * Id.offset -> mquery * Comp.typ * LF.msub * (Id.name * Comp.meta_obj) list
@@ -21,8 +22,11 @@ end
 
 module Solver : sig
   val solve : LF.mctx -> LF.dctx -> query -> (LF.dctx * LF.normal -> unit) -> unit
-  val msolve : LF.mctx -> LF.dctx -> mquery -> (LF.dctx * LF.normal -> unit) -> unit
 end
+
+module CSolver : sig
+  val cgSolve : comp_goal list -> LF.mctx -> mquery -> (LF.mctx -> (LF.dctx * LF.normal) -> unit) -> unit
+end 
 
 type bound = int option
 

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -3,6 +3,7 @@ open Syntax.Int
 type goal
 type query
 type mquery
+type comp_res
    
 
 module Options : sig
@@ -25,7 +26,7 @@ module Solver : sig
 end
 
 module CSolver : sig
-  val cgSolve : comp_goal list -> LF.mctx -> mquery -> (LF.mctx -> (LF.dctx * LF.normal) -> unit) -> unit
+  val cgSolve : LF.mctx -> Comp.gctx -> comp_res list -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) -> unit
 end 
 
 type bound = int option

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -30,12 +30,12 @@ module Solver : sig
   val solve : LF.mctx -> LF.dctx -> query -> (LF.dctx * LF.normal -> unit) -> unit
 end
 
-module CSolver : sig
-  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (Comp.exp_chk -> unit) -> unit
-end 
-     
 type bound = int option
 
+module CSolver : sig
+  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (Comp.exp_chk -> unit) -> bound-> unit
+end 
+     
 val storeQuery : Id.name option -> LF.typ * Id.offset -> LF.mctx -> bound -> bound -> unit
 val storeMQuery: Comp.typ * Id.offset -> bound -> bound -> bound -> unit
 val runLogic : unit -> unit

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -6,7 +6,6 @@ type query
 type mquery
 type comp_res
 
-
 module Options : sig
   val enableLogic : bool ref
 end
@@ -22,7 +21,6 @@ module Index : sig
   type inst
 end
 
-
 module Frontend : sig
   exception Done
 end
@@ -36,7 +34,6 @@ type bound = int option
 module CSolver : sig
   val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (Comp.exp_chk -> unit) -> bound-> unit
 end
-
 val storeQuery : Id.name option -> LF.typ * Id.offset -> LF.mctx -> bound -> bound -> unit
 val storeMQuery: Comp.typ * Id.offset -> bound -> bound -> bound -> unit
 val runLogic : unit -> unit

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -31,7 +31,7 @@ module Solver : sig
 end
 
 module CSolver : sig
-  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) -> unit
+  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (Comp.exp_chk -> unit) -> unit
 end 
      
 type bound = int option

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -1,26 +1,27 @@
 open Syntax.Int
 
 type goal
+type comp_goal
 type query
 type mquery
 type comp_res
-   
+
 
 module Options : sig
   val enableLogic : bool ref
 end
 
 module Convert : sig
-  val comptypToCompGoal : Comp.typ -> comp_goal 
+  val comptypToCompGoal : Comp.typ -> comp_goal
   val typToQuery : LF.mctx -> LF.dctx -> LF.typ * Id.offset
                    -> query * LF.typ * LF.sub * (Id.name * LF.normal) list
   val comptypToMQuery : Comp.typ * Id.offset -> mquery * Comp.typ * LF.msub * (Id.name * Comp.meta_obj) list
 end
 
 module Index : sig
-  type inst 
+  type inst
 end
-     
+
 
 module Frontend : sig
   exception Done
@@ -34,8 +35,8 @@ type bound = int option
 
 module CSolver : sig
   val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (Comp.exp_chk -> unit) -> bound-> unit
-end 
-     
+end
+
 val storeQuery : Id.name option -> LF.typ * Id.offset -> LF.mctx -> bound -> bound -> unit
 val storeMQuery: Comp.typ * Id.offset -> bound -> bound -> bound -> unit
 val runLogic : unit -> unit

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -31,8 +31,7 @@ module Solver : sig
 end
 
 module CSolver : sig
-  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) ->
-     ((LF.sub * Index.inst list * LF.typ) -> (LF.dctx * LF.normal) -> unit) -> unit
+  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) -> unit
 end 
      
 type bound = int option

--- a/src/core/logic.mli
+++ b/src/core/logic.mli
@@ -17,6 +17,11 @@ module Convert : sig
   val comptypToMQuery : Comp.typ * Id.offset -> mquery * Comp.typ * LF.msub * (Id.name * Comp.meta_obj) list
 end
 
+module Index : sig
+  type inst 
+end
+     
+
 module Frontend : sig
   exception Done
 end
@@ -26,9 +31,10 @@ module Solver : sig
 end
 
 module CSolver : sig
-  val cgSolve : LF.mctx -> Comp.gctx -> comp_res list -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) -> unit
+  val cgSolve : LF.mctx -> Comp.gctx -> mquery -> (LF.mctx -> Comp.gctx -> Comp.exp_chk -> unit) ->
+     ((LF.sub * Index.inst list * LF.typ) -> (LF.dctx * LF.normal) -> unit) -> unit
 end 
-
+     
 type bound = int option
 
 val storeQuery : Id.name option -> LF.typ * Id.offset -> LF.mctx -> bound -> bound -> unit

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2671,14 +2671,14 @@ let sgn_query_pragma =
   <& token T.DOT
   |> span
   |> labelled "logic programming engine query pragma"
-  $> fun (location, ((expected_solutions, maximum_tries), cD name, typ)) ->
+  $> fun (location, ((expected_solutions, maximum_tries), cD, name, typ)) ->
      Sgn.Query { location; name; mctx=cD; typ; expected_solutions; maximum_tries }
 
 let sgn_mquery_pragma =
   let bound =
     alt
       (token T.STAR &> pure None)
-      (integer $> Maybe.pure)
+      (integer $> Option.some)
     |> labelled "search bound"
   in
   pragma "mquery" &>

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2689,8 +2689,8 @@ let sgn_mquery_pragma =
   <& token T.DOT
   |> span
   |> labelled "meta-logic search engine mquery pragma"
-  $> fun (loc, ((e, t, d), tau)) ->
-     Sgn.MQuery (loc, tau,e,t,d)
+  $> fun (location, ((expected_solutions, search_tries, search_depth), tau)) ->
+     Sgn.MQuery { location; typ=tau; expected_solutions; search_tries; search_depth }
 
 
 let sgn_oldstyle_lf_decl =

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -2692,7 +2692,7 @@ let sgn_mquery_pragma =
   $> fun (loc, ((e, t, d), tau)) ->
      Sgn.MQuery (loc, tau,e,t,d)
 
-     
+
 let sgn_oldstyle_lf_decl =
   labelled
     "old-style LF type or constant declaration"

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -941,7 +941,7 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
          (fmt_ppr_cmp_meta_obj_typed cD (lvl + 1)) (mO, mT)
          (fmt_ppr_cmp_meta_spine cD lvl) mS
 
-  let rec fmt_ppr_cmp_typ  cD lvl ppf =
+  let rec fmt_ppr_cmp_typ cD lvl ppf =
     function
     | Comp.TypBase (_, c, mS)->
        let cond = lvl > 10 in

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -1168,7 +1168,13 @@ let recSgnDecls decls =
        }
 
 
-    | Ext.Sgn.MQuery (loc, tau, expected, tries, depth) ->
+    | Ext.Sgn.MQuery
+      { location=loc
+      ; typ=tau
+      ; expected_solutions=expected
+      ; search_tries=tries
+      ; search_depth=depth
+      } ->
        (dprintf
          (fun p ->
            p.fmt "[RecSgn Checking] MQuery at %a"
@@ -1206,8 +1212,13 @@ let recSgnDecls decls =
            Check.Comp.checkTyp Int.LF.Empty tau'
           );
         Logic.storeMQuery (tau', i) expected tries depth)   ;
-        Int.Sgn.MQuery (loc, (tau', i), expected, tries, depth)))
-
+        Int.Sgn.MQuery
+        { location=loc
+        ; typ=(tau',i)
+        ; expected_solutions=expected
+        ; search_tries=tries
+        ; search_depth=depth
+        }))
 
 
     | Ext.Sgn.Pragma

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -1150,7 +1150,7 @@ let recSgnDecls decls =
          begin fun p ->
            p.fmt "Reconstruction (with abstraction) of query: %a with %s abstracted variables"
              (P.fmt_ppr_lf_typ cD Int.LF.Null P.l0) tA'
-             (string_of_int i)   
+             (string_of_int i)
          end;
        Monitor.timer
          ( "Constant Check"
@@ -1198,18 +1198,18 @@ let recSgnDecls decls =
         begin fun p ->
         p.fmt "Reconstruction (with abstraction) of mquery: %a with %s abstracted variables"
           (P.fmt_ppr_cmp_typ (Int.LF.Empty) P.l0) tau'
-          (string_of_int i)   
+          (string_of_int i)
         end;
         Monitor.timer
           ( "Constant Check"
           , fun () ->
            Check.Comp.checkTyp Int.LF.Empty tau'
           );
-        Logic.storeMQuery (tau', i) expected tries depth)   ;                 
+        Logic.storeMQuery (tau', i) expected tries depth)   ;
         Int.Sgn.MQuery (loc, (tau', i), expected, tries, depth)))
 
 
-       
+
     | Ext.Sgn.Pragma (loc, Ext.Sgn.NamePrag (typ_name, m_name, v_name)) ->
        dprintf
          (fun p ->

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -1210,7 +1210,10 @@ let recSgnDecls decls =
 
 
 
-    | Ext.Sgn.Pragma (loc, Ext.Sgn.NamePrag (typ_name, m_name, v_name)) ->
+    | Ext.Sgn.Pragma
+      { location=loc
+      ; pragma=Ext.Sgn.NamePrag (typ_name, m_name, v_name)
+      } ->
        dprintf
          (fun p ->
            p.fmt "[RecSgn Checking] Pragma at %a"

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -1119,7 +1119,7 @@ let recSgnDecls decls =
            p.fmt "[RecSgn Checking] Query at %a"
              Syntax.Loc.print_short location);
        let (_, apxT) = Index.typ Index.disambiguate_to_fvars extT in
-                                                                            dprint (fun () -> "Reconstructing query.");
+       dprint (fun () -> "Reconstructing query.");
        FVar.clear ();
        let tA =
          Monitor.timer

--- a/src/core/store.mli
+++ b/src/core/store.mli
@@ -144,7 +144,7 @@ module Cid : sig
 
     (* val entry_list : (Id.cid_comp_typ list ref) DynArray.t *)
     val mk_entry : name -> Comp.kind -> int -> Sgn.positivity_flag -> entry
-
+    val current_entries : unit -> (cid_comp_typ * entry) list
     val add : (cid_comp_typ -> entry) -> cid_comp_typ
     val get : cid_comp_typ -> entry
     val freeze : cid_comp_typ -> unit
@@ -175,6 +175,7 @@ module Cid : sig
     val add : (cid_comp_cotyp -> entry) -> cid_comp_cotyp
     val fixed_name_of : cid_comp_cotyp -> Id.name
     val get : cid_comp_cotyp -> entry
+    val current_entries : unit -> (cid_comp_cotyp * entry) list
     val freeze : cid_comp_cotyp -> unit
     val addDestructor : cid_comp_dest -> cid_comp_cotyp -> unit
     val index_of_name : name -> cid_comp_typ
@@ -197,6 +198,7 @@ module Cid : sig
 
     val mk_entry : name -> Comp.typ -> int -> entry
     val add : cid_comp_typ -> (cid_comp_const -> entry) -> cid_comp_const
+    val current_entries : unit -> (cid_comp_const * entry) list
     val get : cid_comp_const -> entry
     val get_implicit_arguments : cid_comp_const -> int
     val index_of_name : name -> cid_comp_const
@@ -221,6 +223,7 @@ module Cid : sig
 
     val mk_entry : name -> LF.mctx -> Comp.typ -> Comp.typ -> int -> entry
     val add : cid_comp_cotyp -> (cid_comp_dest -> entry) -> cid_comp_dest
+    val current_entries : unit -> (cid_comp_dest * entry) list
     val get : cid_comp_dest -> entry
     val fixed_name_of : cid_comp_dest -> Id.name
     val get_implicit_arguments : cid_comp_dest -> int
@@ -246,6 +249,7 @@ module Cid : sig
 
     val mk_entry : name -> int -> (LF.mctx * Comp.typ) -> Comp.kind -> entry
     val add : (cid_comp_typdef -> entry) -> cid_comp_typdef
+    val current_entries : unit -> (cid_comp_typdef * entry) list
     val get : cid_comp_typdef -> entry
     val fixed_name_of : cid_comp_typdef -> Id.name
     val get_implicit_arguments : cid_comp_typdef -> int
@@ -301,6 +305,7 @@ module Cid : sig
      *)
     val add : (cid_prog -> entry) -> cid_prog
     val get : cid_prog -> entry
+    val current_entries : unit -> (cid_prog * entry) list
 
     val fixed_name_of : cid_prog -> Id.name
     val index_of_name : name -> cid_prog

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -441,7 +441,13 @@ module Sgn = struct
       ; maximum_tries: int option
       } (** Logic programming query on LF type *)
 
-    | MQuery of Location.t * Comp.typ * int option * int option * int option
+    | MQuery of
+      { location: Location.t
+      ; typ: Comp.typ
+      ; expected_solutions: int option
+      ; search_tries: int option
+      ; search_depth: int option
+      } (** Logic programming mquery on Comp. type *)
 
     | Module of
       { location: Location.t

--- a/src/core/synext.ml
+++ b/src/core/synext.ml
@@ -441,7 +441,7 @@ module Sgn = struct
       ; maximum_tries: int option
       } (** Logic programming query on LF type *)
 
-    | MQuery of Loc.t * Comp.typ * int option * int option * int option
+    | MQuery of Location.t * Comp.typ * int option * int option * int option
 
     | Module of
       { location: Location.t

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -41,8 +41,8 @@ module LF = struct
      a hole (_) so that when printing, it can be reproduced correctly.
    *)
   and normal =                                  (* normal terms                   *)
-    | Lam of Location.t * name * normal              (* M ::= \x.M                     *)
-    | Root of Location.t * head * spine * plicity    (*   | h . S                      *)
+    | Lam of Location.t * name * normal              (* M ::= \x.M                *)
+    | Root of Location.t * head * spine * plicity    (*   | h . S                 *)
     | LFHole of Location.t * HoleId.t * HoleId.name
     | Clo of (normal * sub)                     (*   | Clo(N,s)                   *)
     | Tuple of Location.t * tuple

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -985,7 +985,13 @@ module Sgn = struct
       ; maximum_tries: int option
       } (** Logic programming query on LF type *)
 
-    | MQuery of Location.t * (Comp.typ * Id.offset)  * int option * int option * int option
+    | MQuery of
+      { location: Location.t
+      ; typ: (Comp.typ * Id.offset)
+      ; expected_solutions: int option
+      ; search_tries: int option
+      ; search_depth: int option
+      } (** Logic programming mquery on Comp. type *)
 
     | Comment of
       { location: Location.t

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -32,7 +32,6 @@ module LF = struct
   and typ =                                     (* LF level                       *)
     | Atom of Location.t * cid_typ * spine           (* A ::= a M1 ... Mn              *)
     | PiTyp of (typ_decl * depend) * typ        (*   | Pi x:A.B                   *)
-
     | Sigma of typ_rec
     | TClo of (typ * sub)                       (*   | TClo(A,s)                  *)
 

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -32,6 +32,7 @@ module LF = struct
   and typ =                                     (* LF level                       *)
     | Atom of Location.t * cid_typ * spine           (* A ::= a M1 ... Mn              *)
     | PiTyp of (typ_decl * depend) * typ        (*   | Pi x:A.B                   *)
+
     | Sigma of typ_rec
     | TClo of (typ * sub)                       (*   | TClo(A,s)                  *)
 

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -21,7 +21,7 @@ module LF = struct
     | PTyp of typ
     | STyp of svar_class * dctx
 
-  and ctyp =
+  and ctyp =                                   
     | ClTyp of cltyp * dctx
     | CTyp of cid_schema option
 
@@ -373,6 +373,7 @@ module LF = struct
     | tS when k = 0 -> tS
     | Nil -> Nil
     | App (_, tS') -> drop_spine (k-1) tS'
+    | SClo (tS', _) -> drop_spine (k-1) tS'
 end
 
 (* Internal Computation Syntax *)

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -21,7 +21,7 @@ module LF = struct
     | PTyp of typ
     | STyp of svar_class * dctx
 
-  and ctyp =                                   
+  and ctyp =
     | ClTyp of cltyp * dctx
     | CTyp of cid_schema option
 

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -452,13 +452,13 @@ module Comp = struct
   and exp_chk =                                                              (* e :=                                              *)
     | Syn        of Location.t * exp_syn                                     (* | n                                               *)
     | Fn         of Location.t * name * exp_chk                              (* | \x. e'                                          *)
-    | Fun        of Location.t * fun_branches                                (* | b_1...b_k                                       *) 
+    | Fun        of Location.t * fun_branches                                (* | b_1...b_k                                       *)
     | MLam       of Location.t * name * exp_chk * plicity                    (* | Pi X.e'                                         *)
     | Pair       of Location.t * exp_chk * exp_chk                           (* | (e_1, e_2)                                      *)
     | LetPair    of Location.t * exp_syn * (name * name * exp_chk)           (* | letpair n (x, y, e) := let (x=n.1, y=n.2) in  e *)
     | Let        of Location.t * exp_syn * (name * exp_chk)                  (* | let x = n in e                                  *)
     | Box        of Location.t * meta_obj * meta_typ (* type annotation,     (* | Box ([cPsihat |- tM]) : [cPsi |- tA]            *)
-                                            used for pretty-printing *)              
+                                            used for pretty-printing *)
     | Case       of Location.t * case_pragma * exp_syn * branch list
     | Impossible of Location.t * exp_syn
     | Hole       of Location.t * HoleId.t * HoleId.name

--- a/src/core/synint.ml
+++ b/src/core/synint.ml
@@ -447,28 +447,31 @@ module Comp = struct
 
   type ihctx = ih_decl LF.ctx
 
-  and exp_chk =
-    | Syn        of Location.t * exp_syn
-    | Fn         of Location.t * name * exp_chk
-    | Fun        of Location.t * fun_branches
-    | MLam       of Location.t * name * exp_chk * plicity
-    | Pair       of Location.t * exp_chk * exp_chk
-    | LetPair    of Location.t * exp_syn * (name * name * exp_chk)
-    | Let        of Location.t * exp_syn * (name * exp_chk)
-    | Box        of Location.t * meta_obj * meta_typ (* type annotation used for pretty-printing *)
+  (* normal comp. terms  *)
+  and exp_chk =                                                              (* e :=                                              *)
+    | Syn        of Location.t * exp_syn                                     (* | n                                               *)
+    | Fn         of Location.t * name * exp_chk                              (* | \x. e'                                          *)
+    | Fun        of Location.t * fun_branches                                (* | b_1...b_k                                       *) 
+    | MLam       of Location.t * name * exp_chk * plicity                    (* | Pi X.e'                                         *)
+    | Pair       of Location.t * exp_chk * exp_chk                           (* | (e_1, e_2)                                      *)
+    | LetPair    of Location.t * exp_syn * (name * name * exp_chk)           (* | letpair n (x, y, e) := let (x=n.1, y=n.2) in  e *)
+    | Let        of Location.t * exp_syn * (name * exp_chk)                  (* | let x = n in e                                  *)
+    | Box        of Location.t * meta_obj * meta_typ (* type annotation,     (* | Box ([cPsihat |- tM]) : [cPsi |- tA]            *)
+                                            used for pretty-printing *)              
     | Case       of Location.t * case_pragma * exp_syn * branch list
     | Impossible of Location.t * exp_syn
     | Hole       of Location.t * HoleId.t * HoleId.name
 
-  and exp_syn =
-    | Var       of Location.t * offset
-    | DataConst of Location.t * cid_comp_const
-    | Obs       of Location.t * exp_chk * LF.msub * cid_comp_dest
-    | Const     of Location.t * cid_prog
-    | Apply     of Location.t * exp_syn * exp_chk
-    | MApp      of Location.t * exp_syn * meta_obj * meta_typ (* annotation for printing *)
-                   * plicity
-    | AnnBox    of meta_obj * meta_typ
+  (* neutral com. terms *)
+and exp_syn =                                                                    (* n :=                                            *)
+    | Var       of Location.t * offset                                           (* | x:tau in cG                                   *)
+    | DataConst of Location.t * cid_comp_const                                   (* | c:tau in Comp. Sig.                           *)
+    | Obs       of Location.t * exp_chk * LF.msub * cid_comp_dest                (* | observation (e, ms, destructor={typ, ret_typ} *)
+    | Const     of Location.t * cid_prog                                         (* | theorem cp                                    *)
+    | Apply     of Location.t * exp_syn * exp_chk                                (* | (n:tau_1 -> tau_2) (e:tau_1)                  *)
+    | MApp      of Location.t * exp_syn * meta_obj * meta_typ (* annotation, *)  (* | (Pi X:U. n': tau) ([cPsihat |- tM] : [U'])    *)
+                    * plicity                            (* for printing *)
+    | AnnBox    of meta_obj * meta_typ                                           (* | [cPsihat |- tM] : [cPsi |- tA]                *)
     | PairVal   of Location.t * exp_syn * exp_syn
 
   and pattern =

--- a/src/core/whnf.ml
+++ b/src/core/whnf.ml
@@ -259,11 +259,11 @@ and lowerMMVar cD =
 *)
 
 (*************************************)
-    
+
 (* mvar_dot1 t = t'
    Invariant:
 
-   If  cD |- t : cD' 
+   If  cD |- t : cD'
    then t' = u. (mshift t 1)
         cD, u::[|t|]U |- t' : cD', u:U
  *)
@@ -1642,7 +1642,7 @@ and cnormMetaSpine (mS, t) =
 
 let cnormCDecl (cdecl, t) =
   match cdecl with
-  | Decl (u, mtyp, dep) -> Decl (u, cnormMTyp (mtyp, t), dep) 
+  | Decl (u, mtyp, dep) -> Decl (u, cnormMTyp (mtyp, t), dep)
 
 let rec cnormCTyp =
   function
@@ -2433,7 +2433,6 @@ let dotMMVar loc' cD t (u, cU, dep) =
  *)
 let extend_mctx cD (cdecl, t) =
   Dec(cD, cnormCDecl (cdecl, t))
-  
+
 let extend_gctx cG (cdecl, t) =
   Dec(cG, cnormCCDecl (cdecl, t))
-    

--- a/src/core/whnf.ml
+++ b/src/core/whnf.ml
@@ -1642,7 +1642,7 @@ and cnormMetaSpine (mS, t) =
 
 let cnormCDecl (cdecl, t) =
   match cdecl with
-  | Decl (u, mtyp, dep) -> Decl (u, cnormMTyp (mtyp, t), dep)
+  | Decl (u, mtyp, dep) -> Decl (u, cnormMTyp (mtyp, t), dep) 
 
 let rec cnormCTyp =
   function
@@ -1669,6 +1669,11 @@ let rec cnormCTyp =
      cnormCTyp (tT, mcomp t' t)
 
   | (Comp.TypInd tau, t) -> Comp.TypInd (cnormCTyp (tau, t))
+
+let cnormCCDecl (cdecl, t) =
+  match cdecl with
+  | Comp.CTypDecl(n, typ, wf_t) ->
+     Comp.CTypDecl(n, cnormCTyp (typ,t), wf_t)
 
 let rec cnormCKind (cK, t) =
   match cK with
@@ -2428,4 +2433,7 @@ let dotMMVar loc' cD t (u, cU, dep) =
  *)
 let extend_mctx cD (cdecl, t) =
   Dec(cD, cnormCDecl (cdecl, t))
+  
+let extend_gctx cG (cdecl, t) =
+  Dec(cG, cnormCCDecl (cdecl, t))
     

--- a/src/core/whnf.ml
+++ b/src/core/whnf.ml
@@ -2420,14 +2420,12 @@ let dotMMVar loc' cD t (u, cU, dep) =
   let mO = mmVarToMFront loc' (newMMVar' (Some u) (cD, cU) dep) cU in
   ((loc', mO), MDot (mO, t))
 
-
-
-(* extend_mctx cD (cdecl, t) = cD'
+(** extend_mctx cD (cdecl, t) = cD'
 
    if cD mctx
       cD' |- cU   where cdecl = _ : cU
-      cD  |- t : cD
-   the
+      cD  |- t : cD'
+   then
       cD, x:[t]U  mctx
 
  *)

--- a/src/core/whnf.mli
+++ b/src/core/whnf.mli
@@ -154,6 +154,7 @@ val cnormClObj : clobj -> msub -> clobj
 val cnormMFt : mfront -> msub -> mfront
 val cnormMSub : msub -> msub
 
+val cnormCCDecl : Comp.ctyp_decl * msub -> Comp.ctyp_decl
 val cnormCKind : Comp.kind * msub -> Comp.kind
 val cnormCTyp : Comp.typ * msub -> Comp.typ
 val cnormCDecl : LF.ctyp_decl * msub -> LF.ctyp_decl

--- a/src/core/whnf.mli
+++ b/src/core/whnf.mli
@@ -239,7 +239,3 @@ val dotMMVar : Location.t -> mctx -> msub -> Id.name * ctyp * depend
 val extend_mctx : mctx -> (LF.ctyp_decl * msub ) -> mctx
 
 val extend_gctx : Comp.gctx -> (Comp.ctyp_decl * msub) -> Comp.gctx
-
-                                                      
-
-                                                     

--- a/src/core/whnf.mli
+++ b/src/core/whnf.mli
@@ -236,3 +236,9 @@ val dotMMVar : Location.t -> mctx -> msub -> Id.name * ctyp * depend
                -> Comp.meta_obj * msub
 
 val extend_mctx : mctx -> (LF.ctyp_decl * msub ) -> mctx
+
+val extend_gctx : Comp.gctx -> (Comp.ctyp_decl * msub) -> Comp.gctx
+
+                                                      
+
+                                                     

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -176,10 +176,6 @@ let process_command
     | Holes.CompInfo ->
       begin
         let { compGoal; Holes.cG = cGh; compSolution } = h.info
-
-       (* TODO:: how to turn the computation-type assumptions (cGh) into
-                 useable assumptions since they aren't currently being used.
-                 Can we unbox them- placing them in our meta-context?  *)
         in
         assert (compSolution = None);
         let typ = Whnf.cnormCTyp compGoal in
@@ -190,7 +186,8 @@ let process_command
           end;
         Logic.prepare ();
         let (mquery, skinnyCTyp, mquerySub, instMMVars) =
-          Logic.Convert.comptypToMQuery (typ,0)
+          let (typ',k) = Abstract.comptyp typ in
+          Logic.Convert.comptypToMQuery (typ',k)
         in
            try
           Logic.CSolver.cgSolve cDh cGh mquery

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -172,7 +172,7 @@ let process_command
         (HoleId.string_of_name_or_id (h.Holes.name, id))
       end;
     let { name; Holes.cD = cDh; info; _ } = h in
-    match w with 
+    match w with
     | Holes.CompInfo ->
       begin
         let { compGoal; Holes.cG = cGh; compSolution } = h.info
@@ -194,17 +194,17 @@ let process_command
             begin
               fun e ->
               State.printf s "found solution: @[%a@]@,@?"
-                (P.fmt_ppr_cmp_exp_chk cDh cGh P.l0) e;           
-              h.info.compSolution <- Some e; 
+                (P.fmt_ppr_cmp_exp_chk cDh cGh P.l0) e;
+              h.info.compSolution <- Some e;
               raise Logic.Frontend.Done
             end
             (Some 999)
         with
           | Logic.Frontend.Done ->
-              State.printf s "logic programming finished@,@?"; 
+              State.printf s "logic programming finished@,@?";
               ()
              end
-         
+
     | Holes.LFInfo ->
        let { lfGoal; cPsi; lfSolution } = h.info in
        assert (lfSolution = None);
@@ -229,7 +229,7 @@ let process_command
        with
        | Logic.Frontend.Done ->
           State.printf s "logic programming finished@,@?";
-          () 
+          ()
   in
 
   let { cD; cG; cIH } = g.context in

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -198,6 +198,7 @@ let process_command
               h.info.compSolution <- Some e; 
               raise Logic.Frontend.Done
             end
+            (Some 999)
         with
           | Logic.Frontend.Done ->
               State.printf s "logic programming finished@,@?"; 

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -172,15 +172,6 @@ let process_command
         (HoleId.string_of_name_or_id (h.Holes.name, id))
       end;
     let { name; Holes.cD = cDh; info; _ } = h in
-    let rec cGtoList gctx cG =
-      (* Turn the Computation assumptions into a list of comp goals *)
-      match gctx with
-      | LF.Empty -> []
-      | LF.Dec (gctx', CTypDecl (name, typ, wf_tag)) ->
-         let c_g = Logic.Convert.comptypToCompGoal typ in
-         let cG' =  c_g :: cG in
-         cGtoList gctx' cG'
-    in
     match w with 
     | Holes.CompInfo ->
       begin
@@ -190,7 +181,6 @@ let process_command
                  useable assumptions since they aren't currently being used.
                  Can we unbox them- placing them in our meta-context?  *)
         in
-        let cG' = cGtoList cGh [] in
         assert (compSolution = None);
         let typ = Whnf.cnormCTyp compGoal in
         dprintf
@@ -203,11 +193,11 @@ let process_command
           Logic.Convert.comptypToMQuery (typ,0)
         in
            try
-          Logic.CSolver.cgSolve cG' cDh mquery
+          Logic.CSolver.cgSolve cDh cGh [] mquery
             begin
-              fun cD (cPsi, tM) ->
-            State.printf s "found solution: @[%a@]@,@?"
-              (P.fmt_ppr_lf_normal cD cPsi P.l0) tM;
+              fun cD cG tM ->
+(*            State.printf s "found solution: @[%a@]@,@?"
+              (P.fmt_ppr_lf_normal cD LF.Null P.l0) tM;  *)
            (* TODO:: How to add a solution to compSolution??
                      Will need to convert term into type exp_chk *)
            (*

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -195,14 +195,11 @@ let process_command
            try
           Logic.CSolver.cgSolve cDh cGh mquery
             begin
-              fun cD cG tM ->
-(*            State.printf s "found solution: @[%a@]@,@?"
-              (P.fmt_ppr_lf_normal cD LF.Null P.l0) tM;  *)
-           (* TODO:: How to add a solution to compSolution??
-                     Will need to convert term into type exp_chk *)
-           (*
-           h.info.compSolution <- Some (tM, LF.Shift 0); *)
-            raise Logic.Frontend.Done
+              fun e ->
+              State.printf s "found solution: @[%a@]@,@?"
+                (P.fmt_ppr_cmp_exp_chk cDh cGh P.l0) e;           
+              h.info.compSolution <- Some e; 
+              raise Logic.Frontend.Done
             end
         with
           | Logic.Frontend.Done ->

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -204,7 +204,6 @@ let process_command
               State.printf s "logic programming finished@,@?";
               ()
              end
-
     | Holes.LFInfo ->
        let { lfGoal; cPsi; lfSolution } = h.info in
        assert (lfSolution = None);

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -193,7 +193,7 @@ let process_command
           Logic.Convert.comptypToMQuery (typ,0)
         in
            try
-          Logic.CSolver.cgSolve cDh cGh [] mquery
+          Logic.CSolver.cgSolve cDh cGh mquery
             begin
               fun cD cG tM ->
 (*            State.printf s "found solution: @[%a@]@,@?"
@@ -203,14 +203,23 @@ let process_command
            (*
            h.info.compSolution <- Some (tM, LF.Shift 0); *)
             raise Logic.Frontend.Done
-            end 
+            end
+            begin
+                fun (s,xs,tA) (cPsi, tM) ->
+  (*            State.printf s "found solution: @[%a@]@,@?"
+                (P.fmt_ppr_lf_normal cD LF.Null P.l0) tM;  *)
+             (* TODO:: How to add a solution to compSolution??
+                       Will need to convert term into type exp_chk *)
+             (*
+             h.info.compSolution <- Some (tM, LF.Shift 0); *)
+              raise Logic.Frontend.Done
+              end 
         with
           | Logic.Frontend.Done ->
               State.printf s "logic programming finished@,@?"; 
               ()
-         end
-       
-  
+             end
+         
     | Holes.LFInfo ->
        let { lfGoal; cPsi; lfSolution } = h.info in
        assert (lfSolution = None);

--- a/src/harpoon/prover.ml
+++ b/src/harpoon/prover.ml
@@ -204,16 +204,6 @@ let process_command
            h.info.compSolution <- Some (tM, LF.Shift 0); *)
             raise Logic.Frontend.Done
             end
-            begin
-                fun (s,xs,tA) (cPsi, tM) ->
-  (*            State.printf s "found solution: @[%a@]@,@?"
-                (P.fmt_ppr_lf_normal cD LF.Null P.l0) tM;  *)
-             (* TODO:: How to add a solution to compSolution??
-                       Will need to convert term into type exp_chk *)
-             (*
-             h.info.compSolution <- Some (tM, LF.Shift 0); *)
-              raise Logic.Frontend.Done
-              end 
         with
           | Logic.Frontend.Done ->
               State.printf s "logic programming finished@,@?"; 


### PR DESCRIPTION
### Changes
- queries now accept a LF.mctx as an argument
- new signature declaration for mquery; similar to query but has added depth bound (e.g. ` --mquery <expected> <tries> <depth> <comp_typ>`)
     - Accepts the following comp_typ's:  Comp.TypBase, Comp.TypBox, Comp.TypPiBox, and Comp.TypArr 
- examples have been added to examples/aps to test mquery
- module CSolver added to logic.ml
     - in addition to the LF signature being processed, the Comp signature (including constants and theorems) is now also processed; each declaration is transformed into a clause whose structure allows easy access to the head of the type and meta-variables that require instantiation
     - mqueries are transformed into a sgnMQuery record
     - `msolve` is called on each sgnMQuery; it creates the success-continuation function which, when called, will check the synthesized proof term against the synthesized meta-sub (containing instantiations for the MVars) applied to the queried type as well as ensure that the number of solutions found doesn't exceed the tries bound
     - the proof-search loop `cgSolve` is then called to find a proof term; each recursive call to `cgSolve` will increment the current depth count by 1
     - `cgSolve` follows a uniform/ focusing proof loop; first we enter into the uniform right phase which collects global and local assumptions, adding them to cD and cG (and cPool) respectively
     - cPool holds our dynamic assumptions, that is, the current state of cG; an assumption is considered part of cG when it is tagged with **boxed** in cPool
     - we then enter the uniform left phase where local-boxed assumptions are unboxed and put into the cD (thus no longer considered to be in cG)
     - we enter into the focusing phase, which depending on the goal type can go several ways; we either enter into proof search on the LF level (for box-types), focus on the comp. signature (for atomic-types), focus on comp. theorems, or on assumptions from cPool
     - in each of the focusing cases we focus on an assumption whose head matches our goal; a meta-sub is created for the matched assumption containing the MVars that require instantiation and the head and type are then unified
     - if the assumption has a non-empty list of subgoals, we proceed to solve them recursively, building our proof term using the success-continuation
   