### PR TITLE
Remove usages of lazy evaluation for flattening LF contexts

### DIFF
--- a/src/core/check.ml
+++ b/src/core/check.ml
@@ -402,7 +402,7 @@ module Comp = struct
        | Int.LF.(ClTyp (mT, cPsi)) -> (* when Context.containsSigma cPsi -> *)
           begin match mT with
           | Int.LF.(MTyp (Atom (_, a, _) as tA)) ->
-             let (flat_cPsi, lazy s_proj, lazy s_tup) = ConvSigma.gen_flattening cD cPsi in
+             let (flat_cPsi, s_proj, s_tup) = ConvSigma.gen_flattening cD cPsi in
              (* flat_cPsi |- s_tup : cPsi and cPsi |- s_proj : flat_cPsi *)
              dprintf begin fun p ->
              p.fmt "[apply unbox modifier] cPsi = %a \n s_tup = %a \n s_proj = %a"

--- a/src/core/convSigma.ml
+++ b/src/core/convSigma.ml
@@ -480,6 +480,6 @@ let etaExpandMPVstr =
 
 let gen_flattening cD cPsi =
   let (cPhi, conv_list) = flattenDCtx cD cPsi in
-  let s_proj = lazy (gen_proj_sub conv_list) in
-  let s_tup = lazy (gen_tup_sub conv_list) in
+  let s_proj = gen_proj_sub conv_list in
+  let s_tup = gen_tup_sub conv_list in
   (cPhi, s_proj, s_tup)

--- a/src/core/convSigma.mli
+++ b/src/core/convSigma.mli
@@ -33,11 +33,9 @@ val etaExpandMMVstr : Loc.t -> mctx -> dctx -> tclo -> Plicity.t -> Name.t optio
     strengthening its type. *)
 val etaExpandMPVstr : Loc.t -> mctx -> dctx -> tclo -> Plicity.t -> Name.t option -> Name.t list -> normal
 
-(** gen_flattening cD cPsi = (cPhi, lazy s_proj, lazy s_tup)
+(** gen_flattening cD cPsi = (cPhi, s_proj, s_tup)
     Generates a flattened LF context cPhi in which all blocks present
     in cPsi have been decomposed.
-    Packing and unpacking substitutions s_proj and s_tup are lazily
-    computed to mediate between the contexts.
     Specifically:
       if cD |- cPsi ctx
       then cD |- cPhi ctx such that
@@ -48,4 +46,4 @@ val etaExpandMPVstr : Loc.t -> mctx -> dctx -> tclo -> Plicity.t -> Name.t optio
     these substitutions *contain*; e.g. s_proj contains projections,
     so it takes us from the block context to the flat context.
  *)
-val gen_flattening : mctx -> dctx -> dctx * sub Lazy.t * sub Lazy.t
+val gen_flattening : mctx -> dctx -> dctx * sub * sub

--- a/src/core/coverage.ml
+++ b/src/core/coverage.ml
@@ -174,7 +174,7 @@ type refinement_cands =
       - cPhi' |- tQ' <= type
  *)
 let gen_str cD cPsi (LF.Atom (_, a, _) as tP) =
-  let (cPhi, lazy s_proj, lazy s_tup) = ConvSigma.gen_flattening cD cPsi in
+  let (cPhi, s_proj, s_tup) = ConvSigma.gen_flattening cD cPsi in
   (* cPsi |- s_proj          : cPhi
      cPhi |- s_tup           : cPsi
      cPhi |- tQ                       where cPsi |- tP !! tQ = [s_tup]tP !! *)

--- a/src/core/lfrecon.ml
+++ b/src/core/lfrecon.ml
@@ -1162,9 +1162,7 @@ and elTerm' recT cD cPsi r sP =
          | Pibox ->
             begin match tA with
             | Int.LF.Atom (_, a, _) ->
-               let (cPhi, lazy s_proj, lazy s_tup) =
-                 ConvSigma.gen_flattening cD cPsi
-               in
+               let (cPhi, s_proj, s_tup) = ConvSigma.gen_flattening cD cPsi in
                let tA' = Whnf.normTyp (tA, s_tup) in
                (*  cPsi |- s_proj : cPhi
                    cPhi |- s_tup : cPsi

--- a/src/core/reconstruct.ml
+++ b/src/core/reconstruct.ml
@@ -484,7 +484,7 @@ let rec elMCtx recT =
 
 
 let mgAtomicTyp cD cPsi a kK =
-  let (flat_cPsi, lazy s_proj, lazy s_tup) = gen_flattening cD cPsi in
+  let (flat_cPsi, s_proj, s_tup) = gen_flattening cD cPsi in
   (* cPsi |- s_proj : flat_cPsi *)
   (* flat_cPsi |- s_tup : cPsi *)
   dprintf

--- a/src/core/total.ml
+++ b/src/core/total.ml
@@ -907,7 +907,7 @@ bp: Generalization to support
  *)
 
 let convDCtxMod cD cPhi (* found *) cPsi (* expected *) =
-  let (cPsi', lazy s_proj, _) = ConvSigma.gen_flattening cD cPsi in
+  let (cPsi', s_proj, _s_tup) = ConvSigma.gen_flattening cD cPsi in
   dprintf
     begin fun p ->
     p.fmt "[convDCtxGenMod] - @[<v> (expected) cPsi = %a \n (expected) flat_cPsi = %a \n (found) cPhi = %a@]"

--- a/src/core/unify.ml
+++ b/src/core/unify.ml
@@ -169,7 +169,7 @@ let rec blockdeclInDctx =
         (P.fmt_ppr_lf_typ cD cPsi P.l0) (Whnf.normTyp (tP, s))
         (P.fmt_ppr_lf_dctx cD P.l0) cPsi
       end;
-    let (cPhi, lazy s_proj, lazy s_tup) = ConvSigma.gen_flattening cD cPsi in
+    let (cPhi, s_proj, s_tup) = ConvSigma.gen_flattening cD cPsi in
     (* let tQ = ConvSigma.strans_typ cD cPsi (tP, s) conv_list in*)
     let tQ = Whnf.normTyp (tP, Substitution.LF.comp s s_tup) in
     (*  cPsi |- s_proj : cPhi


### PR DESCRIPTION
This PR simplifies the function `ConvSigma.gen_flattening` by removing usages of lazy evaluation.

This undoes an optimization in `Total.convDCtxMod`. In that function, `s_tup` is unused. It was not being computed when using `lazy` because the OCaml destructuring pattern `_` would not force its evaluation. It is now eagerly computed.