### PR TITLE
Allow `--prefix`, `--infix` and `--postfix` pragmas to refer to later constant declarations

### DIFF
--- a/doc/userguide.tex
+++ b/doc/userguide.tex
@@ -2,6 +2,7 @@
 
 \usepackage[utf8x]{inputenc}
 \usepackage[T1]{fontenc}
+\usepackage{hyperref}
 
 \newcommand{\shellcmd}[1]{\\\indent\texttt{\# #1}\\}
 
@@ -410,13 +411,13 @@ LF term : type =
 \end{verbatim}
 
 \subsection{Operators}
-A type constructor which takes two arguments can be declared an infix operator using the \verb+--infix+ pragma.
-The \verb+--infix+ pragma is proceeded by the identifier of the operator which must match the identifier of the LF declaration to which it is applied.
-The association is specified next to be left, right, or non-associative.
+A term or type constructor which takes two arguments can be declared an infix operator using the \verb+--infix+ pragma.
+The \verb+--infix+ pragma is proceeded by the identifier of the operator which must match the identifier of the declaration to which it is applied.
+The association is specified next to be left-associative (\verb+left+), right-associative (\verb+right+), or non-associative (\verb+none+).
 Operator precedence is specified last as a natural number, delineated from largest to smallest such that the largest number takes the highest precedence.
 
 The precedence of ordinary prefix operators can be adjusted using the \verb+--prefix+ pragma which takes all the same arguments as \verb+--infix+ except associativity.
-Prefix operators default to the low precedence of -1 if none is specified.
+Prefix operators default to the low precedence of 0 if none is specified.
 
 The operator is treated as non-associative by default if no associativity is stated explicitly.
 The default associativity can be altered with the \verb+--assoc+ pragma.
@@ -424,11 +425,27 @@ The default associativity can be altered with the \verb+--assoc+ pragma.
 \textbf{Example:} A user may wish to declare \verb+app+ and \verb+lam+ as infix operators while ensuring that \verb+red+ has higher precedence.
 Seeing as no associativity was listed, \verb+lam+ takes the default associativity, here defined as \verb+right+.
 \begin{verbatim}
---assoc right
+--assoc right.
 
-app: term -> term -> term. --infix app none 1.
-lam: (term -> term) -> term. --infix lam 1.
+app: term -> term -> term. --infix app 1 none.
+lam: (term -> term) -> term. --prefix lam 1.
 red: term -> term --prefix red 2.
+\end{verbatim}
+
+Fixity pragmas for defining operators can be used immediately before a declaration, or after the declaration.
+The notation specified by a fixity pragma takes effect after the pragma.
+As such, the previous snippet could be declared equivalently as follows:
+\begin{verbatim}
+--assoc right.
+
+--infix app 1 none.
+--prefix lam 1.
+--prefix red 2.
+
+LF term : type =
+| app: term -> term -> term =
+| lam: (term -> term) -> term
+| red: term -> term;
 \end{verbatim}
 
 \subsection{Schemas and Context Variables}

--- a/src/core/index_state.ml
+++ b/src/core/index_state.ml
@@ -1147,6 +1147,10 @@ module Indexing_state = struct
           (Qualified_identifier.location qualified_identifier)
           (Error.composite_exception2 Expected_constant
              (actual_binding_exn qualified_identifier entry))
+    | exception exn ->
+        Error.raise_at1
+          (Qualified_identifier.location qualified_identifier)
+          exn
 
   let index_of_lf_type_constant state qualified_identifier =
     match lookup state qualified_identifier with

--- a/src/core/prettyint.ml
+++ b/src/core/prettyint.ml
@@ -1977,7 +1977,7 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
           module_identifier
     | Sgn.DefaultAssocPrag { associativity; location = _ } ->
         fprintf ppf "@\n--assoc %a.@\n" fmt_ppr_associativity associativity
-    | Sgn.PrefixFixityPrag { constant; precedence; location = _ } -> (
+    | Sgn.PrefixFixityPrag { constant; precedence; postponed = _; location = _ } -> (
         match precedence with
         | Option.Some precedence ->
             fprintf ppf "@\n--prefix %a %d.@\n" Qualified_identifier.pp
@@ -1986,7 +1986,7 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
             fprintf ppf "@\n--prefix %a.@\n" Qualified_identifier.pp constant
         )
     | Sgn.InfixFixityPrag
-        { constant; precedence; associativity; location = _ } -> (
+        { constant; precedence; associativity; postponed = _; location = _ } -> (
         match (precedence, associativity) with
         | Option.Some precedence, Option.Some associativity ->
             fprintf ppf "@\n--infix %a %d %a.@\n" Qualified_identifier.pp
@@ -1999,7 +1999,7 @@ module Make (R : Store.Cid.RENDERER) : Printer.Int.T = struct
               constant precedence
         | Option.None, Option.None ->
             fprintf ppf "@\n--infix %a.@\n" Qualified_identifier.pp constant)
-    | Sgn.PostfixFixityPrag { constant; precedence; location = _ } -> (
+    | Sgn.PostfixFixityPrag { constant; precedence; postponed = _; location = _ } -> (
         match precedence with
         | Option.Some precedence ->
             fprintf ppf "@\n--postfix %a %d.@\n" Qualified_identifier.pp

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -482,8 +482,9 @@ module Make
               Synint.Sgn.PostfixFixityPrag { location; constant; precedence }
           ; location = entry_location
           }
-    | _ ->
-        Error.raise_violation
+    | Ext.Signature.Entry.Pragma { location; _ }
+    | Ext.Signature.Entry.Declaration { location; _ } ->
+        Error.raise_violation ~location
           (Format.asprintf
              "[%s] unexpectedly encountered an entry that is neither a \
               fixity pragma nor a documentation comment"

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -325,6 +325,170 @@ module Make
         with_coverage_checking state ~location (fun state ->
             f state global_pragma')
 
+  (** [get_constant_declaration_identifier_if_can_have_fixity_pragma declaration]
+      is [Option.Some identifier] if [declaration] can have a fixity pragma
+      attached to it. In that case, a fixity pragma could be declared before
+      it, and it would apply to [declaration]. Such a pragma is called a
+      postponed fixity pragma. *)
+  and get_constant_declaration_identifier_if_can_have_fixity_pragma =
+    function
+    | Synext.Signature.Declaration.Typ { identifier; _ }
+    | Synext.Signature.Declaration.Const { identifier; _ }
+    | Synext.Signature.Declaration.CompTyp { identifier; _ }
+    | Synext.Signature.Declaration.CompCotyp { identifier; _ }
+    | Synext.Signature.Declaration.CompConst { identifier; _ }
+    | Synext.Signature.Declaration.CompTypAbbrev { identifier; _ }
+    | Synext.Signature.Declaration.Theorem { identifier; _ }
+    | Synext.Signature.Declaration.Proof { identifier; _ }
+    | Synext.Signature.Declaration.Val { identifier; _ } ->
+        Option.some identifier
+    | Synext.Signature.Declaration.CompDest _
+    | Synext.Signature.Declaration.Schema _
+    | Synext.Signature.Declaration.Recursive_declarations _
+    | Synext.Signature.Declaration.Module _ ->
+        Option.none
+
+  (** [fixable_constant_declaration_identifiers entry] is the set of
+      identifiers in [entry] to which a postponed fixity pragma can be
+      attached. [entry] is assumed to be the signature-level entry that
+      immediately follows a set of fixity pragmas. *)
+  and fixable_constant_declaration_identifiers = function
+    | Synext.Signature.Entry.Declaration
+        { declaration =
+            Synext.Signature.Declaration.Recursive_declarations
+              { declarations; _ }
+        ; _
+        } ->
+        (* Collect all the declaration identifiers in the group of mutually
+           recursive declarations that can have fixity pragmas attached to
+           them *)
+        List.fold_left
+          (fun identifier_set declaration ->
+            match
+              get_constant_declaration_identifier_if_can_have_fixity_pragma
+                declaration
+            with
+            | Option.None -> identifier_set
+            | Option.Some identifier ->
+                Identifier.Set.add identifier identifier_set)
+          Identifier.Set.empty
+          (List1.to_list declarations)
+    | Synext.Signature.Entry.Declaration { declaration; _ } -> (
+        (* Return the declaration identifier if it can have a fixity pragma
+           attached to it *)
+        match
+          get_constant_declaration_identifier_if_can_have_fixity_pragma
+            declaration
+        with
+        | Option.None -> Identifier.Set.empty
+        | Option.Some identifier -> Identifier.Set.singleton identifier)
+    | _ -> Identifier.Set.empty
+
+  (** [is_entry_fixity_pragma_or_comment entry] is [true] if and only if
+      [entry] is a fixity pragma or a documentation comment.
+
+      This predicate is used to determine which signature entries can be
+      skipped over when looking ahead to find which signature-level
+      declaration can a postponed fixity pragma be applied to. *)
+  and is_entry_fixity_pragma_or_comment = function
+    | Synext.Signature.Entry.Pragma
+        { pragma =
+            ( Synext.Signature.Pragma.Prefix_fixity _
+            | Synext.Signature.Pragma.Infix_fixity _
+            | Synext.Signature.Pragma.Postfix_fixity _ )
+        ; _
+        }
+    | Synext.Signature.Entry.Comment _ ->
+        true
+    | _ -> false
+
+  (** [reconstruct_postponable_fixity_pragma state applicable_constant_identifiers entry]
+      pretty-prints the fixity pragma or documentation comment [entry] with
+      respect to the pretty-printing state [state] and the set
+      [applicable_constant_identifiers] of identifiers in the signature-level
+      declaration that follows the pragma/comment.
+
+      If [entry] is a pragma whose constant is in
+      [applicable_constant_identifiers], then [entry] is a postponed fixity
+      pragma, and its application should wait until the later declaration is
+      in scope.
+
+      It is assumed that [entry] does not affect the lookahead for the target
+      declaration for a postponed fixity pragma. That is, [entry] must be a
+      prefix, infix or postfix fixity pragma, or a documentation comment. *)
+  and reconstruct_postponable_fixity_pragma state
+      applicable_constant_identifiers =
+    let is_constant_a_plain_identifier constant =
+      List.null (Qualified_identifier.namespaces constant)
+    in
+    let is_fixity_constant_postponed constant =
+      is_constant_a_plain_identifier constant
+      && Identifier.Set.mem
+           (Qualified_identifier.name constant)
+           applicable_constant_identifiers
+    in
+    function
+    | Synext.Signature.Entry.Comment _ as entry ->
+        reconstruct_signature_entry state entry
+    | Synext.Signature.Entry.Pragma
+        { pragma =
+            Synext.Signature.Pragma.Prefix_fixity
+              { constant; precedence; location }
+        ; location = entry_location
+        } ->
+        let add_notation =
+          if is_fixity_constant_postponed constant then
+            add_postponed_prefix_notation
+          else add_prefix_notation
+        in
+        add_notation state ?precedence constant;
+        Synint.Sgn.Pragma
+          { pragma =
+              Synint.Sgn.PrefixFixityPrag { location; constant; precedence }
+          ; location = entry_location
+          }
+    | Synext.Signature.Entry.Pragma
+        { pragma =
+            Synext.Signature.Pragma.Infix_fixity
+              { constant; precedence; associativity; location }
+        ; location = entry_location
+        } ->
+        let add_notation =
+          if is_fixity_constant_postponed constant then
+            add_postponed_infix_notation
+          else add_infix_notation
+        in
+        add_notation state ?precedence ?associativity constant;
+        Synint.Sgn.Pragma
+          { pragma =
+              Synint.Sgn.InfixFixityPrag
+                { location; constant; precedence; associativity }
+          ; location = entry_location
+          }
+    | Synext.Signature.Entry.Pragma
+        { pragma =
+            Synext.Signature.Pragma.Postfix_fixity
+              { constant; precedence; location }
+        ; location = entry_location
+        } ->
+        let add_notation =
+          if is_fixity_constant_postponed constant then
+            add_postponed_postfix_notation
+          else add_postfix_notation
+        in
+        add_notation state ?precedence constant;
+        Synint.Sgn.Pragma
+          { pragma =
+              Synint.Sgn.PostfixFixityPrag { location; constant; precedence }
+          ; location = entry_location
+          }
+    | _ ->
+        Error.raise_violation
+          (Format.asprintf
+             "[%s] unexpectedly encountered an entry that is neither a \
+              fixity pragma nor a documentation comment"
+             __FUNCTION__)
+
   (** [reconstruct_signature_entries entries] reconstructs a list of
       signature entries. This in particular handles the reconstruction of
       entries that are not handled independently from one another, such as
@@ -361,6 +525,36 @@ module Make
                     Format.fprintf ppf
                       "Reconstruction fails for --not'd declaration@\n");
                 reconstruct_signature_entries state entries))
+    | Synext.Signature.Entry.Pragma
+        { pragma =
+            ( Synext.Signature.Pragma.Prefix_fixity _
+            | Synext.Signature.Pragma.Infix_fixity _
+            | Synext.Signature.Pragma.Postfix_fixity _ )
+        ; _
+        }
+      :: _ as entries -> (
+        (* Special case of pretty-printing where the fixity pragma may apply
+           to a constant declared subsequently after the pragma *)
+        match List.take_while is_entry_fixity_pragma_or_comment entries with
+        | _, [] -> reconstruct_signature_entries state entries
+        | pragmas_and_comments, entry :: entries ->
+            let applicable_constant_identifiers =
+              fixable_constant_declaration_identifiers entry
+            in
+            (* The fixity pragmas in [pragmas_and_comments] whose identifiers
+               are in [applicable_constant_identifiers] are postponed fixity
+               pragmas *)
+            let pragmas_and_comments' =
+              traverse_list state
+                (fun state ->
+                  reconstruct_postponable_fixity_pragma state
+                    applicable_constant_identifiers)
+                pragmas_and_comments
+            in
+            let entries' =
+              reconstruct_signature_entries state (entry :: entries)
+            in
+            pragmas_and_comments' @ entries')
     | entry :: entries ->
         let entry' = reconstruct_signature_entry state entry in
         let entries' = reconstruct_signature_entries state entries in
@@ -410,17 +604,17 @@ module Make
         Synint.Sgn.DefaultAssocPrag { associativity; location }
     | Synext.Signature.Pragma.Prefix_fixity
         { location; constant; precedence } ->
-        set_operator_prefix state ~location ?precedence constant;
+        add_prefix_notation state ~location ?precedence constant;
         Synint.Sgn.PrefixFixityPrag { location; constant; precedence }
     | Synext.Signature.Pragma.Infix_fixity
         { location; constant; precedence; associativity } ->
-        set_operator_infix state ~location ?precedence ?associativity
+        add_infix_notation state ~location ?precedence ?associativity
           constant;
         Synint.Sgn.InfixFixityPrag
           { location; constant; precedence; associativity }
     | Synext.Signature.Pragma.Postfix_fixity
         { location; constant; precedence } ->
-        set_operator_postfix state ~location ?precedence constant;
+        add_postfix_notation state ~location ?precedence constant;
         Synint.Sgn.PostfixFixityPrag { location; constant; precedence }
     | Synext.Signature.Pragma.Open_module { location; module_identifier } ->
         freeze_all_unfrozen_declarations state;

--- a/src/core/recsgn.ml
+++ b/src/core/recsgn.ml
@@ -722,6 +722,7 @@ module Make
       Store.Cid.Typ.add (fun _cid -> Store.Cid.Typ.mk_entry name tK' i)
     in
     add_lf_type_constant state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.Typ { location; identifier; cid; kind = tK' }
 
   and reconstruct_lf_const_declaration state location identifier extT =
@@ -781,6 +782,7 @@ module Make
           Store.Cid.Term.mk_entry name tA' i)
     in
     add_lf_term_constant state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.Const { location; identifier; cid; typ = tA' }
 
   and reconstruct_comp_typ_constant state location identifier kind
@@ -835,6 +837,7 @@ module Make
         add_comp_stratified_type_constant state ~location identifier cid
     | `Inductive ->
         add_comp_inductive_type_constant state ~location identifier cid);
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.CompTyp
       { location; identifier; cid; kind = cK'; positivity_flag = p }
 
@@ -885,6 +888,7 @@ module Make
           Store.Cid.CompCotyp.mk_entry name cK' i)
     in
     add_comp_cotype_constant state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.CompCotyp { location; identifier; cid; kind = cK' }
 
   and reconstruct_comp_constructor state location ~stratNum identifier typ =
@@ -952,6 +956,7 @@ module Make
           Store.Cid.CompConst.mk_entry name tau' i)
     in
     add_comp_constructor state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.CompConst { location; identifier; cid; typ = tau' }
 
   and reconstruct_comp_destructor state location identifier observation_type
@@ -1083,6 +1088,7 @@ module Make
           Store.Cid.CompTypDef.mk_entry name i (cD, cT) cK)
     in
     add_comp_typedef state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.CompTypAbbrev
       { location; identifier; cid; kind = cK; typ = cT }
 
@@ -1145,6 +1151,7 @@ module Make
           Store.Cid.Comp.mk_entry name tau' 0 mgid value_opt)
     in
     add_comp_val state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.Val
       { location
       ; identifier
@@ -1216,6 +1223,7 @@ module Make
           Store.Cid.Comp.mk_entry name tau' 0 mgid value_opt)
     in
     add_comp_val state ~location identifier cid;
+    apply_postponed_fixity_pragmas_for_constant state identifier;
     Synint.Sgn.Val
       { location
       ; identifier
@@ -1653,6 +1661,7 @@ module Make
             Store.Cid.Comp.mk_entry name tau' 0 total_decs Option.none)
       in
       add_prog state identifier cid;
+      apply_postponed_fixity_pragmas_for_constant state identifier;
       cid
     in
 

--- a/src/core/recsgn_state.ml
+++ b/src/core/recsgn_state.ml
@@ -253,18 +253,18 @@ struct
       determined where the pragma is declared, hence why those fields are not
       optional like in the external syntax. *)
   type postponed_fixity_pragma =
-    | Prefix_fixity of
+    | Postponed_prefix_fixity of
         { location : Location.t Option.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t
         }
-    | Infix_fixity of
+    | Postponed_infix_fixity of
         { location : Location.t Option.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t
         ; associativity : Associativity.t
         }
-    | Postfix_fixity of
+    | Postponed_postfix_fixity of
         { location : Location.t Option.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t
@@ -522,33 +522,33 @@ struct
   let add_postponed_prefix_notation state ?location ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     add_postponed_notation state
-      (Prefix_fixity { location; precedence; constant })
+      (Postponed_prefix_fixity { location; precedence; constant })
 
   let add_postponed_infix_notation state ?location ?precedence ?associativity
       constant =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     add_postponed_notation state
-      (Infix_fixity { location; precedence; associativity; constant })
+      (Postponed_infix_fixity { location; precedence; associativity; constant })
 
   let add_postponed_postfix_notation state ?location ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     add_postponed_notation state
-      (Postfix_fixity { location; precedence; constant })
+      (Postponed_postfix_fixity { location; precedence; constant })
 
   let postponed_fixity_pragma_identifier = function
-    | Prefix_fixity { constant; _ }
-    | Infix_fixity { constant; _ }
-    | Postfix_fixity { constant; _ } ->
+    | Postponed_prefix_fixity { constant; _ }
+    | Postponed_infix_fixity { constant; _ }
+    | Postponed_postfix_fixity { constant; _ } ->
         Qualified_identifier.name constant
 
   let apply_postponed_fixity_pragma state = function
-    | Prefix_fixity { location; constant; precedence } ->
+    | Postponed_prefix_fixity { location; constant; precedence } ->
         add_prefix_notation state ?location ~precedence constant
-    | Infix_fixity { location; constant; precedence; associativity } ->
+    | Postponed_infix_fixity { location; constant; precedence; associativity } ->
         add_infix_notation state ?location ~precedence ~associativity
           constant
-    | Postfix_fixity { location; constant; precedence } ->
+    | Postponed_postfix_fixity { location; constant; precedence } ->
         add_postfix_notation state ?location ~precedence constant
 
   let apply_postponed_fixity_pragmas state =

--- a/src/core/recsgn_state.ml
+++ b/src/core/recsgn_state.ml
@@ -251,7 +251,7 @@ struct
   (** The type of fixity pragmas that are postponed to be applied at a later
       point. The default precedence and associativity to be used are
       determined where the pragma is declared, hence why those fields are not
-      optional like in the parser syntax. *)
+      optional like in the external syntax. *)
   type postponed_fixity_pragma =
     | Prefix_fixity of
         { location : Location.t Option.t

--- a/src/core/recsgn_state.mli
+++ b/src/core/recsgn_state.mli
@@ -61,14 +61,14 @@ module type SIGNATURE_RECONSTRUCTION_STATE = sig
 
   val get_default_precedence : state -> Int.t
 
-  val set_operator_prefix :
+  val add_prefix_notation :
        state
     -> ?location:Location.t
     -> ?precedence:Int.t
     -> Qualified_identifier.t
     -> Unit.t
 
-  val set_operator_infix :
+  val add_infix_notation :
        state
     -> ?location:Location.t
     -> ?precedence:Int.t
@@ -76,12 +76,64 @@ module type SIGNATURE_RECONSTRUCTION_STATE = sig
     -> Qualified_identifier.t
     -> Unit.t
 
-  val set_operator_postfix :
+  val add_postfix_notation :
        state
     -> ?location:Location.t
     -> ?precedence:Int.t
     -> Qualified_identifier.t
     -> Unit.t
+
+  (** [add_postponed_prefix_notation state ?location ?precedence identifier]
+      adds a postponed prefix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_prefix_notation :
+       state
+    -> ?location:Location.t
+    -> ?precedence:Int.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  (** [add_postponed_infix_notation state ?location ?precedence ?associativity identifier]
+      adds a postponed infix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead. Likewise, if [associativity = Option.None], then
+      {!get_default_associativity} is used instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_infix_notation :
+       state
+    -> ?location:Location.t
+    -> ?precedence:Int.t
+    -> ?associativity:Associativity.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  (** [add_postponed_postfix_notation state ?location ?precedence identifier]
+      adds a postponed postfix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_postfix_notation :
+       state
+    -> ?location:Location.t
+    -> ?precedence:Int.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  (** [apply_postponed_fixity_pragmas state] adds in scope the postponed
+      prefix, infix and postfix fixity pragmas. This function should be
+      called only when the targets of those postponed pragmas are in scope.
+      That is, postponed fixity pragmas are applied after the subsequent
+      declaration is added, or after a group of mutually recursive
+      declarations are added. *)
+  val apply_postponed_fixity_pragmas : state -> unit
 
   val open_module :
     state -> ?location:Location.t -> Qualified_identifier.t -> Unit.t

--- a/src/core/recsgn_state.mli
+++ b/src/core/recsgn_state.mli
@@ -135,6 +135,12 @@ module type SIGNATURE_RECONSTRUCTION_STATE = sig
       declarations are added. *)
   val apply_postponed_fixity_pragmas : state -> unit
 
+  (** [apply_postponed_fixity_pragmas_for_constant state identifier] adds in
+      scope the postponed fixity pragmas for the constant having identifier
+      [identifier]. *)
+  val apply_postponed_fixity_pragmas_for_constant :
+    state -> Identifier.t -> unit
+
   val open_module :
     state -> ?location:Location.t -> Qualified_identifier.t -> Unit.t
 

--- a/src/html/synext_html_pp.ml
+++ b/src/html/synext_html_pp.ml
@@ -2169,6 +2169,25 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
     | Associativity.Right_associative -> pp_string state "right"
     | Associativity.Non_associative -> pp_string state "none"
 
+  let apply_signature_pragma state pragma =
+    match pragma with
+    | Signature.Pragma.Name _ -> ()
+    | Signature.Pragma.Default_associativity { associativity; _ } ->
+        set_default_associativity state associativity
+    | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
+        make_prefix state ?precedence constant
+    | Signature.Pragma.Infix_fixity
+        { constant; precedence; associativity; _ } ->
+        make_infix state ?precedence ?associativity constant
+    | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
+        make_postfix state ?precedence constant
+    | Signature.Pragma.Not _ -> ()
+    | Signature.Pragma.Open_module { module_identifier; _ } ->
+        open_module state module_identifier
+    | Signature.Pragma.Abbreviation { module_identifier; abbreviation; _ } ->
+        add_abbreviation state module_identifier abbreviation
+    | Signature.Pragma.Query _ -> ()
+
   let rec pp_signature_pragma state pragma =
     match pragma with
     | Signature.Pragma.Name
@@ -2196,8 +2215,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
               pp_associativity state associativity;
               pp_dot state)
         in
-        pp_pragma state "assoc" pp_associativity_pragma;
-        set_default_associativity state associativity
+        pp_pragma state "assoc" pp_associativity_pragma
     | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
         let pp_prefix_pragma state =
           pp_hovbox state ~indent (fun state ->
@@ -2211,8 +2229,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
                 precedence;
               pp_dot state)
         in
-        pp_pragma state "prefix" pp_prefix_pragma;
-        make_prefix state ?precedence constant
+        pp_pragma state "prefix" pp_prefix_pragma
     | Signature.Pragma.Infix_fixity
         { constant; precedence; associativity; _ } ->
         let pp_infix_pragma state =
@@ -2232,8 +2249,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
                 associativity;
               pp_dot state)
         in
-        pp_pragma state "infix" pp_infix_pragma;
-        make_infix state ?precedence ?associativity constant
+        pp_pragma state "infix" pp_infix_pragma
     | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
         let pp_postfix_pragma state =
           pp_hovbox state ~indent (fun state ->
@@ -2247,8 +2263,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
                 precedence;
               pp_dot state)
         in
-        pp_pragma state "postfix" pp_postfix_pragma;
-        make_postfix state ?precedence constant
+        pp_pragma state "postfix" pp_postfix_pragma
     | Signature.Pragma.Not _ ->
         let pp_not_pragma state = pp_string state "--not" in
         pp_pragma state "not" pp_not_pragma
@@ -2260,8 +2275,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
               pp_constant_invoke state module_identifier;
               pp_dot state)
         in
-        pp_pragma state "open" pp_open_pragma;
-        open_module state module_identifier
+        pp_pragma state "open" pp_open_pragma
     | Signature.Pragma.Abbreviation { module_identifier; abbreviation; _ } ->
         let pp_abbrev_pragma state =
           pp_hovbox state ~indent (fun state ->
@@ -2272,8 +2286,7 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
               pp_identifier state abbreviation;
               pp_dot state)
         in
-        pp_pragma state "abbrev" pp_abbrev_pragma;
-        add_abbreviation state module_identifier abbreviation
+        pp_pragma state "abbrev" pp_abbrev_pragma
     | Signature.Pragma.Query
         { identifier; typ; expected_solutions; maximum_tries; _ } ->
         let pp_query_argument state argument_opt =
@@ -2898,7 +2911,8 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
     | Signature.Entry.Declaration { declaration; _ } ->
         pp_signature_declaration state declaration
     | Signature.Entry.Pragma { pragma; _ } ->
-        pp_signature_pragma state pragma
+        pp_signature_pragma state pragma;
+        apply_signature_pragma state pragma
     | Signature.Entry.Comment { location; content } ->
         let html = render_markdown location content in
         pp_string state html

--- a/src/html/synext_html_pp.ml
+++ b/src/html/synext_html_pp.ml
@@ -2175,12 +2175,12 @@ module Make_html_printer (Html_printing_state : HTML_PRINTING_STATE) = struct
     | Signature.Pragma.Default_associativity { associativity; _ } ->
         set_default_associativity state associativity
     | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
-        make_prefix state ?precedence constant
+        add_prefix_notation state ?precedence constant
     | Signature.Pragma.Infix_fixity
         { constant; precedence; associativity; _ } ->
-        make_infix state ?precedence ?associativity constant
+        add_infix_notation state ?precedence ?associativity constant
     | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
-        make_postfix state ?precedence constant
+        add_postfix_notation state ?precedence constant
     | Signature.Pragma.Not _ -> ()
     | Signature.Pragma.Open_module { module_identifier; _ } ->
         open_module state module_identifier

--- a/src/html/synext_html_pp_state.ml
+++ b/src/html/synext_html_pp_state.ml
@@ -224,16 +224,16 @@ module Html_printing_state = struct
       determined where the pragma is declared, hence why those fields are not
       optional like in the external syntax. *)
   type postponed_fixity_pragma =
-    | Prefix_fixity of
+    | Postponed_prefix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
-    | Infix_fixity of
+    | Postponed_infix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         ; associativity : Associativity.t
         }
-    | Postfix_fixity of
+    | Postponed_postfix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
@@ -583,26 +583,28 @@ module Html_printing_state = struct
 
   let add_postponed_prefix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Prefix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_prefix_fixity { precedence; constant })
 
   let add_postponed_infix_notation state ?precedence ?associativity constant
       =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     add_postponed_notation state
-      (Infix_fixity { precedence; associativity; constant })
+      (Postponed_infix_fixity { precedence; associativity; constant })
 
   let add_postponed_postfix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Postfix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_postfix_fixity { precedence; constant })
 
   let apply_postponed_fixity_pragmas =
     let apply_postponed_fixity_pragma state = function
-      | Prefix_fixity { constant; precedence } ->
+      | Postponed_prefix_fixity { constant; precedence } ->
           add_prefix_notation state ~precedence constant
-      | Infix_fixity { constant; precedence; associativity } ->
+      | Postponed_infix_fixity { constant; precedence; associativity } ->
           add_infix_notation state ~precedence ~associativity constant
-      | Postfix_fixity { constant; precedence } ->
+      | Postponed_postfix_fixity { constant; precedence } ->
           add_postfix_notation state ~precedence constant
     in
     fun state ->

--- a/src/html/synext_html_pp_state.ml
+++ b/src/html/synext_html_pp_state.ml
@@ -69,17 +69,17 @@ module type HTML_PRINTING_STATE = sig
     -> (state -> 'a)
     -> 'a
 
-  val make_prefix :
+  val add_prefix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
-  val make_infix :
+  val add_infix_notation :
        state
     -> ?precedence:Int.t
     -> ?associativity:Associativity.t
     -> Qualified_identifier.t
     -> Unit.t
 
-  val make_postfix :
+  val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
   val lookup_operator :
@@ -188,9 +188,9 @@ module Entry = struct
   let make_module_entry ?location:_ ~page ~id _identifier =
     { reference = Html_reference.make ~page ~id; operator = Option.none }
 
-  let[@warning "-23"] modify_operator f entry =
+  let modify_operator f entry =
     let operator' = f entry.operator in
-    { entry with operator = operator' }
+    { entry with operator = operator' } [@warning "-23"]
 end
 
 module Html_printing_state = struct
@@ -484,18 +484,18 @@ module Html_printing_state = struct
             declarations
         else ()
 
-  let[@warning "-23"] make_prefix state ?precedence constant =
+  let add_prefix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_prefix ~precedence))
 
-  let[@warning "-23"] make_infix state ?precedence ?associativity constant =
+  let add_infix_notation state ?precedence ?associativity constant =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_infix ~precedence ~associativity))
 
-  let[@warning "-23"] make_postfix state ?precedence constant =
+  let add_postfix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_postfix ~precedence))

--- a/src/html/synext_html_pp_state.mli
+++ b/src/html/synext_html_pp_state.mli
@@ -115,16 +115,16 @@ module type HTML_PRINTING_STATE = sig
     -> (state -> 'a)
     -> 'a
 
-  (** [make_prefix state ?precedence constant] sets [constant] as a prefix
-      operator with precedence [p] if [precedence = Option.Some p], or
+  (** [add_prefix_notation state ?precedence constant] sets [constant] as a
+      prefix operator with precedence [p] if [precedence = Option.Some p], or
       [state]'s default precedence if [precedence = Option.None].
 
       If [constant] is unbound in [state], then an exception is raised. *)
-  val make_prefix :
+  val add_prefix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
-  (** [make_infix state ?precedence ?associativity constant] sets [constant]
-      as an infix operator with:
+  (** [add_infix_notation state ?precedence ?associativity constant] sets
+      [constant] as an infix operator with:
 
       - precedence [p] if [precedence = Option.Some p], or [state]'s default
         precedence if [precedence = Option.None].
@@ -132,19 +132,19 @@ module type HTML_PRINTING_STATE = sig
         default associativity if [associativity = Option.None].
 
       If [constant] is unbound in [state], then an exception is raised. *)
-  val make_infix :
+  val add_infix_notation :
        state
     -> ?precedence:Int.t
     -> ?associativity:Associativity.t
     -> Qualified_identifier.t
     -> Unit.t
 
-  (** [make_postfix state ?precedence constant] sets [constant] as a postfix
-      operator with precedence [p] if [precedence = Option.Some p], or
-      [state]'s default precedence if [precedence = Option.None].
+  (** [add_postfix_notation state ?precedence constant] sets [constant] as a
+      postfix operator with precedence [p] if [precedence = Option.Some p],
+      or [state]'s default precedence if [precedence = Option.None].
 
       If [constant] is unbound, then an exception is raised. *)
-  val make_postfix :
+  val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
   (** [lookup_operator state constant] is the operator description

--- a/src/parser/disambiguation_state.ml
+++ b/src/parser/disambiguation_state.ml
@@ -1372,7 +1372,7 @@ module Disambiguation_state = struct
           add_postfix_notation state ~precedence constant
     in
     fun state ->
-      List.iter
+      List.iter_rev
         (apply_postponed_fixity_pragma state)
         state.postponed_fixity_pragmas;
       state.postponed_fixity_pragmas <- []

--- a/src/parser/disambiguation_state.ml
+++ b/src/parser/disambiguation_state.ml
@@ -808,16 +808,16 @@ module Disambiguation_state = struct
       determined where the pragma is declared, hence why those fields are not
       optional like in the parser syntax. *)
   type postponed_fixity_pragma =
-    | Prefix_fixity of
+    | Postponed_prefix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
-    | Infix_fixity of
+    | Postponed_infix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         ; associativity : Associativity.t
         }
-    | Postfix_fixity of
+    | Postponed_postfix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
@@ -1349,26 +1349,28 @@ module Disambiguation_state = struct
 
   let add_postponed_prefix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Prefix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_prefix_fixity { precedence; constant })
 
   let add_postponed_infix_notation state ?precedence ?associativity constant
       =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     add_postponed_notation state
-      (Infix_fixity { precedence; associativity; constant })
+      (Postponed_infix_fixity { precedence; associativity; constant })
 
   let add_postponed_postfix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Postfix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_postfix_fixity { precedence; constant })
 
   let apply_postponed_fixity_pragmas =
     let apply_postponed_fixity_pragma state = function
-      | Prefix_fixity { constant; precedence } ->
+      | Postponed_prefix_fixity { constant; precedence } ->
           add_prefix_notation state ~precedence constant
-      | Infix_fixity { constant; precedence; associativity } ->
+      | Postponed_infix_fixity { constant; precedence; associativity } ->
           add_infix_notation state ~precedence ~associativity constant
-      | Postfix_fixity { constant; precedence } ->
+      | Postponed_postfix_fixity { constant; precedence } ->
           add_postfix_notation state ~precedence constant
     in
     fun state ->

--- a/src/parser/disambiguation_state.mli
+++ b/src/parser/disambiguation_state.mli
@@ -563,6 +563,49 @@ module type DISAMBIGUATION_STATE = sig
   val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
+  (** [add_postponed_prefix_notation state ?precedence identifier] adds a
+      postponed prefix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_prefix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  (** [add_postponed_infix_notation state ?precedence ?associativity identifier]
+      adds a postponed infix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead. Likewise, if [associativity = Option.None], then
+      {!get_default_associativity} is used instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_infix_notation :
+       state
+    -> ?precedence:Int.t
+    -> ?associativity:Associativity.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  (** [add_postponed_postfix_notation state ?precedence identifier] adds a
+      postponed postfix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_postfix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  (** [apply_postponed_fixity_pragmas state] adds in scope the postponed
+      prefix, infix and postfix fixity pragmas. This function should be
+      called only when the targets of those postponed pragmas are in scope.
+      That is, postponed fixity pragmas are applied after the subsequent
+      declaration is added, or after a group of mutually recursive
+      declarations are added. *)
+  val apply_postponed_fixity_pragmas : state -> unit
+
   (** [lookup_operator state identifier] is [Option.Some operator] if
       [identifier] is bound to an operator with descriptor [operator] in
       [state], and [Option.None] otherwise.

--- a/src/parser/signature_disambiguation.ml
+++ b/src/parser/signature_disambiguation.ml
@@ -346,17 +346,22 @@ struct
         { location; constant; precedence } ->
         add_prefix_notation state ?precedence constant;
         Synext.Signature.Pragma.Prefix_fixity
-          { location; constant; precedence }
+          { location; constant; precedence; postponed = false }
     | Synprs.Signature.Pragma.Infix_fixity
         { location; constant; precedence; associativity } ->
         add_infix_notation state ?precedence ?associativity constant;
         Synext.Signature.Pragma.Infix_fixity
-          { location; constant; precedence; associativity }
+          { location
+          ; constant
+          ; precedence
+          ; associativity
+          ; postponed = false
+          }
     | Synprs.Signature.Pragma.Postfix_fixity
         { location; constant; precedence } ->
         add_postfix_notation state ?precedence constant;
         Synext.Signature.Pragma.Postfix_fixity
-          { location; constant; precedence }
+          { location; constant; precedence; postponed = false }
     | Synprs.Signature.Pragma.Not { location } ->
         Synext.Signature.Pragma.Not { location }
     | Synprs.Signature.Pragma.Open_module { location; module_identifier } ->
@@ -768,16 +773,16 @@ struct
               { location; constant; precedence }
         ; location = entry_location
         } ->
+        let is_postponed = is_fixity_constant_postponed constant in
         let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_prefix_notation
+          if is_postponed then add_postponed_prefix_notation
           else add_prefix_notation
         in
         add_notation state ?precedence constant;
         Synext.Signature.Entry.Pragma
           { pragma =
               Synext.Signature.Pragma.Prefix_fixity
-                { location; constant; precedence }
+                { location; constant; precedence; postponed = is_postponed }
           ; location = entry_location
           }
     | Synprs.Signature.Entry.Raw_pragma
@@ -786,16 +791,21 @@ struct
               { location; constant; precedence; associativity }
         ; location = entry_location
         } ->
+        let is_postponed = is_fixity_constant_postponed constant in
         let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_infix_notation
+          if is_postponed then add_postponed_infix_notation
           else add_infix_notation
         in
         add_notation state ?precedence ?associativity constant;
         Synext.Signature.Entry.Pragma
           { pragma =
               Synext.Signature.Pragma.Infix_fixity
-                { location; constant; precedence; associativity }
+                { location
+                ; constant
+                ; precedence
+                ; associativity
+                ; postponed = is_postponed
+                }
           ; location = entry_location
           }
     | Synprs.Signature.Entry.Raw_pragma
@@ -804,16 +814,16 @@ struct
               { location; constant; precedence }
         ; location = entry_location
         } ->
+        let is_postponed = is_fixity_constant_postponed constant in
         let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_postfix_notation
+          if is_postponed then add_postponed_postfix_notation
           else add_postfix_notation
         in
         add_notation state ?precedence constant;
         Synext.Signature.Entry.Pragma
           { pragma =
               Synext.Signature.Pragma.Postfix_fixity
-                { location; constant; precedence }
+                { location; constant; precedence; postponed = is_postponed }
           ; location = entry_location
           }
     | Synprs.Signature.Entry.Raw_declaration { location; _ }

--- a/src/parser/signature_disambiguation.ml
+++ b/src/parser/signature_disambiguation.ml
@@ -441,14 +441,6 @@ struct
         Synext.Signature.Totality.Order.Simultaneous_ordering
           { location; arguments = arguments' }
 
-  and disambiguate_mutually_recursive_declarations state declarations =
-    iter_list1 state add_declaration declarations;
-    apply_postponed_fixity_pragmas state;
-    let declarations =
-      traverse_list1 state disambiguate_declaration declarations
-    in
-    declarations
-
   and disambiguate_declaration state = function
     | Synprs.Signature.Declaration.Raw_lf_typ_or_term_constant
         { location; identifier; typ_or_const }
@@ -631,8 +623,10 @@ struct
               (Duplicate_identifiers_recursive_declaration
                  (List1.map Pair.fst duplicates))
         | Option.None ->
+            iter_list1 state add_declaration declarations;
+            apply_postponed_fixity_pragmas state;
             let declarations' =
-              disambiguate_mutually_recursive_declarations state declarations
+              traverse_list1 state disambiguate_declaration declarations
             in
             Synext.Signature.Declaration.Recursive_declarations
               { location; declarations = declarations' })
@@ -829,12 +823,12 @@ struct
               fixity pragma nor a documentation comment"
              __FUNCTION__)
 
-  (** [disambiguate_entries state entries] is disambiguated list of entries
-      derived from [entries]. This function handles entry disambiguation for
-      entries that interact in special cases with other declarations.
-      Particularly, this determines whether a fixity pragma should apply to
-      an already declared constant, or if it should be postponed to be
-      applied to a constant declared later. *)
+  (** [disambiguate_entries state entries] is the disambiguated list of
+      entries derived from [entries]. This function handles entry
+      disambiguation for entries that interact in special cases with other
+      declarations. Particularly, this determines whether a fixity pragma
+      should apply to an already declared constant, or if it should be
+      postponed to be applied to a constant declared later. *)
   and disambiguate_entries state = function
     | Synprs.Signature.Entry.Raw_pragma
         { pragma =

--- a/src/parser/signature_disambiguation.ml
+++ b/src/parser/signature_disambiguation.ml
@@ -816,8 +816,9 @@ struct
                 { location; constant; precedence }
           ; location = entry_location
           }
-    | _ ->
-        Error.raise_violation
+    | Synprs.Signature.Entry.Raw_declaration { location; _ }
+    | Synprs.Signature.Entry.Raw_pragma { location; _ } ->
+        Error.raise_violation ~location
           (Format.asprintf
              "[%s] unexpectedly encountered an entry that is neither a \
               fixity pragma nor a documentation comment"

--- a/src/syntax/syncom/error.mli
+++ b/src/syntax/syncom/error.mli
@@ -23,13 +23,15 @@ val re_raise : exn -> 'a
 val raise_notrace : exn -> 'a
 
 (** [Violation message] is the exception signalling a programmer error, like
-    an unmet pre-condition. This exception variant should not be exported,
-    but it is incorrectly being used for backtracking with exceptions in the
-    core library. *)
+    an unmet pre-condition. FIXME: This exception variant should not be
+    exported, but it is incorrectly being used for backtracking with
+    exceptions in the core library. *)
 exception Violation of string
 
 (** [raise_violation ?location message] raises a violation exception with the
-    given [message] and [location]. *)
+    given [message] and [location]. A violation encountered at runtime
+    indicates that there is a bug in the implementation, such as a
+    pre-condition, post-condition or invariant not being upheld. *)
 val raise_violation : ?location:Location.t -> string -> 'a
 
 (** [located_exception locations cause] is a decorated exception having

--- a/src/syntax/synext/synext_definition.ml
+++ b/src/syntax/synext/synext_definition.ml
@@ -1487,21 +1487,29 @@ module Signature = struct
           { location : Location.t
           ; constant : Qualified_identifier.t
           ; precedence : Int.t Option.t
+          ; postponed : Bool.t
           }
-          (** [Prefix_fixity { constant = c; precedence; _ }] is the pragma
-              [--prefix c precedence.] for configuring the constant [c] to be
-              parsed as a prefix operator with [precedence].
+          (** [Prefix_fixity { constant = c; precedence; postponed; _ }] is
+              the pragma [--prefix c precedence.] for configuring the
+              constant [c] to be parsed as a prefix operator with
+              [precedence].
 
               If a precedence is already assigned to [c], and
               [precedence = Option.None], then the pre-existing precedence is
-              used. *)
+              used.
+
+              If [postponed = false], then the pragma is attached to a
+              constant declared earlier than the pragma. Otherwise, when
+              [postponed = true], then the pragma is attached to a constant
+              declared immediately after the pragma. *)
       | Infix_fixity of
           { location : Location.t
           ; constant : Qualified_identifier.t
           ; precedence : Int.t Option.t
           ; associativity : Associativity.t Option.t
+          ; postponed : Bool.t
           }
-          (** [Infix_fixity { constant = c; precedence; associativity; _ }]
+          (** [Infix_fixity { constant = c; precedence; associativity; postponed; _ }]
               is the pragma [--infix c precedence associativity.] for
               configuring the constant [c] to be parsed as an infix operator
               with [precedence] and [associativity].
@@ -1513,19 +1521,31 @@ module Signature = struct
                 defaults to the associativity configured by the
                 [--default_associativity assoc.] pragma, or
                 [Associativity.Non_associative] if that pragma was never
-                used. *)
+                used.
+
+              If [postponed = false], then the pragma is attached to a
+              constant declared earlier than the pragma. Otherwise, when
+              [postponed = true], then the pragma is attached to a constant
+              declared immediately after the pragma. *)
       | Postfix_fixity of
           { location : Location.t
           ; constant : Qualified_identifier.t
           ; precedence : Int.t Option.t
+          ; postponed : Bool.t
           }
-          (** [Postfix_fixity { constant = c; precedence; _ }] is the pragma
-              [--postfix c precedence.] for configuring the constant [c] to
-              be parsed as a postfix operator with [precedence].
+          (** [Postfix_fixity { constant = c; precedence; postponed; _ }] is
+              the pragma [--postfix c precedence.] for configuring the
+              constant [c] to be parsed as a postfix operator with
+              [precedence].
 
               If a precedence is already assigned to [c], and
               [precedence = Option.None], then the pre-existing precedence is
-              used. *)
+              used.
+
+              If [postponed = false], then the pragma is attached to a
+              constant declared earlier than the pragma. Otherwise, when
+              [postponed = true], then the pragma is attached to a constant
+              declared immediately after the pragma. *)
       | Not of { location : Location.t }
           (** [Not _] is the pragma [--not] which asserts that the
               declaration that follows it fails reconstruction. *)

--- a/src/syntax/synext/synext_pp.ml
+++ b/src/syntax/synext/synext_pp.ml
@@ -2041,6 +2041,25 @@ struct
     | Associativity.Right_associative -> pp_string state "right"
     | Associativity.Non_associative -> pp_string state "none"
 
+  let apply_signature_pragma state pragma =
+    match pragma with
+    | Signature.Pragma.Name _ -> ()
+    | Signature.Pragma.Default_associativity { associativity; _ } ->
+        set_default_associativity state associativity
+    | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
+        make_prefix state ?precedence constant
+    | Signature.Pragma.Infix_fixity
+        { constant; precedence; associativity; _ } ->
+        make_infix state ?precedence ?associativity constant
+    | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
+        make_postfix state ?precedence constant
+    | Signature.Pragma.Not _ -> ()
+    | Signature.Pragma.Open_module { module_identifier; _ } ->
+        open_module state module_identifier
+    | Signature.Pragma.Abbreviation { module_identifier; abbreviation; _ } ->
+        add_abbreviation state module_identifier abbreviation
+    | Signature.Pragma.Query _ -> ()
+
   let rec pp_signature_pragma state pragma =
     match pragma with
     | Signature.Pragma.Name
@@ -2062,8 +2081,7 @@ struct
             pp_string state "--assoc";
             pp_space state;
             pp_associativity state associativity;
-            pp_dot state);
-        set_default_associativity state associativity
+            pp_dot state)
     | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
         pp_hovbox state ~indent (fun state ->
             pp_string state "--prefix";
@@ -2074,8 +2092,7 @@ struct
                 pp_space state;
                 pp_int state precedence)
               precedence;
-            pp_dot state);
-        make_prefix state ?precedence constant
+            pp_dot state)
     | Signature.Pragma.Infix_fixity
         { constant; precedence; associativity; _ } ->
         pp_hovbox state ~indent (fun state ->
@@ -2092,8 +2109,7 @@ struct
                 pp_space state;
                 pp_associativity state associativity)
               associativity;
-            pp_dot state);
-        make_infix state ?precedence ?associativity constant
+            pp_dot state)
     | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
         pp_hovbox state ~indent (fun state ->
             pp_string state "--postfix";
@@ -2104,16 +2120,14 @@ struct
                 pp_space state;
                 pp_int state precedence)
               precedence;
-            pp_dot state);
-        make_postfix state ?precedence constant
+            pp_dot state)
     | Signature.Pragma.Not _ -> pp_string state "--not"
     | Signature.Pragma.Open_module { module_identifier; _ } ->
         pp_hovbox state ~indent (fun state ->
             pp_string state "--open";
             pp_space state;
             pp_constant_invoke state module_identifier;
-            pp_dot state);
-        open_module state module_identifier
+            pp_dot state)
     | Signature.Pragma.Abbreviation { module_identifier; abbreviation; _ } ->
         pp_hovbox state ~indent (fun state ->
             pp_string state "--abbrev";
@@ -2121,8 +2135,7 @@ struct
             pp_constant_invoke state module_identifier;
             pp_space state;
             pp_identifier state abbreviation;
-            pp_dot state);
-        add_abbreviation state module_identifier abbreviation
+            pp_dot state)
     | Signature.Pragma.Query
         { identifier; typ; expected_solutions; maximum_tries; _ } ->
         let pp_query_argument state =
@@ -2687,7 +2700,8 @@ struct
     | Signature.Entry.Declaration { declaration; _ } ->
         pp_signature_declaration state declaration
     | Signature.Entry.Pragma { pragma; _ } ->
-        pp_signature_pragma state pragma
+        pp_signature_pragma state pragma;
+        apply_signature_pragma state pragma
     | Signature.Entry.Comment { content; _ } ->
         pp_vbox state (fun state ->
             pp_string state "%{{";

--- a/src/syntax/synext/synext_pp.ml
+++ b/src/syntax/synext/synext_pp.ml
@@ -2046,13 +2046,22 @@ struct
     | Signature.Pragma.Name _ -> ()
     | Signature.Pragma.Default_associativity { associativity; _ } ->
         set_default_associativity state associativity
-    | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
-        add_prefix_notation state ?precedence constant
+    | Signature.Pragma.Prefix_fixity { constant; precedence; postponed; _ }
+      ->
+        if postponed then
+          add_postponed_prefix_notation state ?precedence constant
+        else add_prefix_notation state ?precedence constant
     | Signature.Pragma.Infix_fixity
-        { constant; precedence; associativity; _ } ->
-        add_infix_notation state ?precedence ?associativity constant
-    | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
-        add_postfix_notation state ?precedence constant
+        { constant; precedence; associativity; postponed; _ } ->
+        if postponed then
+          add_postponed_infix_notation state ?precedence ?associativity
+            constant
+        else add_infix_notation state ?precedence ?associativity constant
+    | Signature.Pragma.Postfix_fixity { constant; precedence; postponed; _ }
+      ->
+        if postponed then
+          add_postponed_postfix_notation state ?precedence constant
+        else add_postfix_notation state ?precedence constant
     | Signature.Pragma.Not _ -> ()
     | Signature.Pragma.Open_module { module_identifier; _ } ->
         open_module state module_identifier
@@ -2721,196 +2730,9 @@ struct
              first_declaration)
           Unsupported_recursive_declaration
 
-  (** [get_constant_declaration_identifier_if_can_have_fixity_pragma declaration]
-      is [Option.Some identifier] if [declaration] can have a fixity pragma
-      attached to it. In that case, a fixity pragma could be declared before
-      it, and it would apply to [declaration]. Such a pragma is called a
-      postponed fixity pragma. *)
-  and get_constant_declaration_identifier_if_can_have_fixity_pragma =
-    function
-    | Signature.Declaration.Typ { identifier; _ }
-    | Signature.Declaration.Const { identifier; _ }
-    | Signature.Declaration.CompTyp { identifier; _ }
-    | Signature.Declaration.CompCotyp { identifier; _ }
-    | Signature.Declaration.CompConst { identifier; _ }
-    | Signature.Declaration.CompTypAbbrev { identifier; _ }
-    | Signature.Declaration.Theorem { identifier; _ }
-    | Signature.Declaration.Proof { identifier; _ }
-    | Signature.Declaration.Val { identifier; _ } ->
-        Option.some identifier
-    | Signature.Declaration.CompDest _
-    | Signature.Declaration.Schema _
-    | Signature.Declaration.Recursive_declarations _
-    | Signature.Declaration.Module _ ->
-        Option.none
-
-  (** [fixable_constant_declaration_identifiers entry] is the set of
-      identifiers in [entry] to which a postponed fixity pragma can be
-      attached. [entry] is assumed to be the signature-level entry that
-      immediately follows a set of fixity pragmas. *)
-  and fixable_constant_declaration_identifiers = function
-    | Signature.Entry.Declaration
-        { declaration =
-            Signature.Declaration.Recursive_declarations { declarations; _ }
-        ; _
-        } ->
-        (* Collect all the declaration identifiers in the group of mutually
-           recursive declarations that can have fixity pragmas attached to
-           them *)
-        List.fold_left
-          (fun identifier_set declaration ->
-            match
-              get_constant_declaration_identifier_if_can_have_fixity_pragma
-                declaration
-            with
-            | Option.None -> identifier_set
-            | Option.Some identifier ->
-                Identifier.Set.add identifier identifier_set)
-          Identifier.Set.empty
-          (List1.to_list declarations)
-    | Signature.Entry.Declaration { declaration; _ } -> (
-        (* Return the declaration identifier if it can have a fixity pragma
-           attached to it *)
-        match
-          get_constant_declaration_identifier_if_can_have_fixity_pragma
-            declaration
-        with
-        | Option.None -> Identifier.Set.empty
-        | Option.Some identifier -> Identifier.Set.singleton identifier)
-    | _ -> Identifier.Set.empty
-
-  (** [is_entry_fixity_pragma_or_comment entry] is [true] if and only if
-      [entry] is a fixity pragma or a documentation comment.
-
-      This predicate is used to determine which signature entries can be
-      skipped over when looking ahead to find which signature-level
-      declaration can a postponed fixity pragma be applied to. *)
-  and is_entry_fixity_pragma_or_comment = function
-    | Signature.Entry.Pragma
-        { pragma =
-            ( Signature.Pragma.Prefix_fixity _
-            | Signature.Pragma.Infix_fixity _
-            | Signature.Pragma.Postfix_fixity _ )
-        ; _
-        }
-    | Signature.Entry.Comment _ ->
-        true
-    | _ -> false
-
-  (** [pp_postponable_fixity_pragma state applicable_constant_identifiers entry]
-      pretty-prints the fixity pragma or documentation comment [entry] with
-      respect to the pretty-printing state [state] and the set
-      [applicable_constant_identifiers] of identifiers in the signature-level
-      declaration that follows the pragma/comment.
-
-      If [entry] is a pragma whose constant is in
-      [applicable_constant_identifiers], then [entry] is a postponed fixity
-      pragma, and its application should wait until the later declaration is
-      in scope.
-
-      It is assumed that [entry] does not affect the lookahead for the target
-      declaration for a postponed fixity pragma. That is, [entry] must be a
-      prefix, infix or postfix fixity pragma, or a documentation comment. *)
-  and pp_postponable_fixity_pragma state applicable_constant_identifiers =
-    let is_constant_a_plain_identifier constant =
-      List.null (Qualified_identifier.namespaces constant)
-    in
-    let is_fixity_constant_postponed constant =
-      is_constant_a_plain_identifier constant
-      && Identifier.Set.mem
-           (Qualified_identifier.name constant)
-           applicable_constant_identifiers
-    in
-    function
-    | Signature.Entry.Comment _ as entry -> pp_signature_entry state entry
-    | Signature.Entry.Pragma
-        { pragma =
-            Signature.Pragma.Prefix_fixity { constant; precedence; _ } as
-            pragma
-        ; _
-        } ->
-        let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_prefix_notation
-          else add_prefix_notation
-        in
-        add_notation state ?precedence constant;
-        pp_signature_pragma state pragma
-    | Signature.Entry.Pragma
-        { pragma =
-            Signature.Pragma.Infix_fixity
-              { constant; precedence; associativity; _ } as pragma
-        ; _
-        } ->
-        let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_infix_notation
-          else add_infix_notation
-        in
-        add_notation state ?precedence ?associativity constant;
-        pp_signature_pragma state pragma
-    | Signature.Entry.Pragma
-        { pragma =
-            Signature.Pragma.Postfix_fixity { constant; precedence; _ } as
-            pragma
-        ; _
-        } ->
-        let add_notation =
-          if is_fixity_constant_postponed constant then
-            add_postponed_postfix_notation
-          else add_postfix_notation
-        in
-        add_notation state ?precedence constant;
-        pp_signature_pragma state pragma
-    | Signature.Entry.Pragma { location; _ }
-    | Signature.Entry.Declaration { location; _ } ->
-        Error.raise_violation ~location
-          (Format.asprintf
-             "[%s] unexpectedly encountered an entry that is neither a \
-              fixity pragma nor a documentation comment"
-             __FUNCTION__)
-
-  (** [pp_signature_entries state entries] pretty-prints [entries]. This
-      function handles pretty-printing for entries that interact in special
-      cases with other declarations. Particularly, this determines whether a
-      fixity pragma should apply to an already declared constant, or if it
-      should be postponed to be applied to a constant declared later. *)
-  and pp_signature_entries state ?(sep = pp_double_cut) = function
-    | Signature.Entry.Pragma
-        { pragma =
-            ( Signature.Pragma.Prefix_fixity _
-            | Signature.Pragma.Infix_fixity _
-            | Signature.Pragma.Postfix_fixity _ )
-        ; _
-        }
-      :: _ as entries -> (
-        (* Special case of pretty-printing where the fixity pragma may apply
-           to a constant declared subsequently after the pragma *)
-        match List.take_while is_entry_fixity_pragma_or_comment entries with
-        | _, [] -> pp_list state ~sep pp_signature_entry entries
-        | pragmas_and_comments, entry :: entries ->
-            let applicable_constant_identifiers =
-              fixable_constant_declaration_identifiers entry
-            in
-            (* The fixity pragmas in [pragmas_and_comments] whose identifiers
-               are in [applicable_constant_identifiers] are postponed fixity
-               pragmas *)
-            pp_list state ~sep
-              (fun state ->
-                pp_postponable_fixity_pragma state
-                  applicable_constant_identifiers)
-              pragmas_and_comments;
-            sep state;
-            pp_signature_entries state ~sep (entry :: entries))
-    | [] -> pp_nop state
-    | [ x ] -> pp_signature_entry state x
-    | x :: xs ->
-        pp_signature_entry state x;
-        sep state;
-        pp_signature_entries state xs
-
   and pp_module_entries state entries =
-    pp_vbox state ~indent:0 (fun state -> pp_signature_entries state entries)
+    pp_vbox state ~indent:0 (fun state ->
+        pp_list state ~sep:pp_double_cut pp_signature_entry entries)
 
   and pp_signature_entry state entry =
     match entry with
@@ -2938,7 +2760,7 @@ struct
     in
     pp_vbox state ~indent:0 (fun state ->
         pp_global_pragmas_opt state;
-        pp_signature_entries state entries)
+        pp_list state ~sep:pp_double_cut pp_signature_entry entries)
 
   and pp_signature state signature =
     pp_list1 state ~sep:pp_double_cut pp_signature_file signature

--- a/src/syntax/synext/synext_pp.ml
+++ b/src/syntax/synext/synext_pp.ml
@@ -2047,12 +2047,12 @@ struct
     | Signature.Pragma.Default_associativity { associativity; _ } ->
         set_default_associativity state associativity
     | Signature.Pragma.Prefix_fixity { constant; precedence; _ } ->
-        make_prefix state ?precedence constant
+        add_prefix_notation state ?precedence constant
     | Signature.Pragma.Infix_fixity
         { constant; precedence; associativity; _ } ->
-        make_infix state ?precedence ?associativity constant
+        add_infix_notation state ?precedence ?associativity constant
     | Signature.Pragma.Postfix_fixity { constant; precedence; _ } ->
-        make_postfix state ?precedence constant
+        add_postfix_notation state ?precedence constant
     | Signature.Pragma.Not _ -> ()
     | Signature.Pragma.Open_module { module_identifier; _ } ->
         open_module state module_identifier

--- a/src/syntax/synext/synext_pp_state.ml
+++ b/src/syntax/synext/synext_pp_state.ml
@@ -146,16 +146,16 @@ module Printing_state = struct
       determined where the pragma is declared, hence why those fields are not
       optional like in the external syntax. *)
   type postponed_fixity_pragma =
-    | Prefix_fixity of
+    | Postponed_prefix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
-    | Infix_fixity of
+    | Postponed_infix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         ; associativity : Associativity.t
         }
-    | Postfix_fixity of
+    | Postponed_postfix_fixity of
         { constant : Qualified_identifier.t
         ; precedence : Int.t
         }
@@ -373,26 +373,28 @@ module Printing_state = struct
 
   let add_postponed_prefix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Prefix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_prefix_fixity { precedence; constant })
 
   let add_postponed_infix_notation state ?precedence ?associativity constant
       =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     add_postponed_notation state
-      (Infix_fixity { precedence; associativity; constant })
+      (Postponed_infix_fixity { precedence; associativity; constant })
 
   let add_postponed_postfix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
-    add_postponed_notation state (Postfix_fixity { precedence; constant })
+    add_postponed_notation state
+      (Postponed_postfix_fixity { precedence; constant })
 
   let apply_postponed_fixity_pragmas =
     let apply_postponed_fixity_pragma state = function
-      | Prefix_fixity { constant; precedence } ->
+      | Postponed_prefix_fixity { constant; precedence } ->
           add_prefix_notation state ~precedence constant
-      | Infix_fixity { constant; precedence; associativity } ->
+      | Postponed_infix_fixity { constant; precedence; associativity } ->
           add_infix_notation state ~precedence ~associativity constant
-      | Postfix_fixity { constant; precedence } ->
+      | Postponed_postfix_fixity { constant; precedence } ->
           add_postfix_notation state ~precedence constant
     in
     fun state ->

--- a/src/syntax/synext/synext_pp_state.ml
+++ b/src/syntax/synext/synext_pp_state.ml
@@ -391,7 +391,7 @@ module Printing_state = struct
           add_postfix_notation state ~precedence constant
     in
     fun state ->
-      List.iter
+      List.iter_rev
         (apply_postponed_fixity_pragma state)
         state.postponed_fixity_pragmas;
       state.postponed_fixity_pragmas <- []

--- a/src/syntax/synext/synext_pp_state.ml
+++ b/src/syntax/synext/synext_pp_state.ml
@@ -68,6 +68,21 @@ module type PRINTING_STATE = sig
   val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
+  val add_postponed_prefix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  val add_postponed_infix_notation :
+       state
+    -> ?precedence:Int.t
+    -> ?associativity:Associativity.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  val add_postponed_postfix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  val apply_postponed_fixity_pragmas : state -> unit
+
   val lookup_operator :
     state -> Qualified_identifier.t -> Operator.t Option.t
 
@@ -126,11 +141,33 @@ module Printing_state = struct
         ; declarations : Entry.t Binding_tree.t
         }
 
+  (** The type of fixity pragmas that are postponed to be applied at a later
+      point. The default precedence and associativity to be used are
+      determined where the pragma is declared, hence why those fields are not
+      optional like in the parser syntax. *)
+  type postponed_fixity_pragma =
+    | Prefix_fixity of
+        { constant : Qualified_identifier.t
+        ; precedence : Int.t
+        }
+    | Infix_fixity of
+        { constant : Qualified_identifier.t
+        ; precedence : Int.t
+        ; associativity : Associativity.t
+        }
+    | Postfix_fixity of
+        { constant : Qualified_identifier.t
+        ; precedence : Int.t
+        }
+
   type state =
     { mutable formatter : Format.formatter
     ; mutable scopes : scope List1.t
     ; mutable default_precedence : Int.t
     ; mutable default_associativity : Associativity.t
+    ; mutable postponed_fixity_pragmas : postponed_fixity_pragma List.t
+          (** The list of fixity pragmas that refer to constants declared
+              immediately after them instead of pragmas declared earlier. *)
     }
 
   include (
@@ -152,6 +189,7 @@ module Printing_state = struct
     ; scopes = List1.singleton (create_module_scope ())
     ; default_precedence
     ; default_associativity
+    ; postponed_fixity_pragmas = []
     }
 
   let set_formatter state formatter = state.formatter <- formatter
@@ -323,6 +361,40 @@ module Printing_state = struct
     let precedence = get_default_precedence_opt state precedence in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_postfix ~precedence))
+
+  let add_postponed_notation state pragma =
+    state.postponed_fixity_pragmas <-
+      pragma :: state.postponed_fixity_pragmas
+
+  let add_postponed_prefix_notation state ?precedence constant =
+    let precedence = get_default_precedence_opt state precedence in
+    add_postponed_notation state (Prefix_fixity { precedence; constant })
+
+  let add_postponed_infix_notation state ?precedence ?associativity constant
+      =
+    let precedence = get_default_precedence_opt state precedence in
+    let associativity = get_default_associativity_opt state associativity in
+    add_postponed_notation state
+      (Infix_fixity { precedence; associativity; constant })
+
+  let add_postponed_postfix_notation state ?precedence constant =
+    let precedence = get_default_precedence_opt state precedence in
+    add_postponed_notation state (Postfix_fixity { precedence; constant })
+
+  let apply_postponed_fixity_pragmas =
+    let apply_postponed_fixity_pragma state = function
+      | Prefix_fixity { constant; precedence } ->
+          add_prefix_notation state ~precedence constant
+      | Infix_fixity { constant; precedence; associativity } ->
+          add_infix_notation state ~precedence ~associativity constant
+      | Postfix_fixity { constant; precedence } ->
+          add_postfix_notation state ~precedence constant
+    in
+    fun state ->
+      List.iter
+        (apply_postponed_fixity_pragma state)
+        state.postponed_fixity_pragmas;
+      state.postponed_fixity_pragmas <- []
 
   let open_namespace state identifier =
     let _entry, subtree = lookup state identifier in

--- a/src/syntax/synext/synext_pp_state.ml
+++ b/src/syntax/synext/synext_pp_state.ml
@@ -55,17 +55,17 @@ module type PRINTING_STATE = sig
   val add_program_constant :
     state -> ?location:Location.t -> Identifier.t -> Unit.t
 
-  val make_prefix :
+  val add_prefix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
-  val make_infix :
+  val add_infix_notation :
        state
     -> ?precedence:Int.t
     -> ?associativity:Associativity.t
     -> Qualified_identifier.t
     -> Unit.t
 
-  val make_postfix :
+  val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
   val lookup_operator :
@@ -114,9 +114,9 @@ module Entry = struct
 
   let make_module_entry ?location:_ _identifier = { operator = Option.none }
 
-  let[@warning "-23"] modify_operator f entry =
+  let modify_operator f entry =
     let operator' = f entry.operator in
-    { entry with operator = operator' }
+    { entry with operator = operator' } [@warning "-23"]
 end
 
 module Printing_state = struct
@@ -308,18 +308,18 @@ module Printing_state = struct
             declarations
         else ()
 
-  let[@warning "-23"] make_prefix state ?precedence constant =
+  let add_prefix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_prefix ~precedence))
 
-  let[@warning "-23"] make_infix state ?precedence ?associativity constant =
+  let add_infix_notation state ?precedence ?associativity constant =
     let precedence = get_default_precedence_opt state precedence in
     let associativity = get_default_associativity_opt state associativity in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_infix ~precedence ~associativity))
 
-  let[@warning "-23"] make_postfix state ?precedence constant =
+  let add_postfix_notation state ?precedence constant =
     let precedence = get_default_precedence_opt state precedence in
     modify_operator state constant (fun _operator ->
         Option.some (Operator.make_postfix ~precedence))

--- a/src/syntax/synext/synext_pp_state.ml
+++ b/src/syntax/synext/synext_pp_state.ml
@@ -144,7 +144,7 @@ module Printing_state = struct
   (** The type of fixity pragmas that are postponed to be applied at a later
       point. The default precedence and associativity to be used are
       determined where the pragma is declared, hence why those fields are not
-      optional like in the parser syntax. *)
+      optional like in the external syntax. *)
   type postponed_fixity_pragma =
     | Prefix_fixity of
         { constant : Qualified_identifier.t
@@ -320,7 +320,12 @@ module Printing_state = struct
 
   let lookup state query =
     let identifiers = Qualified_identifier.to_list1 query in
-    lookup_in_scopes (List1.to_list state.scopes) identifiers
+    try lookup_in_scopes (List1.to_list state.scopes) identifiers with
+    | exn ->
+        Error.re_raise
+          (Error.located_exception1
+             (Qualified_identifier.location query)
+             exn)
 
   let lookup_operator state constant =
     let entry, _subtree = lookup state constant in

--- a/src/syntax/synext/synext_pp_state.mli
+++ b/src/syntax/synext/synext_pp_state.mli
@@ -87,16 +87,16 @@ module type PRINTING_STATE = sig
   val add_program_constant :
     state -> ?location:Location.t -> Identifier.t -> Unit.t
 
-  (** [make_prefix state ?precedence constant] sets [constant] as a prefix
-      operator with precedence [p] if [precedence = Option.Some p], or
+  (** [add_prefix_notation state ?precedence constant] sets [constant] as a
+      prefix operator with precedence [p] if [precedence = Option.Some p], or
       [state]'s default precedence if [precedence = Option.None].
 
       If [constant] is unbound in [state], then an exception is raised. *)
-  val make_prefix :
+  val add_prefix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
-  (** [make_infix state ?precedence ?associativity constant] sets [constant]
-      as an infix operator with:
+  (** [add_infix_notation state ?precedence ?associativity constant] sets
+      [constant] as an infix operator with:
 
       - precedence [p] if [precedence = Option.Some p], or [state]'s default
         precedence if [precedence = Option.None].
@@ -104,19 +104,19 @@ module type PRINTING_STATE = sig
         default associativity if [associativity = Option.None].
 
       If [constant] is unbound in [state], then an exception is raised. *)
-  val make_infix :
+  val add_infix_notation :
        state
     -> ?precedence:Int.t
     -> ?associativity:Associativity.t
     -> Qualified_identifier.t
     -> Unit.t
 
-  (** [make_postfix state ?precedence constant] sets [constant] as a postfix
-      operator with precedence [p] if [precedence = Option.Some p], or
-      [state]'s default precedence if [precedence = Option.None].
+  (** [add_postfix_notation state ?precedence constant] sets [constant] as a
+      postfix operator with precedence [p] if [precedence = Option.Some p],
+      or [state]'s default precedence if [precedence = Option.None].
 
       If [constant] is unbound, then an exception is raised. *)
-  val make_postfix :
+  val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
   (** [lookup_operator state constant] is the operator description

--- a/src/syntax/synext/synext_pp_state.mli
+++ b/src/syntax/synext/synext_pp_state.mli
@@ -119,6 +119,49 @@ module type PRINTING_STATE = sig
   val add_postfix_notation :
     state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
 
+  (** [add_postponed_prefix_notation state ?precedence identifier] adds a
+      postponed prefix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_prefix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  (** [add_postponed_infix_notation state ?precedence ?associativity identifier]
+      adds a postponed infix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead. Likewise, if [associativity = Option.None], then
+      {!get_default_associativity} is used instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_infix_notation :
+       state
+    -> ?precedence:Int.t
+    -> ?associativity:Associativity.t
+    -> Qualified_identifier.t
+    -> Unit.t
+
+  (** [add_postponed_postfix_notation state ?precedence identifier] adds a
+      postponed postfix notation for [identifier]. If
+      [precedence = Option.None], then {!get_default_precedence} is used
+      instead.
+
+      This notation is postponed, meaning that it only applies once
+      {!val:apply_postponed_fixity_pragmas} is called. *)
+  val add_postponed_postfix_notation :
+    state -> ?precedence:Int.t -> Qualified_identifier.t -> Unit.t
+
+  (** [apply_postponed_fixity_pragmas state] adds in scope the postponed
+      prefix, infix and postfix fixity pragmas. This function should be
+      called only when the targets of those postponed pragmas are in scope.
+      That is, postponed fixity pragmas are applied after the subsequent
+      declaration is added, or after a group of mutually recursive
+      declarations are added. *)
+  val apply_postponed_fixity_pragmas : state -> unit
+
   (** [lookup_operator state constant] is the operator description
       corresponding to [constant] bound in [state].
 

--- a/src/syntax/synint/synint.ml
+++ b/src/syntax/synint/synint.ml
@@ -941,17 +941,20 @@ module Sgn = struct
         { location : Location.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t Option.t
+        ; postponed : Bool.t
         }
     | InfixFixityPrag of
         { location : Location.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t Option.t
         ; associativity : Associativity.t Option.t
+        ; postponed : Bool.t
         }
     | PostfixFixityPrag of
         { location : Location.t
         ; constant : Qualified_identifier.t
         ; precedence : Int.t Option.t
+        ; postponed : Bool.t
         }
     | AbbrevPrag of
         { location : Location.t

--- a/t/code/success/infix/postponed.bel
+++ b/t/code/success/infix/postponed.bel
@@ -1,0 +1,65 @@
+% Proof that a big step evaluation relation for lambda terms is deterministic
+% (An an argument for using refl for equality instead of algorithmic equality)
+% Author: Andrew Cave
+
+--infix app 4.
+LF exp : type =
+| lam : (exp -> exp) -> exp
+| app : exp -> exp -> exp
+;
+
+--infix eq 5.
+LF eq : exp -> exp -> type =
+| refl : M eq M
+;
+
+LF notLam : exp -> type =
+| notLam/c : notLam (M app N)
+;
+
+--infix eval 4.
+--infix eval_app1 4.
+LF eval : exp -> exp -> type =
+| eval_lam : ({x:exp} x eval x -> notLam x -> (M x) eval (N x))
+           -> (lam M) eval (lam N)
+| eval_app1 : M eval (lam M') -> (M' N) eval R -> (M app N) eval R
+| eval_app2 : M eval M' -> notLam M' -> N eval N' -> (M app N) eval (M' app N')
+;
+
+schema evctx = block x:exp, u:x eval x, _t:notLam x;
+
+rec deterministic : (g:evctx) [g |- M[..] eval R[..]] -> [g |- M[..] eval R'[..]]
+-> [g |- R[..] eq R'[..]] =
+fn d => fn f =>
+case d of
+| [g |- eval_app2 D1[..] NL[..] D2[..]] =>
+  (case f of
+    | [g |- eval_app2 F1[..] NL'[..] F2[..]] =>
+      let [g |- refl] = deterministic [g |- D1[..]] [g |- F1[..]] in
+      let [g |- refl] = deterministic [g |- D2[..]] [g |- F2[..]] in
+      [g |- refl]
+
+    | [g |- F1[..] eval_app1 F2[..]] =>
+      let [g |- refl] = deterministic [g |- D1[..]] [g |- F1[..]] in
+       impossible [g |- NL[..]])
+
+ | [g |- eval_lam (\x.\u.\v. D1)] =>
+  let [g |- eval_lam (\x.\u.\v. F1)] = f in
+  let [g, b:block x:exp, v:x eval x, _t:notLam x |- refl] =
+    deterministic
+     [g, b:block x:exp, v:x eval x, _t:notLam x |- D1[.., b.1, b.2, b.3]]
+     [g, b |- F1[.., b.1, b.2, b.3]] in
+  [g |- refl]
+
+| [g |- D1[..] eval_app1 D2[..]] : [g |- (M[..] app N[..]) eval R[..]] =>
+  (case f of
+    | [g |- F1[..] eval_app1 F2[..]] =>
+      let [g |- refl] = deterministic [g |- D1[..]] [g |- F1[..]] in
+      deterministic [g |- D2[..]] [g |- F2[..]]
+
+    | [g |- eval_app2 F1[..] NL[..] F2[..]] =>
+      let [g |- refl] = deterministic [g |- D1[..]] [g |- F1[..]] in
+      impossible [g |- NL[..]])
+
+| [g |- #p.2[..]] => let [g |- #q.2[..]] = f in [g |- refl]
+;

--- a/test/util/synext_json.ml
+++ b/test/util/synext_json.ml
@@ -1285,28 +1285,33 @@ let rec json_of_signature_pragma pragma =
           [ ("associativity", json_of_associativity associativity)
           ; ("location", json_of_location location)
           ]
-  | Signature.Pragma.Prefix_fixity { constant; precedence; location } ->
+  | Signature.Pragma.Prefix_fixity
+      { constant; precedence; postponed; location } ->
       json_of_variant ~name:"Signature.Pragma.Prefix_fixity"
         ~data:
           [ ("constant", json_of_qualified_identifier constant)
           ; ("precedence", json_of_option json_of_int precedence)
+          ; ("postponed", json_of_bool postponed)
           ; ("location", json_of_location location)
           ]
   | Signature.Pragma.Infix_fixity
-      { constant; precedence; associativity; location } ->
+      { constant; precedence; associativity; postponed; location } ->
       json_of_variant ~name:"Signature.Pragma.Infix_fixity"
         ~data:
           [ ("constant", json_of_qualified_identifier constant)
           ; ( "associativity"
             , json_of_option json_of_associativity associativity )
           ; ("precedence", json_of_option json_of_int precedence)
+          ; ("postponed", json_of_bool postponed)
           ; ("location", json_of_location location)
           ]
-  | Signature.Pragma.Postfix_fixity { constant; precedence; location } ->
+  | Signature.Pragma.Postfix_fixity
+      { constant; precedence; postponed; location } ->
       json_of_variant ~name:"Signature.Pragma.Postfix_fixity"
         ~data:
           [ ("constant", json_of_qualified_identifier constant)
           ; ("precedence", json_of_option json_of_int precedence)
+          ; ("postponed", json_of_bool postponed)
           ; ("location", json_of_location location)
           ]
   | Signature.Pragma.Not { location } ->


### PR DESCRIPTION
## Motivation

Before v1.1, it was possible to declare an identifier as an operator before any constant declaration was attached to that identifier.

For instance, the following snippet first defines `~` as an infix operator, then declares an LF type-level constant with identifier `~`. This made it possible to use that infix notation in the definition of LF term-level constants.

```
--infix ~ 1 right.

LF ~ : tm → exp → type =
  | tr_unit : unit ~ unit'
  | tr_pair : M ~ E → N ~ F
              → (pair M N) ~ (pair' E F)
```

The re-write of the parser in #266 to support shadowing of constants and the definition of namespaces broke that feature. Indeed, it became necessary for fixity pragmas to refer to constants that are already bound. This meant that parsing the pragma `--infix ~ 1 right.` would result in an "Unbound identifier ~" exception to be thrown.

The reason why this breaking change occurred is because in the disambiguation state, the notation for an identifier has to be attached to the constant it is meant to affect. This is necessary because opening a module with the `--open` pragma has to bring that notation back in scope.

## Changes

This PR re-introduces the feature of having a `--prefix`, `--infix` or `--postfix` pragma before the declaration it is meant to affect. During the disambiguation of Beluga signatures, when a fixity pragma is encountered, a lookahead is performed to determine if the closest declaration that follows the pragma introduces a constant with the same identifier as the target of the pragma. If it is the case that this next declaration introduces the pragma's target, then the fixity pragma is said to be postponed, in the sense that it is applied once that constant is added to the disambiguation state.

Put more precisely, if `P` is a fixity pragma with target identifier `c`, and `D` is a declaration that introduces a constant with identifier `c`, then `P` is a postponed fixity pragma if we have the following in a Beluga signature file:

```
P (<prefix-pragma> | <infix-pragma> | <postfix-pragma> | <documentation-comment>)* D
```

This makes it possible to write snippets like the following:

```
--assoc right.

--infix app 1 none.
--prefix lam 1.
--prefix red 2.

LF term : type =
| app: term -> term -> term =
| lam: (term -> term) -> term
| red: term -> term;
```

The `./t/code/success/infix/postponed.bel` test case is added to showcase this feature.

If a fixity pragma is found not to be postponed, then it affects a constant declared earlier in the signature, like it did in v1.1. The proposed lookahead solution does not introduce ambiguity in the placement of fixity pragmas. If the pragma is between two declarations that use the same identifier, then the pragma is postponed. Attaching the pragma to the earlier declaration would not be useful since that constant is immediately shadowed by the other declaration.

This change affects all the areas where fixity pragmas are involved, namely:
- Signature disambiguation
- Pretty-printing of the external syntax
- Pretty-printing of the external syntax to HTML pages
- Pretty-printing of the internal syntax (using the legacy `OpPragmas` store, which is constructed during signature reconstruction)